### PR TITLE
+Missing Pointers for Benthic Fluxes in Direct Sinking of Phytoplankton P 

### DIFF
--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -7746,6 +7746,8 @@ contains
     !
     call g_tracer_get_values(tracer_list,'pdi','btm_reservoir',phyto(DIAZO)%fp_btm,isd,jsd)
     phyto(DIAZO)%fp_btm = phyto(DIAZO)%fp_btm/dt
+    call g_tracer_get_pointer(tracer_list,'pdi_btf','field',temp_field)
+    temp_field(:,:,1) = phyto(DIAZO)%fp_btm(:,:)
     call g_tracer_set_values(tracer_list,'pdi','btm_reservoir',0.0)
     if (phyto(DIAZO)%id_fp_btm .gt. 0)           &
          used = g_send_data(phyto(DIAZO)%id_fp_btm,phyto(DIAZO)%fp_btm, &
@@ -7754,6 +7756,8 @@ contains
 
     call g_tracer_get_values(tracer_list,'plg','btm_reservoir',phyto(LARGE)%fp_btm,isd,jsd)
     phyto(LARGE)%fp_btm = phyto(LARGE)%fp_btm/dt
+    call g_tracer_get_pointer(tracer_list,'plg_btf','field',temp_field)
+    temp_field(:,:,1) = phyto(LARGE)%fp_btm(:,:)
     call g_tracer_set_values(tracer_list,'plg','btm_reservoir',0.0)
     if (phyto(LARGE)%id_fp_btm .gt. 0)           &
          used = g_send_data(phyto(LARGE)%id_fp_btm,phyto(LARGE)%fp_btm, &
@@ -7762,6 +7766,8 @@ contains
 
     call g_tracer_get_values(tracer_list,'pmd','btm_reservoir',phyto(MEDIUM)%fp_btm,isd,jsd)
     phyto(MEDIUM)%fp_btm = phyto(MEDIUM)%fp_btm/dt
+    call g_tracer_get_pointer(tracer_list,'pmd_btf','field',temp_field)
+    temp_field(:,:,1) = phyto(MEDIUM)%fp_btm(:,:)
     call g_tracer_set_values(tracer_list,'pmd','btm_reservoir',0.0)
     if (phyto(MEDIUM)%id_fp_btm .gt. 0)           &
          used = g_send_data(phyto(MEDIUM)%id_fp_btm,phyto(MEDIUM)%fp_btm, &
@@ -7770,6 +7776,8 @@ contains
 
     call g_tracer_get_values(tracer_list,'psm','btm_reservoir',phyto(SMALL)%fp_btm,isd,jsd)
     phyto(SMALL)%fp_btm = phyto(SMALL)%fp_btm/dt
+    call g_tracer_get_pointer(tracer_list,'psm_btf','field',temp_field)
+    temp_field(:,:,1) = phyto(SMALL)%fp_btm(:,:)
     call g_tracer_set_values(tracer_list,'psm','btm_reservoir',0.0)
     if (phyto(SMALL)%id_fp_btm .gt. 0)           &
          used = g_send_data(phyto(SMALL)%id_fp_btm,phyto(SMALL)%fp_btm, &

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -7702,10 +7702,10 @@ contains
     !
     ! Sinking phytoplankton: Iron
     !
+    !> Iron flux to the sediment is removed, and flux from the sediment is
+    !! handled separately later using a relationship based on Dale et al., 2015. 
     call g_tracer_get_values(tracer_list,'fedi','btm_reservoir',phyto(DIAZO)%ffe_btm,isd,jsd)
     phyto(DIAZO)%ffe_btm = phyto(DIAZO)%ffe_btm/dt
-    !call g_tracer_get_pointer(tracer_list,'fedi_btf','field',temp_field)
-    !temp_field(:,:,1) = phyto(DIAZO)%ffe_btm(:,:)
     call g_tracer_set_values(tracer_list,'fedi','btm_reservoir',0.0)
     if (phyto(DIAZO)%id_ffe_btm .gt. 0)           &
          used = g_send_data(phyto(DIAZO)%id_ffe_btm,phyto(DIAZO)%ffe_btm, &
@@ -7714,8 +7714,6 @@ contains
 
     call g_tracer_get_values(tracer_list,'felg','btm_reservoir',phyto(LARGE)%ffe_btm,isd,jsd)
     phyto(LARGE)%ffe_btm = phyto(LARGE)%ffe_btm/dt
-    !call g_tracer_get_pointer(tracer_list,'felg_btf','field',temp_field)
-    !temp_field(:,:,1) = phyto(LARGE)%ffe_btm(:,:)
     call g_tracer_set_values(tracer_list,'felg','btm_reservoir',0.0)
     if (phyto(LARGE)%id_ffe_btm .gt. 0)           &
          used = g_send_data(phyto(LARGE)%id_ffe_btm,phyto(LARGE)%ffe_btm, &
@@ -7724,8 +7722,6 @@ contains
 
     call g_tracer_get_values(tracer_list,'femd','btm_reservoir',phyto(MEDIUM)%ffe_btm,isd,jsd)
     phyto(MEDIUM)%ffe_btm = phyto(MEDIUM)%ffe_btm/dt
-    !call g_tracer_get_pointer(tracer_list,'femd_btf','field',temp_field)
-    !temp_field(:,:,1) = phyto(MEDIUM)%ffe_btm(:,:)
     call g_tracer_set_values(tracer_list,'femd','btm_reservoir',0.0)
     if (phyto(MEDIUM)%id_ffe_btm .gt. 0)           &
          used = g_send_data(phyto(MEDIUM)%id_ffe_btm,phyto(MEDIUM)%ffe_btm, &
@@ -7734,8 +7730,6 @@ contains
 
     call g_tracer_get_values(tracer_list,'fesm','btm_reservoir',phyto(SMALL)%ffe_btm,isd,jsd)
     phyto(SMALL)%ffe_btm = phyto(SMALL)%ffe_btm/dt
-    !call g_tracer_get_pointer(tracer_list,'fesm_btf','field',temp_field)
-    !temp_field(:,:,1) = phyto(SMALL)%ffe_btm(:,:)
     call g_tracer_set_values(tracer_list,'fesm','btm_reservoir',0.0)
     if (phyto(SMALL)%id_ffe_btm .gt. 0)           &
          used = g_send_data(phyto(SMALL)%id_ffe_btm,phyto(SMALL)%ffe_btm, &
@@ -9908,7 +9902,7 @@ contains
 
           ! iron from sediment (Elrod)
           !cobalt%ffe_sed(i,j) = cobalt%fe_2_n_sed * cobalt%f_ndet_btf(i,j,1)
-          ! iron from sediment (Dale)
+          ! iron from sediment (Dale, 2015)
           cobalt%ffe_sed(i,j) = cobalt%ffe_sed_max * tanh( (cobalt%fntot_btm(i,j)*cobalt%c_2_n*sperd*1.0e3)/ &
                                 max(cobalt%btm_o2(i,j)*1.0e6,epsln) )
           cobalt%ffe_geotherm(i,j) = cobalt%ffe_geotherm_ratio*internal_heat(i,j)*4184.0/dt


### PR DESCRIPTION
As @charliestock suggested, now the pointers for the benthic fluxes for the direct sinking of phytoplankton P are set correctly in `generic_COBALT_update_from_bottom` subroutine. This PR is to solve #18. 

@charliestock , While reviewing the `generic_COBALT_update_from_bottom` subroutine, I noticed that pointers for the benthic fluxes for the direct sinking of phytoplankton Fe are also turned off. Below is an example for diazotroph Fe:

https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC/blob/01f7a0cff3270d6ef076be301b9417a0c1e3f83f/generic_tracers/generic_COBALT.F90#L7707-L7708 

Could you confirm if this was done intentionally?