### PR TITLE
Add felim term in Diazotrophs nutrient limitation calculation

### DIFF
--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -8276,7 +8276,7 @@ contains
     do k = 1, nk ; do j = jsc, jec ; do i = isc, iec   !{
        n=DIAZO
        phyto(n)%liebig_lim(i,j,k) = phyto(n)%o2lim(i,j,k)* &
-          min(phyto(n)%po4lim(i,j,k), phyto(n)%def_fe(i,j,k))
+          min(phyto(n)%po4lim(i,j,k), max(phyto(n)%def_fe(i,j,k),phyto(n)%felim(i,j,k)))
        do n= 2, NUM_PHYTO   !{
           phyto(n)%liebig_lim(i,j,k) = min(phyto(n)%no3lim(i,j,k)+phyto(n)%nh4lim(i,j,k),&
              phyto(n)%po4lim(i,j,k), max(phyto(n)%def_fe(i,j,k),phyto(n)%felim(i,j,k)))


### PR DESCRIPTION
Adding the `felim` term to the diazotrophs' nutrient limitation calculation for consistency with other phytoplankton groups.