### PR TITLE
Make geolat and eqn_of_state as required 

### DIFF
--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -8315,7 +8315,8 @@ contains
         !  write(outunit,*) 'kmld_ref = ',kmld_ref
         !endif
 
-
+        if (.not. PRESENT(eqn_of_state)) call mpp_error(FATAL,"eqn_of_state is missing! Unable to compute &
+                                         density in COBALT!")
         ! calculate the mld for the photoacclimation calculations
         call calculate_density(Temp(i,j,kmld_ref),Salt(i,j,kmld_ref),101325.0,rho_mld_ref,eqn_of_state)
         !if ((i.eq.isc).and.(j.eq.jsc)) then
@@ -8380,6 +8381,8 @@ contains
           endif !}
        enddo !}
 
+       if (.not. PRESENT(geolat)) call mpp_error(FATAL,"geolat is missing! Unable to compute day length &
+                                  in COBALT!")
        ! calculate day length based on the CBM daylength model as described in:
        !
        ! Forsythe, W.C., et al. (1995). A model comparison for daylength as a function of latitude and day of year.

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -8315,8 +8315,8 @@ contains
         !  write(outunit,*) 'kmld_ref = ',kmld_ref
         !endif
 
-        if (.not. PRESENT(eqn_of_state)) call mpp_error(FATAL,"eqn_of_state is missing! Unable to compute &
-                                         density in COBALT!")
+        if (.not. PRESENT(eqn_of_state) .or. .not. PRESENT(geolat)) &
+          call mpp_error(FATAL,"eqn_of_state/geolat is missing! Unable to compute density/daylength in COBALT!")
         ! calculate the mld for the photoacclimation calculations
         call calculate_density(Temp(i,j,kmld_ref),Salt(i,j,kmld_ref),101325.0,rho_mld_ref,eqn_of_state)
         !if ((i.eq.isc).and.(j.eq.jsc)) then
@@ -8381,8 +8381,6 @@ contains
           endif !}
        enddo !}
 
-       if (.not. PRESENT(geolat)) call mpp_error(FATAL,"geolat is missing! Unable to compute day length &
-                                  in COBALT!")
        ! calculate day length based on the CBM daylength model as described in:
        !
        ! Forsythe, W.C., et al. (1995). A model comparison for daylength as a function of latitude and day of year.

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -7873,8 +7873,8 @@ contains
     real, dimension(:,ilb:,jlb:,:), intent(in) :: opacity_band
     real, dimension(ilb:,jlb:),     intent(in) :: internal_heat
     real, dimension(ilb:,jlb:),     intent(in) :: frunoff
-    real, dimension(ilb:,jlb:), optional, intent(in) :: geolat
-    type(EOS_type),             optional, intent(in) :: eqn_of_state !< Equation of state structure
+    real, dimension(ilb:,jlb:),     intent(in) :: geolat
+    type(EOS_type),                 intent(in) :: eqn_of_state !< Equation of state structure
 
     character(len=fm_string_len), parameter :: sub_name = 'generic_COBALT_update_from_source'
     integer :: isc,iec, jsc,jec,isd,ied,jsd,jed,nk,ntau, i, j, k , m, n, k_100, k_200, kbot
@@ -8315,8 +8315,6 @@ contains
         !  write(outunit,*) 'kmld_ref = ',kmld_ref
         !endif
 
-        if (.not. PRESENT(eqn_of_state) .or. .not. PRESENT(geolat)) &
-          call mpp_error(FATAL,"eqn_of_state/geolat is missing! Unable to compute density/daylength in COBALT!")
         ! calculate the mld for the photoacclimation calculations
         call calculate_density(Temp(i,j,kmld_ref),Salt(i,j,kmld_ref),101325.0,rho_mld_ref,eqn_of_state)
         !if ((i.eq.isc).and.(j.eq.jsc)) then

--- a/generic_tracers/generic_tracer.F90
+++ b/generic_tracers/generic_tracer.F90
@@ -522,8 +522,8 @@ contains
     real, dimension(ilb:,jlb:),optional,  intent(in) :: grid_ht
     real, dimension(ilb:,jlb:),optional , intent(in) :: current_wave_stress
     real,                      optional , intent(in) :: sosga ! global avg. sea surface salinity
-    real, dimension(ilb:,jlb:),optional,  intent(in) :: geolat 
-    type(EOS_type),            optional,  intent(in) :: eqn_of_state
+    real, dimension(ilb:,jlb:),  intent(in) :: geolat 
+    type(EOS_type),              intent(in) :: eqn_of_state
 
 
     character(len=fm_string_len), parameter :: sub_name = 'generic_tracer_update_from_source'
@@ -553,18 +553,11 @@ contains
          hblt_depth,ilb,jlb,tau,dtts,grid_dat,model_time,&
          nbands,max_wavelength_band,sw_pen_band,opacity_band, grid_ht)
 
-    if (do_generic_COBALT) then
-       if (present(geolat) .and. present(eqn_of_state)) then
+    if (do_generic_COBALT) & 
           call generic_COBALT_update_from_source(tracer_list,Temp,Salt,rho_dzt,dzt,&
             hblt_depth,ilb,jlb,tau,dtts,grid_dat,model_time,&
             nbands,max_wavelength_band,sw_pen_band,opacity_band,internal_heat,frunoff,&
             geolat,eqn_of_state)
-       else
-          call generic_COBALT_update_from_source(tracer_list,Temp,Salt,rho_dzt,dzt,&
-            hblt_depth,ilb,jlb,tau,dtts,grid_dat,model_time,&
-            nbands,max_wavelength_band,sw_pen_band,opacity_band,internal_heat,frunoff)
-       endif
-    endif
 
     if(do_generic_SF6)  call generic_SF6_update_from_source(tracer_list,rho_dzt,dzt,hblt_depth,&
          ilb,jlb,tau,dtts,grid_dat,model_time)


### PR DESCRIPTION
As tiled. This PR is to address issue #29.  ~~We have added a fatal error message to handle cases where `geolat` or `eqn_of_state` is missing in the call.~~ We have changed `geolat` and `eqn_of_state` from `optional` to `required` so it will fail at compile time if they are missing on MOM6 side

This PR does not change answers.