### PR TITLE
Fix setting of as_param and allow generic_COBALT to set as_param_COBALT

### DIFF
--- a/.github/workflows/cobalt_ci.yml
+++ b/.github/workflows/cobalt_ci.yml
@@ -11,7 +11,7 @@ on:
     branches: [ "dev/cefi" ]
 
 env:
-  BRANCH_NAME: main 
+  BRANCH_NAME: develop 
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -181,10 +181,14 @@ module generic_COBALT
   !The following variables for using this module
   ! are overwritten by generic_tracer_nml namelist
   logical, save :: do_generic_COBALT = .false.       !< Activate the generic_COBALT module if it is set to true.
-  character(len=10), save :: as_param_cobalt = 'W92' !< air-sea flux parameter settings for COBALT
+  character(len=10), save :: as_param_cobalt !< air-sea flux parameter settings for COBALT. Set from
+                                             !! as_param in generic_tracer_nml by generic_tracer.F90, 
+                                             !! but can be replaced by setting as_param_cobalt
+                                             !! in generic_COBALT_nml.
 
-namelist /generic_COBALT_nml/ do_14c, co2_calc, do_nh3_atm_ocean_exchange, scheme_nitrif, debug, &
-     o2_min_nit,k_o2_nit,irr_inhibit,k_nh3_nitrif,gamma_nitrif,do_vertfill_pre,imbalance_tolerance
+  namelist /generic_COBALT_nml/ do_14c, co2_calc, do_nh3_atm_ocean_exchange, scheme_nitrif, debug, &
+     o2_min_nit,k_o2_nit,irr_inhibit,k_nh3_nitrif,gamma_nitrif,do_vertfill_pre,imbalance_tolerance, &
+     as_param_cobalt
   
   !
   ! Array allocations and flux calculations assume that phyto(1) is the

--- a/generic_tracers/generic_tracer.F90
+++ b/generic_tracers/generic_tracer.F90
@@ -141,7 +141,7 @@ module generic_tracer
   logical :: do_vertfill_post = .false.
   logical :: generic_tracer_register_called = .false.
   logical :: force_update_fluxes = .false.
-  character(len=10) :: as_param   = 'gfdl_cmip6'     ! Use default Wanninkhoff/OCMIP2 parameters for air-sea gas transfer
+  character(len=10) :: as_param   = 'W14'     ! Use Wanninkhoff 2014 parameters for air-sea gas transfer by default
 
   namelist /generic_tracer_nml/ do_generic_tracer, do_generic_abiotic, do_generic_age, do_generic_argon, do_generic_CFC, &
       do_generic_SF6, do_generic_TOPAZ,do_generic_ERGOM, do_generic_BLING, do_generic_miniBLING, do_generic_COBALT, &
@@ -169,7 +169,6 @@ contains
     write (stdoutunit, generic_tracer_nml)
     write (stdlogunit, generic_tracer_nml)
 
-    ! Use Wanninkhoff 2014 parameters for air-sea gas exchange if as_param='W14' in generic_tracer_nml
     ! The air-sea parameters for each generic tracer package default
     ! to being the same as as_param.
     ! For generic_COBALT, the as_param can be overwritten by setting

--- a/generic_tracers/generic_tracer.F90
+++ b/generic_tracers/generic_tracer.F90
@@ -170,13 +170,15 @@ contains
     write (stdlogunit, generic_tracer_nml)
 
     ! Use Wanninkhoff 2014 parameters for air-sea gas exchange if as_param='W14' in generic_tracer_nml
-    if (as_param == 'gfdl_cmip6') then
-      if (do_generic_abiotic) as_param_abiotic = as_param
-      if (do_generic_CFC)     as_param_cfc     = as_param
-      if (do_generic_SF6)     as_param_sf6     = as_param
-      if (do_generic_BLING)   as_param_bling   = as_param
-      if (do_generic_COBALT)  as_param_cobalt  = as_param
-    endif
+    ! The air-sea parameters for each generic tracer package default
+    ! to being the same as as_param.
+    ! For generic_COBALT, the as_param can be overwritten by setting
+    ! as_param_cobalt in generic_COBALT_nml.
+    if (do_generic_abiotic) as_param_abiotic = as_param
+    if (do_generic_CFC)     as_param_cfc     = as_param
+    if (do_generic_SF6)     as_param_sf6     = as_param
+    if (do_generic_BLING)   as_param_bling   = as_param
+    if (do_generic_COBALT)  as_param_cobalt  = as_param
 
     call read_mocsy_namelist()
 


### PR DESCRIPTION
This fixes #9 by always setting the air-sea parameters for each generic tracer package to the value set by as_param in generic_tracer_nml. For COBALT, it also allows overriding the globally set as_param by setting as_param_cobalt in generic_COBALT_nml. (This probably won't be used, but the option is there since each generic tracer package is maintaining its own as_param).

I'd appreciate a double-check that this works correctly in case generic_COBALT.F90 is not always setting the value of the as_param_cobalt module variable before generic_COBALT.F90 reads and overwrites from the namelist.