### PR TITLE
add parameters for case 2 (coastal) waters

### DIFF
--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -429,6 +429,7 @@ module cobalt_types
 
      logical  ::       &
           init,             &                  ! If tracers should be initializated
+          do_case2_mod,     &                  ! Flag to include augmented opacity in shallow/river-influenced systems
           force_update_fluxes,&                ! If OCMIP2 tracers fluxes should be updated every coupling timesteps
                                                !    when update_from_source is not called every coupling timesteps
                                                !    as is the case with MOM6  THERMO_SPANS_COUPLING option

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -461,6 +461,9 @@ module cobalt_types
           zmld_ref,         &
           densdiff_mld,     &
           irrad_day_thresh, &
+          case2_depth,      & ! depth threshold for case 2 (coastal) waters
+          case2_salt,       & ! salt threshold for case 2 (coastal) waters
+          case2_opac_add,   & ! added opacity for case 2 (coastal) waters
           min_daylength,    &
           gamma_irr_mem_dp, &
           gamma_mu_mem,     &

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -586,6 +586,9 @@ contains
     call g_tracer_add_param('zmld_ref', cobalt%zmld_ref, 10.0)                           ! m
     call g_tracer_add_param('densdiff_mld', cobalt%densdiff_mld, 0.03)                   ! kg m-3
     call g_tracer_add_param('irrad_day_thresh', cobalt%irrad_day_thresh, 1.0 )           ! watts m-2
+    call g_tracer_add_param('case2_depth', cobalt%case2_depth, 30.0 )                    ! m
+    call g_tracer_add_param('case2_salt', cobalt%case2_salt, 30.0 )                      ! PSU
+    call g_tracer_add_param('case2_opac_add', cobalt%case2_opac_add, 0.05 )              ! m-1
     call g_tracer_add_param('min_daylength', cobalt%min_daylength, 6.0 )                 ! hours
     call g_tracer_add_param('refuge_conc', cobalt%refuge_conc, 1.0e-10)                  ! moles N kg-1
     !
@@ -2688,8 +2691,8 @@ contains
              ! Issue: This code currently includes an option to increase opacity in shallow/fresh
              ! water.  This should be moved to a namelist (and eventually replaced with a more 
              ! robust coastal optics model with full feedbacks to the physics)
-             if ((zmid(i,j,nk).le.30.0).or.(Salt(i,j,k).le.30.0)) then
-               tmp_opacity = opacity_band(nb,i,j,k) + 0.05
+             if ((zmid(i,j,nk).le.cobalt%case2_depth).or.(Salt(i,j,k).le.cobalt%case2_salt)) then
+               tmp_opacity = opacity_band(nb,i,j,k) + cobalt%case2_opac_add
              else
                tmp_opacity = opacity_band(nb,i,j,k)
              endif

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -592,9 +592,9 @@ contains
       call g_tracer_add_param('case2_salt', cobalt%case2_salt, 30.0 )                    ! PSU
       call g_tracer_add_param('case2_opac_add', cobalt%case2_opac_add, 0.05 )            ! m-1
     else
-      call g_tracer_add_param('case2_depth', cobalt%case2_depth, 0.0 )                   ! m
-      call g_tracer_add_param('case2_salt', cobalt%case2_salt, 0.0 )                     ! PSU
-      call g_tracer_add_param('case2_opac_add', cobalt%case2_opac_add, 0.0 )             ! m-1
+      cobalt%case2_depth = 0.0                                                           ! m
+      cobalt%case2_salt = 0.0                                                            ! PSU
+      cobalt%case2_opac_add = 0.0                                                        ! m-1
     endif
     call g_tracer_add_param('min_daylength', cobalt%min_daylength, 6.0 )                 ! hours
     call g_tracer_add_param('refuge_conc', cobalt%refuge_conc, 1.0e-10)                  ! moles N kg-1

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -385,6 +385,7 @@ contains
 
     call g_tracer_start_param_list(package_name)
     call g_tracer_add_param('init', cobalt%init, .false. )
+    call g_tracer_add_param('do_case2_mod',cobalt%do_case2_mod, .true. )
 
     call g_tracer_add_param('htotal_scale_lo', cobalt%htotal_scale_lo, 0.01)
     call g_tracer_add_param('htotal_scale_hi', cobalt%htotal_scale_hi, 100.0)
@@ -586,9 +587,15 @@ contains
     call g_tracer_add_param('zmld_ref', cobalt%zmld_ref, 10.0)                           ! m
     call g_tracer_add_param('densdiff_mld', cobalt%densdiff_mld, 0.03)                   ! kg m-3
     call g_tracer_add_param('irrad_day_thresh', cobalt%irrad_day_thresh, 1.0 )           ! watts m-2
-    call g_tracer_add_param('case2_depth', cobalt%case2_depth, 30.0 )                    ! m
-    call g_tracer_add_param('case2_salt', cobalt%case2_salt, 30.0 )                      ! PSU
-    call g_tracer_add_param('case2_opac_add', cobalt%case2_opac_add, 0.05 )              ! m-1
+    if (cobalt%do_case2_mod) then
+      call g_tracer_add_param('case2_depth', cobalt%case2_depth, 30.0 )                  ! m
+      call g_tracer_add_param('case2_salt', cobalt%case2_salt, 30.0 )                    ! PSU
+      call g_tracer_add_param('case2_opac_add', cobalt%case2_opac_add, 0.05 )            ! m-1
+    else
+      call g_tracer_add_param('case2_depth', cobalt%case2_depth, 0.0 )                   ! m
+      call g_tracer_add_param('case2_salt', cobalt%case2_salt, 0.0 )                     ! PSU
+      call g_tracer_add_param('case2_opac_add', cobalt%case2_opac_add, 0.0 )             ! m-1
+    endif
     call g_tracer_add_param('min_daylength', cobalt%min_daylength, 6.0 )                 ! hours
     call g_tracer_add_param('refuge_conc', cobalt%refuge_conc, 1.0e-10)                  ! moles N kg-1
     !


### PR DESCRIPTION
During development of the NWA12, we added a salinity threshold and a depth threshold for defining "case 2" coastal waters.  If these conditions were met, the opacity of the water was augmented from the value determined by the chlorophyll based Manizza scheme so that the transmission profile was more consistent with values from coastal waters that have high concentrations of suspended matter and colored dissolved organic material (CDOM).  In NWA12, this enhanced attenuation was primarily added to avoid over-estimating primary production in turbid nearshore waters near the Mississippi River.  This could be particularly problematic near the bottom, since primary production creates oxygen, potentially leading to underestimation of the Gulf of Mexico hypoxic region.

In the NWA12 described in Ross et al. (2023), the depth threshold was set to 30m, the salinity threshold was set to 30 PSU and the opacity was augmented by 0.05 m-1.  These values, however, were "hard coded".  This pull request would establish parameters for both thresholds (case2_depth, case2_salt) and the added opacity (case2_opac_add), allowing values to be set more transparently.  I have set these to the same values that were hard coded in NWA12, so this should not change answers, but I think there are two issues to consider moving forward:

1) What should the default values of these parameters be?  I lean toward setting the values to "0" by default, and allowing for region-specific settings as needed.  It would, however, be good to get input from the group.

2) While this implementation allows for the effects of coastal waters to be felt by the BGC, it does not impact the penetration of heat in MOM6.  A more satisfying long-term solution would be implementing a radiative transfer scheme that accounts for both coastal and open ocean environments, and does so consistently across the physical and BGC components.   I can open an issue on this latter point.



