### PR TITLE
Update ci for PR #59 Add support for a COBALT_param_doc file

### DIFF
--- a/.github/workflows/cobalt_ci.yml
+++ b/.github/workflows/cobalt_ci.yml
@@ -68,11 +68,9 @@ jobs:
           singularity exec --bind /__w:/__w ../ci/singularity/1d_mom6_cobalt.sif bash linux-build.bash -m docker -p linux-gnu -t debug -f mom6sis2
           ls -l -h build/docker-linux-gnu/ocean_ice/debug/MOM6SIS2
 
-      - name: Run 1D toy case
+      - name: Create COBALT_input and COBALT_override
         working-directory: ../CEFI-regional-MOM6/exps/OM4.single_column.COBALT
         run: |
-          echo "Start 1D toy case ..."
-          pwd
           cp ./input.nml_48hr ./input.nml
           echo "add cobalt_input_nml ..."
           cat <<EOL >> ./input.nml
@@ -80,10 +78,19 @@ jobs:
                   parameter_filename = 'COBALT_input','COBALT_override'
            /
           EOL
+          cat input.nml
           echo "touch COBALT_input ..."
           echo "remin_ramp_scale = 100.0" > COBALT_input
+          cat COBALT_input
           echo "touch COBALT_override ..."
-          echo "#override remin_ramp_scale = 50.0" > COBALT_override          
+          echo "#override remin_ramp_scale = 50.0" > COBALT_override
+          cat COBALT_override
+        
+      - name: Run 1D toy case
+        working-directory: ../CEFI-regional-MOM6/exps/OM4.single_column.COBALT
+        run: |
+          echo "Start 1D toy case ..."
+          pwd
           #singularity exec --bind /__w:/__w ../../ci/singularity/1d_mom6_cobalt.sif ./driver.sh
           singularity exec --bind /__w:/__w ../../ci/singularity/1d_mom6_cobalt.sif ../../builds/build/docker-linux-gnu/ocean_ice/debug/MOM6SIS2
           mv RESTART RESTART_48hrs

--- a/.github/workflows/cobalt_ci.yml
+++ b/.github/workflows/cobalt_ci.yml
@@ -4,12 +4,12 @@ name: cobalt CI
 on:
   # Triggers the workflow on push or pull request events but only for the "dev/cefi" branch
   push:
-    branches: [ "dev/cefi" ]
+    branches: [ "update_ci" ]
   pull_request:
     branches: [ "dev/cefi" ]
 
 env:
-  BRANCH_NAME: stable/weekly_release 
+  BRANCH_NAME: main 
 
 jobs:
   # This workflow contains a single job called "build"
@@ -73,9 +73,21 @@ jobs:
         run: |
           echo "Start 1D toy case ..."
           pwd
-          ln -fs ./input.nml_48hr ./input.nml
-          singularity exec --bind /__w:/__w ../../ci/singularity/1d_mom6_cobalt.sif ./driver.sh
-          #singularity exec --bind /__w:/__w ../../ci/singularity/1d_mom6_cobalt.sif ../../builds/build/docker-linux-gnu/ocean_ice/debug/MOM6SIS2
+          cp ./input.nml_48hr ./input.nml
+          echo "add cobalt_input_nml ..."
+          cat <<EOL >> ./input.nml
+          &cobalt_input_nml
+                  parameter_filename = 'COBALT_input','COBALT_override'
+           /
+          EOL
+          echo "touch COBALT_input ..."
+          echo "remin_ramp_scale = 100.0" > COBALT_input
+          echo "touch COBALT_override ..."
+          echo "#override remin_ramp_scale = 50.0" > COBALT_override          
+          #singularity exec --bind /__w:/__w ../../ci/singularity/1d_mom6_cobalt.sif ./driver.sh
+          singularity exec --bind /__w:/__w ../../ci/singularity/1d_mom6_cobalt.sif ../../builds/build/docker-linux-gnu/ocean_ice/debug/MOM6SIS2
+          mv RESTART RESTART_48hrs
+          mv ocean.stats* RESTART_48hrs
           cat ./RESTART_48hrs/ocean.stats
 
       - name: Check with ref 

--- a/.github/workflows/cobalt_ci.yml
+++ b/.github/workflows/cobalt_ci.yml
@@ -68,17 +68,29 @@ jobs:
           singularity exec --bind /__w:/__w ../ci/singularity/1d_mom6_cobalt.sif bash linux-build.bash -m docker -p linux-gnu -t debug -f mom6sis2
           ls -l -h build/docker-linux-gnu/ocean_ice/debug/MOM6SIS2
 
-      - name: Create COBALT_input and COBALT_override
+      - name: Create COBALT_input and COBALT_override to test MOM-style parameter input and override
         working-directory: ../CEFI-regional-MOM6/exps/OM4.single_column.COBALT
         run: |
-          cp ./input.nml_48hr ./input.nml
           echo "add cobalt_input_nml ..."
-          cat <<EOL >> ./input.nml
+          cat <<EOL >> ./input.nml_48hr
           &cobalt_input_nml
                   parameter_filename = 'COBALT_input','COBALT_override'
            /
           EOL
-          cat input.nml
+          cat input.nml_48hr
+          cat <<EOL >> ./input.nml_24hr
+          &cobalt_input_nml
+                  parameter_filename = 'COBALT_input','COBALT_override'
+           /
+          EOL
+          cat input.nml_24hr        
+          cat <<EOL >> ./input.nml_24hr_rst
+          &cobalt_input_nml
+                  parameter_filename = 'COBALT_input','COBALT_override'
+           /
+          EOL
+          sed -i 's/use_modern_diag=.true./use_modern_diag=.false./' ./input.nml_24hr_rst
+          cat input.nml_24hr_rst
           echo "touch COBALT_input ..."
           echo "remin_ramp_scale = 100.0" > COBALT_input
           cat COBALT_input
@@ -91,10 +103,8 @@ jobs:
         run: |
           echo "Start 1D toy case ..."
           pwd
-          #singularity exec --bind /__w:/__w ../../ci/singularity/1d_mom6_cobalt.sif ./driver.sh
-          singularity exec --bind /__w:/__w ../../ci/singularity/1d_mom6_cobalt.sif ../../builds/build/docker-linux-gnu/ocean_ice/debug/MOM6SIS2
-          mv RESTART RESTART_48hrs
-          mv ocean.stats* RESTART_48hrs
+          singularity exec --bind /__w:/__w ../../ci/singularity/1d_mom6_cobalt.sif ./driver.sh
+          #singularity exec --bind /__w:/__w ../../ci/singularity/1d_mom6_cobalt.sif ../../builds/build/docker-linux-gnu/ocean_ice/debug/MOM6SIS2
           cat ./RESTART_48hrs/ocean.stats
 
       - name: Check with ref 

--- a/.github/workflows/cobalt_ci.yml
+++ b/.github/workflows/cobalt_ci.yml
@@ -92,9 +92,11 @@ jobs:
           sed -i 's/use_modern_diag=.true./use_modern_diag=.false./' ./input.nml_24hr_rst
           cat input.nml_24hr_rst
           echo "touch COBALT_input ..."
+          [[ -f COBALT_input ]] && rm COBALT_input
           echo "remin_ramp_scale = 100.0" > COBALT_input
           cat COBALT_input
           echo "touch COBALT_override ..."
+          [[ -f COBALT_override ]] && rm COBALT_override
           echo "#override remin_ramp_scale = 50.0" > COBALT_override
           cat COBALT_override
         

--- a/.github/workflows/cobalt_ci.yml
+++ b/.github/workflows/cobalt_ci.yml
@@ -4,7 +4,7 @@ name: cobalt CI
 on:
   # Triggers the workflow on push or pull request events but only for the "dev/cefi" branch
   push:
-    branches: [ "update_ci" ]
+    branches: [ "dev/cefi" ]
   pull_request:
     branches: [ "dev/cefi" ]
 


### PR DESCRIPTION
PR #59 introduces MOM-style parameter inputs, override, and param_doc outputs for sanity checks. It provides a perfect capability we have been looking for a while. However, it requires additional files (`COBALT_input` and `COBALT_override`). This PR updates the GitHub testing workflow to create these files and test whether the new functionality works properly. Specifically, it first sets `remin_ramp_scale = 100.0` in `COBALT_input` and then overrides it in `COBALT_override` to maintain answers.