### PR TITLE
cleaned up plankton foodweb code

### DIFF
--- a/generic_tracers/cobalt_reg_diag.F90
+++ b/generic_tracers/cobalt_reg_diag.F90
@@ -1802,10 +1802,6 @@ module COBALT_reg_diag
     cobalt%id_sfc_irr_aclm = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("sfc_irr_mem_dp","Surface Irradiance memory, diapause",'h','1','s','W m-2','f')
-    cobalt%id_sfc_irr_mem_dp = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
     vardesc_temp = vardesc("sfc_temp","Surface Temperature",'h','1','s','deg C','f')
     cobalt%id_sfc_temp = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -2345,10 +2341,6 @@ module COBALT_reg_diag
 
     vardesc_temp = vardesc("jprod_mesozoo_200","Mesozooplankton Production, 200m integration",'h','1','s','mol m-2 s-1','f')
     cobalt%id_jprod_mesozoo_200 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
-    vardesc_temp = vardesc("dp_fac","diapause factor",'h','1','s','none','f')
-    cobalt%id_dp_fac = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("daylength","daylength",'h','1','s','hours','f')

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -720,9 +720,6 @@ module COBALT_send_diag
        used = g_send_data(cobalt%id_sfc_irr_aclm,  cobalt%f_irr_aclm_sfc(:,:,1),       &
        model_time, rmask = grid_tmask(:,:,1),&
        is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_irr_mem_dp,  cobalt%f_irr_mem_dp(:,:,1),       &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
        used = g_send_data(cobalt%id_mld_aclm,  cobalt%mld_aclm,       &
        model_time, rmask = grid_tmask(:,:,1),&
        is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
@@ -1053,9 +1050,6 @@ module COBALT_send_diag
         model_time, rmask = grid_tmask(:,:,1),&
         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
         used = g_send_data(cobalt%id_jprod_mesozoo_200, cobalt%jprod_mesozoo_200,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_dp_fac, cobalt%dp_fac,         &
         model_time, rmask = grid_tmask(:,:,1),&
         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
         used = g_send_data(cobalt%id_daylength, cobalt%daylength,         &

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -456,11 +456,7 @@ module cobalt_types
           case2_salt,       & ! salt threshold for case 2 (coastal) waters
           case2_opac_add,   & ! added opacity for case 2 (coastal) waters
           min_daylength,    &
-          gamma_irr_mem_dp, &
           gamma_mu_mem,     &
-          irr_mem_dpthresh1, &
-          irr_mem_dpthresh2, &
-          dpause_max,       &
           gamma_ndet,       &
           gamma_nitrif,     &
           k_nh3_nitrif,     &
@@ -588,7 +584,6 @@ module cobalt_types
           f_irr_aclm,&
           f_irr_aclm_z,&
           f_irr_aclm_sfc, &
-          f_irr_mem_dp,&
           f_cased,&
           f_cadet_arag_btf,&
           f_cadet_calc_btf,&
@@ -846,7 +841,6 @@ module cobalt_types
           z_o2min, &
           z_sat_arag,&
           z_sat_calc,&
-          dp_fac,&
           daylength,&
 !==============================================================================================================
 ! JGJ 2016/08/08 CMIP6 Ocnbgc
@@ -1112,7 +1106,6 @@ module cobalt_types
           id_sfc_chl       = -1,       &
           id_sfc_irr       = -1,       &
           id_sfc_irr_aclm   = -1,       &
-          id_sfc_irr_mem_dp = -1,      &
           id_sfc_temp      = -1,       &
           id_btm_temp      = -1,       &
           id_btm_temp_old  = -1,       &
@@ -1204,7 +1197,6 @@ module cobalt_types
           id_jprod_cadet_calc_100 = -1, &
           id_jprod_cadet_arag_100 = -1, &
           id_jprod_mesozoo_200 = -1,   &
-          id_dp_fac            = -1,   &
           id_daylength         = -1,   &
           id_jremin_ndet_100 = -1,     &
           id_f_ndet_100 = -1,          &

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -3180,7 +3180,7 @@ contains
     ! Zooplankton feeding is parameterized with observed allometric (i.e., size-dependent) feeding rates and predator-
     ! prey linkages (i.e., Hansen, B.W. et al., 1994; Hansen, P.J., et al. 1997).  Feeding relationships are based on
     ! simple saturating (Holling Type 2) relationships when there is a single prey type.  A density dependent switching
-    ! response, however, is included when multiple prey types are present (Stock et al., 2008).  A small "refuge
+    ! response, however, is included when multiple prey types are present (Stock et al., 2008).  A small "refuge"
     ! concentration has also been included as an extra safeguard against negative values and as a reflection of the 
     ! paradigm that Baas Becking's hypothesis that "Everything is everywhere, but the environment selects".  Predation
     ! by higher predators (e.g., planktivorous fish) is modeled in a manner analogous to zooplankton, but assuming that


### PR DESCRIPTION
This pull request cleans up the code associated with zooplankton and higher predator grazing.  This involved:

1) Removing legacy code from COBALTv2 that had just been commented out
2) Removing code associated with an experimental diapause approximation that was not being used.
3) Removing an experimental "self grazing" setting that was not being used.
4) Improved commenting throughout.

The removal of the experimental diapause formulation means that the diagnostic tracer "irr_mem_dp" is no longer needed.  Several diagnostics were also removed in the clean up, but none of these seems to appear in the diagnostic table.  

I have tested the code and it runs.  This should not change answers relative to the last version, and it ultimately removed about 100 lines of code.  