### PR TITLE
Removed unused zooplankton upward swimming

### DIFF
--- a/generic_tracers/cobalt_reg_diag.F90
+++ b/generic_tracers/cobalt_reg_diag.F90
@@ -983,17 +983,6 @@ module COBALT_reg_diag
     zoo(3)%id_temp_lim = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("vmove_Smz","Small zoo movement",'h','L','s','m s-1','f')
-    zoo(1)%id_vmove = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
-    vardesc_temp = vardesc("vmove_Mdz","Medium zoo movement",'h','L','s','m s-1','f')
-    zoo(2)%id_vmove = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
-    vardesc_temp = vardesc("vmove_Lgz","Large zoo movement",'h','L','s','m s-1','f')
-    zoo(3)%id_vmove = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
     !
     ! Register bacterial diagnostics, starting with losses of bacteria to ingestion by zooplankton
     ! CAS: limit loss terms to N
@@ -1311,15 +1300,6 @@ module COBALT_reg_diag
 
     vardesc_temp = vardesc("irr_aclm_inst","Instantaneous light, avg over photoadapt layer",'h','L','s','W m-2','f')
     cobalt%id_irr_aclm_inst = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
-
-    !
-    ! Upward swimming diagnostic
-    !
-
-    vardesc_temp = vardesc("chl2sfcchl","ratio of chl to surface chl",'h','L','s','dimensionless','f')
-    cobalt%id_chl2sfcchl = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     !

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -260,9 +260,6 @@ module COBALT_send_diag
             used = g_send_data(zoo(n)%id_temp_lim, zoo(n)%temp_lim,           &
             model_time, rmask = grid_tmask,&
             is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_vmove,    zoo(n)%vmove,              &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
        enddo
 
     !
@@ -400,9 +397,6 @@ module COBALT_send_diag
        model_time, rmask = grid_tmask(:,:,:),&
        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
        used = g_send_data(cobalt%id_irr_aclm_z,       cobalt%f_irr_aclm_z,               &
-       model_time, rmask = grid_tmask(:,:,:),&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_chl2sfcchl,     cobalt%chl2sfcchl,    &
        model_time, rmask = grid_tmask(:,:,:),&
        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
         used = g_send_data(cobalt%id_jno3denit_wc,  cobalt%jno3denit_wc*rho_dzt,  &

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -271,9 +271,6 @@ module cobalt_types
     real mswitch           !< switching parameter (dimensionless)
     real bresp             !< basal respiration rate (sec-1)
     real ktemp             !< temperature dependence of zooplankton rates (C-1)
-    real upswim_chl_thresh !< threshold for swimming the the mixed layer (chl/chl_surf < thresh)
-    real upswim_I_thresh   !< Irradiance threshold for upward swimming (watts m-2)
-    real swim_max          !< maximum upward swimming speed (m s-2)
     real phi_det           !< fraction of ingested N to detritus
     real phi_ldon          !< fraction of ingested N/P to labile don
     real phi_sldon         !< fraction of ingested N/P to semi-labile don
@@ -325,7 +322,6 @@ module cobalt_types
     real, ALLOCATABLE, dimension(:,:,:) ::  jprod_n      !< zooplankton production
     real, ALLOCATABLE, dimension(:,:,:) ::  o2lim        !< oxygen limitation of zooplankton activity
     real, ALLOCATABLE, dimension(:,:,:) ::  temp_lim     !< Temperature limitation
-    real, ALLOCATABLE, dimension(:,:,:) ::  vmove        !< Vertical movement
     integer ::  id_jzloss_n       = -1 !< ID associated with diagnostics for losses of n due to consumption by other zooplankton groups
     integer ::  id_jzloss_p       = -1 !< ID associated with diagnostics for losses of p due to consumption by other zooplankton groups
     integer ::  id_jhploss_n      = -1 !< ID associated with diagnostics for losses of n due to consumption by unresolved higher preds 
@@ -351,7 +347,6 @@ module cobalt_types
     integer ::  id_jprod_n        = -1 !< ID associated with diagnostics for zooplankton production
     integer ::  id_o2lim          = -1 !< ID associated with diagnostics for oxygen limitation of zooplankton activity
     integer ::  id_temp_lim       = -1 !< ID associated with diagnostics for temperature limitation
-    integer ::  id_vmove          = -1 !< ID associated with diagnostics for vertical movement
     integer ::  id_jprod_n_100    = -1 !< ID associated with diagnostics for zooplankton nitrogen prod. integral in upper 100m
     integer ::  id_jingest_n_100  = -1 !< ID associated with diagnostics for zooplankton nitrogen ingestion integral in upper 100m
     integer ::  id_jzloss_n_100   = -1 !< ID associated with diagnostics for zooplankton nitrogen loss to zooplankton integral in upper 100m
@@ -709,7 +704,6 @@ module cobalt_types
           irr_inst,&
           irr_mix,&
           irr_aclm_inst, &
-          chl2sfcchl, &
           jno3denit_wc,&
           juptake_no3amx,&
           juptake_nh4amx,&
@@ -1024,7 +1018,6 @@ module cobalt_types
           id_irr_inst      = -1,       &
           id_irr_mix       = -1,       &
           id_irr_aclm_inst = -1,       &
-          id_chl2sfcchl    = -1,       &
           id_jalk          = -1,       &
           id_jalkc          = -1,       &  !liao
           id_jalk_plus_btm = -1,       &

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -6349,7 +6349,6 @@ contains
        allocate(zoo(n)%jprod_n(isd:ied,jsd:jed,nk))      ; zoo(n)%jprod_n         = 0.0
        allocate(zoo(n)%o2lim(isd:ied,jsd:jed,nk))        ; zoo(n)%o2lim           = 0.0
        allocate(zoo(n)%temp_lim(isd:ied,jsd:jed,nk))     ; zoo(n)%temp_lim        = 0.0
-       allocate(zoo(n)%vmove(isd:ied,jsd:jed,nk))        ; zoo(n)%vmove           = 0.0
     enddo
 
     ! higher predator ingestion
@@ -6911,7 +6910,6 @@ contains
        deallocate(zoo(n)%jprod_n)
        deallocate(zoo(n)%o2lim)
        deallocate(zoo(n)%temp_lim)
-       deallocate(zoo(n)%vmove)
     enddo
 
     deallocate(cobalt%f_alk)

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -3624,11 +3624,6 @@ contains
     call g_tracer_set_values(tracer_list,'simd','vmove',phyto(MEDIUM)%vmove,isd,jsd)
     call g_tracer_set_values(tracer_list,'silg','vmove',phyto(LARGE)%vmove,isd,jsd)
 
-    ! Set vertical movement for zooplankton
-    call g_tracer_set_values(tracer_list,'nsmz','vmove',zoo(1)%vmove,isd,jsd)
-    call g_tracer_set_values(tracer_list,'nmdz','vmove',zoo(2)%vmove,isd,jsd)
-    call g_tracer_set_values(tracer_list,'nlgz','vmove',zoo(3)%vmove,isd,jsd)
-
     call mpp_clock_end(id_clock_other_losses)
 
     !

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -802,18 +802,6 @@ contains
     call get_param(param_file, "generic_COBALT", "ktemp_smz",        zoo(1)%ktemp,             "ktemp_smz",        units="C-1", default=0.063)                   ! C-1
     call get_param(param_file, "generic_COBALT", "ktemp_mdz",        zoo(2)%ktemp,             "ktemp_mdz",        units="C-1", default=0.063)                   ! C-1
     call get_param(param_file, "generic_COBALT", "ktemp_lgz",        zoo(3)%ktemp,             "ktemp_lgz",        units="C-1", default=0.063)                   ! C-1
-    call get_param(param_file, "generic_COBALT", "upswim_chl_thresh",zoo(1)%upswim_chl_thresh, "upswim_chl_thresh",units="", default=0.0) ! dimensionless
-    call get_param(param_file, "generic_COBALT", "upswim_chl_thresh",zoo(2)%upswim_chl_thresh, "upswim_chl_thresh",units="", default=0.0) ! dimensionless
-    call get_param(param_file, "generic_COBALT", "upswim_chl_thresh",zoo(3)%upswim_chl_thresh, "upswim_chl_thresh",units="", default=0.0) ! dimensionless
-    call get_param(param_file, "generic_COBALT", "upswim_I_thresh",  zoo(1)%upswim_I_thresh,   "upswim_I_thresh",  units="", default=0.0)     ! dimensionless
-    call get_param(param_file, "generic_COBALT", "upswim_I_thresh",  zoo(2)%upswim_I_thresh,   "upswim_I_thresh",  units="", default=0.0)     ! dimensionless
-    call get_param(param_file, "generic_COBALT", "upswim_I_thresh",  zoo(3)%upswim_I_thresh,   "upswim_I_thresh",  units="", default=0.0)     ! dimensionless
-    call get_param(param_file, "generic_COBALT", "swim_max", zoo(1)%swim_max, "swim_max", units="m day-1", &
-                   default= 100.0, scale = I_sperd ) ! s-1
-    call get_param(param_file, "generic_COBALT", "swim_max", zoo(2)%swim_max, "swim_max", units="m day-1", &
-                   default= 500.0, scale = I_sperd ) ! s-1
-    call get_param(param_file, "generic_COBALT", "swim_max", zoo(3)%swim_max, "swim_max", units="m day-1", &
-                   default=2000.0, scale = I_sperd ) ! s-1
     !
     !-----------------------------------------------------------------------
     ! Bacterial growth and uptake parameters
@@ -1577,8 +1565,7 @@ contains
          name       = 'nsmz',     &
          longname   = 'Small Zooplankton Nitrogen', &
          units      = 'mol/kg',   &
-         prog       = .true.,     &
-         move_vertical = .true.  )
+         prog       = .true.     )
 
     !
     !     Medium-sized zooplankton N
@@ -1587,8 +1574,7 @@ contains
          name       = 'nmdz',     &
          longname   = 'Medium-sized zooplankton Nitrogen', &
          units      = 'mol/kg',   &
-         prog       = .true.,     &
-         move_vertical = .true.  )
+         prog       = .true.      )
 
     !
     !     Large zooplankton N (Pred zoo + krill)
@@ -1597,8 +1583,7 @@ contains
          name       = 'nlgz',     &
          longname   = 'large Zooplankton Nitrogen', &
          units      = 'mol/kg',   &
-         prog       = .true.,     &
-         move_vertical = .true.  )
+         prog       = .true.      )
 
       if (do_14c) then                                        !<<RADIOCARBON
       !       D14IC (Dissolved inorganic radiocarbon)
@@ -2937,8 +2922,6 @@ contains
           ! Calculate the chlorophyll.  Coversions give mg Chl (1000 kg)-1 ~ mg Chl m-3 
           phyto(n)%chl(i,j,k) = cobalt%c_2_n*12.0e6*phyto(n)%theta(i,j,k)*phyto(n)%f_n(i,j,k)
           cobalt%f_chl(i,j,k) = cobalt%f_chl(i,j,k)+phyto(n)%chl(i,j,k)
-          ! Issue: remnant from a movement experiment, clean up
-          cobalt%chl2sfcchl(i,j,k) = cobalt%f_chl(i,j,k)/max(cobalt%f_chl(i,j,1),epsln)
 
           ! calculate net production by phytoplankton group
           phyto(n)%jprod_n(i,j,k) = phyto(n)%mu(i,j,k)*phyto(n)%f_n(i,j,k)
@@ -3611,28 +3594,9 @@ contains
           phyto(n)%jexuloss_fe(i,j,k) = phyto(n)%jexuloss_fe(i,j,k) + phyto(n)%exu*max(phyto(n)%juptake_fe(i,j,k),0.0)
        enddo
 
-       !
-       ! 3.2.4 Movement due to swimming
-       !
-
-       do n = 1,NUM_ZOO !{
-          if ( (cobalt%chl2sfcchl(i,j,k).lt.zoo(n)%upswim_chl_thresh).or. &
-               (cobalt%f_irr_aclm(i,j,k).lt.zoo(n)%upswim_I_thresh) ) then
-             zoo(n)%vmove(i,j,k) = -zoo(n)%swim_max
-          else
-             zoo(n)%vmove(i,j,k) = 0.0
-          endif
-       enddo
-
     enddo; enddo; enddo  !} i,j,k
 
-    ! Sign convention for upward swimming to avoid detrainment is positive for
-    ! movement out of cell.  Multiply by -1 to establish a source in k = 1
     do j = jsc, jec ; do i = isc, iec   !{
-       do n = 1,NUM_ZOO
-         zoo(n)%vmove(i,j,1) = 0.0
-       enddo
-
        !
        ! assume that individually sinking phytoplankton collect in nepholoid layer
        ! and are available for resuspension if they are exposed to mixing
@@ -6555,7 +6519,6 @@ contains
     allocate(cobalt%irr_inst(isd:ied, jsd:jed, 1:nk))     ; cobalt%irr_inst=0.0
     allocate(cobalt%irr_mix(isd:ied, jsd:jed, 1:nk))      ; cobalt%irr_mix=0.0
     allocate(cobalt%irr_aclm_inst(isd:ied, jsd:jed, 1:nk))   ; cobalt%irr_aclm_inst=0.0
-    allocate(cobalt%chl2sfcchl(isd:ied, jsd:jed, 1:nk))   ; cobalt%chl2sfcchl=0.0
     allocate(cobalt%jno3denit_wc(isd:ied, jsd:jed, 1:nk)) ; cobalt%jno3denit_wc=0.0
     allocate(cobalt%juptake_no3amx(isd:ied, jsd:jed, 1:nk))   ; cobalt%juptake_no3amx=0.0
     allocate(cobalt%juptake_nh4amx(isd:ied, jsd:jed, 1:nk))   ; cobalt%juptake_nh4amx=0.0
@@ -7115,7 +7078,6 @@ contains
     deallocate(cobalt%irr_inst)
     deallocate(cobalt%irr_mix)
     deallocate(cobalt%irr_aclm_inst)
-    deallocate(cobalt%chl2sfcchl)
     deallocate(cobalt%jno3denit_wc)
     deallocate(cobalt%juptake_no3amx)
     deallocate(cobalt%juptake_nh4amx)


### PR DESCRIPTION
This pull request removes some preliminary work to implement upward zooplankton swimming to avoid detrainment.  This was ultimately not used in any production codes and will be replaced with a more complete representation of zooplankton movement that Jessica is working on with Mathieu Poupon and Laure Resplandy.  

This should not change answers.  No changes to the diagnostic table are required, but we should probably delete the following lines (which were already commented out):

"generic_cobalt_z","chl2sfcchl",         "chl2sfcchl",   "ocean_cobalt_tracers_month_z","all","mean","none",2
"generic_cobalt_z","jupswim_n_Smz",      "jupswim_n_Smz","ocean_cobalt_tracers_month_z","all","mean","none",2
"generic_cobalt_z","jupswim_n_Mdz",      "jupswim_n_Mdz","ocean_cobalt_tracers_month_z","all","mean","none",2
"generic_cobalt_z","jupswim_n_Lgz",      "jupswim_n_Lgz","ocean_cobalt_tracers_month_z","all","mean","none",2
"generic_cobalt_z","vmove_Smz",          "vmove_Smz",    "ocean_cobalt_tracers_month_z","all","mean","none",2
"generic_cobalt_z","vmove_Mdz",          "vmove_Mdz",    "ocean_cobalt_tracers_month_z","all","mean","none",2
"generic_cobalt_z","vmove_Lgz",          "vmove_Lgz",    "ocean_cobalt_tracers_month_z","all","mean","none",2
