### PR TITLE
Completely remove wc_vert_int_chemoautopp

### DIFF
--- a/generic_tracers/cobalt_reg_diag.F90
+++ b/generic_tracers/cobalt_reg_diag.F90
@@ -2331,10 +2331,6 @@ module COBALT_reg_diag
     ! Water column integrated fluxes
     !
 
-    vardesc_temp = vardesc("wc_vert_int_chemoautopp","Water column chemoautrophy vertical integral",'h','1','s','mol N m-2 s-1','f')
-    cobalt%id_wc_vert_int_chemoautopp = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
     vardesc_temp = vardesc("wc_vert_int_npp","Water column net primary production vertical integral",'h','1','s','mol N m-2 s-1','f')
     cobalt%id_wc_vert_int_npp = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -1133,9 +1133,6 @@ module COBALT_send_diag
        used = g_send_data(cobalt%id_wc_vert_int_alk,    cobalt%wc_vert_int_alk,         &
        model_time, rmask = grid_tmask(:,:,1),&
        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_wc_vert_int_chemoautopp, cobalt%wc_vert_int_chemoautopp, &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
        used = g_send_data(cobalt%id_wc_vert_int_npp,    cobalt%wc_vert_int_npp,         &
        model_time, rmask = grid_tmask(:,:,1),&
        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -861,7 +861,6 @@ module cobalt_types
           wc_vert_int_si,&
           wc_vert_int_o2,&
           wc_vert_int_alk,&
-          wc_vert_int_chemoautopp,&
           wc_vert_int_npp, &
           wc_vert_int_jdiss_sidet,&
           wc_vert_int_jdiss_cadet,&
@@ -1157,7 +1156,6 @@ module cobalt_types
           id_wc_vert_int_si = -1,      &
           id_wc_vert_int_o2 = -1,      &
           id_wc_vert_int_alk = -1,     &
-          id_wc_vert_int_chemoautopp = -1, &
           id_wc_vert_int_npp = -1, &
           id_wc_vert_int_jdiss_sidet = -1, &
           id_wc_vert_int_jdiss_cadet = -1, &


### PR DESCRIPTION
This fixes #76 by removing the four references to wc_vert_int_chemoautopp that were missed in #66 .