### PR TITLE
Add simple error message for cobalt_input_nml

### DIFF
--- a/generic_tracers/cobalt_param_doc.F90
+++ b/generic_tracers/cobalt_param_doc.F90
@@ -80,6 +80,8 @@ subroutine get_COBALT_param_file(param_file)
         valid_param_files = valid_param_files + 1
      endif
    enddo
+   if (valid_param_files == 0) call MOM_error(FATAL, "There must be at "//&
+      "least 1 valid entry in parameter_filename in cobalt_input_nml in input.nml.")
 
 end subroutine get_COBALT_param_file
 


### PR DESCRIPTION
As titled, this PR addresses the issue mentioned in #80. Instead of encountering a nonsensical signal 11 error, the code will now notify users if they forget to specify `parameter_filename` in `cobalt_input_nml` within `input.nml`. This PR does not change baselines.