### PR TITLE
re-organize diagnostic timing, improve formatting

### DIFF
--- a/generic_tracers/MOM_generic_tracer.F90
+++ b/generic_tracers/MOM_generic_tracer.F90
@@ -860,7 +860,7 @@ subroutine MOM_generic_tracer_column_physics(h_old, h_new, ea, eb, fluxes, Hml, 
 
   ! Second arg is tau which is always 1 for MOM6
   call generic_tracer_update_from_bottom(US%T_to_s*dt, 1, get_diag_time_end(CS%diag), &
-          US%C_to_degC*tv%T, rho_dzt, dzt, G%isd, G%jsd)
+          US%C_to_degC*tv%T, US%S_to_ppt*tv%S, rho_dzt, dzt, G%isd, G%jsd)
 
   !Output diagnostics via diag_manager for all generic tracers and their fluxes
   call g_tracer_send_diag(CS%g_tracer_list, get_diag_time_end(CS%diag), tau=1)

--- a/generic_tracers/cobalt_reg_diag.F90
+++ b/generic_tracers/cobalt_reg_diag.F90
@@ -353,23 +353,23 @@ module COBALT_reg_diag
     ! Register diagnostics for phytoplankton loss terms: zooplankton
     ! CAS: loss diagnostics simplified to just N
 
-    vardesc_temp = vardesc("jzloss_n_Di","Diazotroph nitrogen loss to zooplankton layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jzloss_n_Di","Diazotroph nitrogen loss to zooplankton",&
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(DIAZO)%id_jzloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jzloss_n_Lg","Large phyto nitrogen loss to zooplankton layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jzloss_n_Lg","Large phyto nitrogen loss to zooplankton",&
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(LARGE)%id_jzloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jzloss_n_Md","Medium phyto nitrogen loss to zooplankton layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jzloss_n_Md","Medium phyto nitrogen loss to zooplankton",&
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(MEDIUM)%id_jzloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jzloss_n_Sm","Small phyto nitrogen loss to zooplankton layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jzloss_n_Sm","Small phyto nitrogen loss to zooplankton",&
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(SMALL)%id_jzloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -377,23 +377,23 @@ module COBALT_reg_diag
     !  Register diagnostics for phytoplankton loss terms: aggregation
     !
 
-    vardesc_temp = vardesc("jaggloss_n_Di","Diazotroph nitrogen loss to aggregation layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jaggloss_n_Di","Diazotroph nitrogen loss to aggregation",&
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(DIAZO)%id_jaggloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jaggloss_n_Lg","Large phyto nitrogen loss to aggregation layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jaggloss_n_Lg","Large phyto nitrogen loss to aggregation",&
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(LARGE)%id_jaggloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jaggloss_n_Md","Medium phyto nitrogen loss to aggregation layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jaggloss_n_Md","Medium phyto nitrogen loss to aggregation",&
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(MEDIUM)%id_jaggloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jaggloss_n_Sm","Small phyto nitrogen loss to aggregation layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jaggloss_n_Sm","Small phyto nitrogen loss to aggregation",&
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(SMALL)%id_jaggloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -422,23 +422,23 @@ module COBALT_reg_diag
     !  Register diagnostics for phytoplankton loss terms: viruses
     !
 
-    vardesc_temp = vardesc("jvirloss_n_Di","Diazotroph nitrogen loss to viruses layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jvirloss_n_Di","Diazotroph nitrogen loss to viruses",&
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(DIAZO)%id_jvirloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jvirloss_n_Lg","Large phyto nitrogen loss to viruses layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jvirloss_n_Lg","Large phyto nitrogen loss to viruses",&
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(LARGE)%id_jvirloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jvirloss_n_Md","Medium phyto nitrogen loss to viruses layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jvirloss_n_Md","Medium phyto nitrogen loss to viruses",&
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(MEDIUM)%id_jvirloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jvirloss_n_Sm","Small phyto nitrogen loss to viruses layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jvirloss_n_Sm","Small phyto nitrogen loss to viruses",&
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(SMALL)%id_jvirloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -446,23 +446,23 @@ module COBALT_reg_diag
     !  Register diagnostics for phytoplankton loss terms: mortality
     !
 
-    vardesc_temp = vardesc("jmortloss_n_Di","Diazotroph nitrogen loss to mortality layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jmortloss_n_Di","Diazotroph nitrogen loss to mortality",&
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(DIAZO)%id_jmortloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jmortloss_n_Lg","Large phyto nitrogen loss to mortality layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jmortloss_n_Lg","Large phyto nitrogen loss to mortality",&
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(LARGE)%id_jmortloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jmortloss_n_Md","Medium phyto nitrogen loss to mortality layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jmortloss_n_Md","Medium phyto nitrogen loss to mortality",&
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(MEDIUM)%id_jmortloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jmortloss_n_Sm","Small phyto nitrogen loss to mortality layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jmortloss_n_Sm","Small phyto nitrogen loss to mortality",&
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(SMALL)%id_jmortloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -470,22 +470,22 @@ module COBALT_reg_diag
     ! Register diagnostics for phytoplankton exudation
     !
     vardesc_temp = vardesc("jexuloss_n_Di","Diazotroph nitrogen loss via exudation",&
-                           'h','L','s','mol N m-2 s-1','f')
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(DIAZO)%id_jexuloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("jexuloss_n_Lg","Large phyto nitrogen loss via exudation",&
-                           'h','L','s','mol N m-2 s-1','f')
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(LARGE)%id_jexuloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("jexuloss_n_Md","Medium phyto nitrogen loss via exudation",&
-                           'h','L','s','mol N m-2 s-1','f')
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(MEDIUM)%id_jexuloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("jexuloss_n_Sm","Small phyto nitrogen loss via exudation",&
-                           'h','L','s','mol N m-2 s-1','f')
+                           'h','L','s','mol N kg-1 s-1','f')
     phyto(SMALL)%id_jexuloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -502,113 +502,112 @@ module COBALT_reg_diag
     cobalt%id_nmd_diatoms = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("q_si_2_n_lg_diatoms","Si:N ratio in large diatoms",&
-                           'h','L','s','mol Si mol N','f')
-    cobalt%id_q_si_2_n_lg_diatoms = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+    vardesc_temp = vardesc("nlg_misc","large phytoplankton nitrogen from misc non-diatoms",&
+                           'h','L','s','mol kg-1','f') 
+    cobalt%id_nlg_diatoms = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("q_si_2_n_md_diatoms","Si:N ratio in medium diatoms",&
-                           'h','L','s','mol Si mol N','f')
-    cobalt%id_q_si_2_n_md_diatoms = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+    vardesc_temp = vardesc("nmd_misc","medium phytoplankton nitrogen from misc. non-diatoms",&
+                           'h','L','s','mol kg-1','f')
+    cobalt%id_nmd_diatoms = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
     !
     ! Register Phytoplankton Production Diagnostics
     !
 
-    vardesc_temp = vardesc("juptake_n2_Di","Nitrogen fixation layer integral",'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_n2_Di","Nitrogen fixation",'h','L','s','mol N kg-1 s-1','f')
     phyto(DIAZO)%id_juptake_n2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_fe_Di","Diaz. phyto. Fed uptake layer integral",'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_fe_Di","Diaz. phyto. Fed uptake",'h','L','s','mol Fe kg-1 s-1','f')
     phyto(DIAZO)%id_juptake_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_fe_Lg","Large phyto. Fed uptake layer integral",'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_fe_Lg","Large phyto. Fed uptake",'h','L','s','mol Fe kg-1 s-1','f')
     phyto(LARGE)%id_juptake_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_fe_Md","Medium phyto. Fed uptake layer integral",'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_fe_Md","Medium phyto. Fed uptake",'h','L','s','mol Fe kg-1 s-1','f')
     phyto(MEDIUM)%id_juptake_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_fe_Sm","Small phyto. Fed uptake layer integral",&
-                           'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_fe_Sm","Small phyto. Fed uptake",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
     phyto(SMALL)%id_juptake_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_nh4_Di","Diaz. phyto. NH4 uptake layer integral",'h','L','s','mol NH4 m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_nh4_Di","Diaz. phyto. NH4 uptake",'h','L','s','mol NH4 kg-1 s-1','f')
     phyto(DIAZO)%id_juptake_nh4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_nh4_Lg","Large phyto. NH4 uptake layer integral",'h','L','s','mol NH4 m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_nh4_Lg","Large phyto. NH4 uptake",'h','L','s','mol NH4 kg-1 s-1','f')
     phyto(LARGE)%id_juptake_nh4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_nh4_Md","Medium phyto. NH4 uptake layer integral",'h','L','s','mol NH4 m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_nh4_Md","Medium phyto. NH4 uptake",'h','L','s','mol NH4 kg-1 s-1','f')
     phyto(MEDIUM)%id_juptake_nh4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_nh4_Sm","Small phyto. NH4 uptake layer integral",&
-                           'h','L','s','mol NH4 m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_nh4_Sm","Small phyto. NH4 uptake",&
+                           'h','L','s','mol NH4 kg-1 s-1','f')
     phyto(SMALL)%id_juptake_nh4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_no3_Di","Diaz. phyto. NO3 uptake layer integral",'h','L','s','mol NO3 m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_no3_Di","Diaz. phyto. NO3 uptake",'h','L','s','mol NO3 kg-1 s-1','f')
     phyto(DIAZO)%id_juptake_no3 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_no3_Lg","Large phyto. NO3 uptake layer integral",'h','L','s','mol NO3 m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_no3_Lg","Large phyto. NO3 uptake",'h','L','s','mol NO3 kg-1 s-1','f')
     phyto(LARGE)%id_juptake_no3 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_no3_Md","Medium phyto. NO3 uptake layer integral",'h','L','s','mol NO3 m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_no3_Md","Medium phyto. NO3 uptake",'h','L','s','mol NO3 kg-1 s-1','f')
     phyto(MEDIUM)%id_juptake_no3 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_no3_Sm","Small phyto. NO3 uptake layer integral",&
-                           'h','L','s','mol NO3 m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_no3_Sm","Small phyto. NO3 uptake",&
+                           'h','L','s','mol NO3 kg-1 s-1','f')
     phyto(SMALL)%id_juptake_no3 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_po4_Di","Diaz. phyto. PO4 uptake layer integral",'h','L','s','mol PO4 m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_po4_Di","Diaz. phyto. PO4 uptake",'h','L','s','mol PO4 kg-1 s-1','f')
     phyto(DIAZO)%id_juptake_po4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_po4_Lg","Large phyto. PO4 uptake layer integral",'h','L','s','mol PO4 m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_po4_Lg","Large phyto. PO4 uptake",'h','L','s','mol PO4 kg-1 s-1','f')
     phyto(LARGE)%id_juptake_po4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_po4_Md","Medium phyto. PO4 uptake layer integral",'h','L','s','mol PO4 m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_po4_Md","Medium phyto. PO4 uptake",'h','L','s','mol PO4 kg-1 s-1','f')
     phyto(MEDIUM)%id_juptake_po4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_po4_Sm","Small phyto. PO4 uptake layer integral",&
-                           'h','L','s','mol PO4 m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_po4_Sm","Small phyto. PO4 uptake",&
+                           'h','L','s','mol PO4 kg-1 s-1','f')
     phyto(SMALL)%id_juptake_po4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_sio4_Lg","Large phyto. SiO4 uptake layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_sio4_Lg","Large phyto. SiO4 uptake",'h','L','s','mol kg-1 s-1','f')
     phyto(LARGE)%id_juptake_sio4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-   vardesc_temp = vardesc("juptake_sio4_Md","Medium phyto. SiO4 uptake layer integral",'h','L','s','mol m-2 s-1','f')
+   vardesc_temp = vardesc("juptake_sio4_Md","Medium phyto. SiO4 uptake",'h','L','s','mol kg-1 s-1','f')
     phyto(MEDIUM)%id_juptake_sio4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_ndi","Diazotroph Nitrogen production layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_ndi","Diazotroph Nitrogen production",'h','L','s','mol kg-1 s-1','f')
     phyto(DIAZO)%id_jprod_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_nsmp","Small phyto. Nitrogen production layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_nsmp","Small phyto. Nitrogen production",'h','L','s','mol kg-1 s-1','f')
     phyto(SMALL)%id_jprod_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_nmdp","Medium phyto. Nitrogen production layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_nmdp","Medium phyto. Nitrogen production",'h','L','s','mol kg-1 s-1','f')
     phyto(MEDIUM)%id_jprod_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_nlgp","Large phyto. Nitrogen production layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_nlgp","Large phyto. Nitrogen production",'h','L','s','mol kg-1 s-1','f')
     phyto(LARGE)%id_jprod_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -616,18 +615,18 @@ module COBALT_reg_diag
     ! Register zooplankton diagnostics, starting with losses of zooplankton to ingestion by zooplankton
     !
 
-    vardesc_temp = vardesc("jzloss_n_Smz","Small zooplankton nitrogen loss to zooplankton layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jzloss_n_Smz","Small zooplankton nitrogen loss to zooplankton",&
+                           'h','L','s','mol N kg-1 s-1','f')
     zoo(1)%id_jzloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jzloss_n_Mdz","Medium-sized zooplankton nitrogen loss to zooplankton layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jzloss_n_Mdz","Medium-sized zooplankton nitrogen loss to zooplankton",&
+                           'h','L','s','mol N kg-1 s-1','f')
     zoo(2)%id_jzloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jzloss_n_Lgz","Large zooplankton nitrogen loss to zooplankton layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jzloss_n_Lgz","Large zooplankton nitrogen loss to zooplankton",&
+                           'h','L','s','mol N kg-1 s-1','f')
     zoo(3)%id_jzloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -635,18 +634,18 @@ module COBALT_reg_diag
     ! Register diagnostics for zooplankton loss terms: higher predators
     !
 
-    vardesc_temp = vardesc("jhploss_n_Smz","Small zooplankton nitrogen loss to higher predators layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jhploss_n_Smz","Small zooplankton nitrogen loss to higher predators",&
+                           'h','L','s','mol N kg-1 s-1','f')
     zoo(1)%id_jhploss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jhploss_n_Mdz","Medium-sized zooplankton nitrogen loss to higher predators layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jhploss_n_Mdz","Medium-sized zooplankton nitrogen loss to higher predators",&
+                           'h','L','s','mol N kg-1 s-1','f')
     zoo(2)%id_jhploss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jhploss_n_Lgz","Large zooplankton nitrogen loss to higher predators layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jhploss_n_Lgz","Large zooplankton nitrogen loss to higher predators",&
+                           'h','L','s','mol N kg-1 s-1','f')
     zoo(3)%id_jhploss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -654,63 +653,63 @@ module COBALT_reg_diag
     ! Register zooplankton ingestion rates
     !
 
-    vardesc_temp = vardesc("jingest_n_Smz","Ingestion of nitrogen by small zooplankton, layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jingest_n_Smz","Ingestion of nitrogen by small zooplankton",&
+                           'h','L','s','mol N kg-1 s-1','f')
     zoo(1)%id_jingest_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jingest_n_Mdz","Ingestion of nitrogen by medium-sized zooplankton, layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jingest_n_Mdz","Ingestion of nitrogen by medium-sized zooplankton",&
+                           'h','L','s','mol N kg-1 s-1','f')
     zoo(2)%id_jingest_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jingest_n_Lgz","Ingestion of nitrogen by large zooplankton, layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jingest_n_Lgz","Ingestion of nitrogen by large zooplankton",&
+                           'h','L','s','mol N kg-1 s-1','f')
     zoo(3)%id_jingest_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jingest_p_Smz","Ingestion of phosphorous by small zooplankton, layer integral", &
-                           'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jingest_p_Smz","Ingestion of phosphorous by small zooplankton", &
+                           'h','L','s','mol P kg-1 s-1','f')
     zoo(1)%id_jingest_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jingest_p_Mdz","Ingestion of phosphorous by medium-sized zooplankton, layer integral",&
-                           'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jingest_p_Mdz","Ingestion of phosphorous by medium-sized zooplankton",&
+                           'h','L','s','mol P kg-1 s-1','f')
     zoo(2)%id_jingest_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jingest_p_Lgz","Ingestion of phosphorous by large zooplankton, layer integral",&
-                           'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jingest_p_Lgz","Ingestion of phosphorous by large zooplankton",&
+                           'h','L','s','mol P kg-1 s-1','f')
     zoo(3)%id_jingest_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jingest_sio2_Smz","Ingestion of sio2 by small zooplankton, layer integral",&
-                           'h','L','s','mol SiO2 m-2 s-1','f')
+    vardesc_temp = vardesc("jingest_sio2_Smz","Ingestion of sio2 by small zooplankton",&
+                           'h','L','s','mol SiO2 kg-1 s-1','f')
     zoo(1)%id_jingest_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jingest_sio2_Mdz","Ingestion of sio2 by medium-sized zooplankton, layer integral",&
-                           'h','L','s','mol SiO2 m-2 s-1','f')
+    vardesc_temp = vardesc("jingest_sio2_Mdz","Ingestion of sio2 by medium-sized zooplankton",&
+                           'h','L','s','mol SiO2 kg-1 s-1','f')
     zoo(2)%id_jingest_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jingest_sio2_Lgz","Ingestion of sio2 by large zooplankton, layer integral",&
-                           'h','L','s','mol SiO2 m-2 s-1','f')
+    vardesc_temp = vardesc("jingest_sio2_Lgz","Ingestion of sio2 by large zooplankton",&
+                           'h','L','s','mol SiO2 kg-1 s-1','f')
     zoo(3)%id_jingest_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jingest_fe_Smz","Ingestion of Fe by small zooplankton, layer integral",&
-                   'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("jingest_fe_Smz","Ingestion of Fe by small zooplankton",&
+                   'h','L','s','mol Fe kg-1 s-1','f')
     zoo(1)%id_jingest_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jingest_fe_Mdz","Ingestion of Fe by medium-sized zooplankton, layer integral",&
-                           'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("jingest_fe_Mdz","Ingestion of Fe by medium-sized zooplankton",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
     zoo(2)%id_jingest_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jingest_fe_Lgz","Ingestion of Fe by large zooplankton, layer integral",&
-                           'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("jingest_fe_Lgz","Ingestion of Fe by large zooplankton",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
     zoo(3)%id_jingest_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -718,78 +717,78 @@ module COBALT_reg_diag
     ! Register detrital production terms for zooplankton
     !
 
-    vardesc_temp = vardesc("jprod_ndet_Smz","Production of nitrogen detritus by small zooplankton, layer integral",&
-                   'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_ndet_Smz","Production of nitrogen detritus by small zooplankton",&
+                   'h','L','s','mol N kg-1 s-1','f')
     zoo(1)%id_jprod_ndet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_ndet_Mdz","Production of nitrogen detritus by medium zooplankton, layer integral",&
-                   'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_ndet_Mdz","Production of nitrogen detritus by medium zooplankton",&
+                   'h','L','s','mol N kg-1 s-1','f')
     zoo(2)%id_jprod_ndet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_ndet_Lgz","Production of nitrogen detritus by large zooplankton, layer integral",&
-                   'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_ndet_Lgz","Production of nitrogen detritus by large zooplankton",&
+                   'h','L','s','mol N kg-1 s-1','f')
     zoo(3)%id_jprod_ndet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_pdet_Smz","Production of phosphorous detritus by small zooplankton, layer integral",&
-                   'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_pdet_Smz","Production of phosphorous detritus by small zooplankton",&
+                   'h','L','s','mol P kg-1 s-1','f')
     zoo(1)%id_jprod_pdet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_pdet_Mdz","Production of phosphorous detritus by medium zooplankton, layer integral",&
-                   'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_pdet_Mdz","Production of phosphorous detritus by medium zooplankton",&
+                   'h','L','s','mol P kg-1 s-1','f')
     zoo(2)%id_jprod_pdet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_pdet_Lgz","Production of phosphorous detritus by large zooplankton, layer integral",&
-                   'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_pdet_Lgz","Production of phosphorous detritus by large zooplankton",&
+                   'h','L','s','mol P kg-1 s-1','f')
     zoo(3)%id_jprod_pdet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_sidet_Smz","Production of opal detritus by small zooplankton, layer integral",&
-                   'h','L','s','mol SiO2 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_sidet_Smz","Production of opal detritus by small zooplankton",&
+                   'h','L','s','mol SiO2 kg-1 s-1','f')
     zoo(1)%id_jprod_sidet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_sidet_Mdz","Production of opal detritus by medium zooplankton, layer integral",&
-                   'h','L','s','mol SiO2 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_sidet_Mdz","Production of opal detritus by medium zooplankton",&
+                   'h','L','s','mol SiO2 kg-1 s-1','f')
     zoo(2)%id_jprod_sidet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_sidet_Lgz","Production of opal detritus by large zooplankton, layer integral",&
-                   'h','L','s','mol SiO2 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_sidet_Lgz","Production of opal detritus by large zooplankton",&
+                   'h','L','s','mol SiO2 kg-1 s-1','f')
     zoo(3)%id_jprod_sidet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_sio4_Smz","Production of sio4 through grazing/dissolution, layer integral",&
-                   'h','L','s','mol SiO4 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_sio4_Smz","Production of sio4 through grazing/dissolution",&
+                   'h','L','s','mol SiO4 kg-1 s-1','f')
     zoo(1)%id_jprod_sio4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_sio4_Mdz","Production of sio4 through grazing/dissolution, layer integral",&
-                   'h','L','s','mol SiO4 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_sio4_Mdz","Production of sio4 through grazing/dissolution",&
+                   'h','L','s','mol SiO4 kg-1 s-1','f')
     zoo(2)%id_jprod_sio4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_sio4_Lgz","Production of sio4 through grazing/dissolution, layer integral",&
-                   'h','L','s','mol SiO4 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_sio4_Lgz","Production of sio4 through grazing/dissolution",&
+                   'h','L','s','mol SiO4 kg-1 s-1','f')
     zoo(3)%id_jprod_sio4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_fedet_Smz","Production of iron detritus by small zooplankton, layer integral",&
-                   'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_fedet_Smz","Production of iron detritus by small zooplankton",&
+                   'h','L','s','mol Fe kg-1 s-1','f')
     zoo(1)%id_jprod_fedet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_fedet_Mdz","Production of iron detritus by medium zooplankton, layer integral",&
-                   'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_fedet_Mdz","Production of iron detritus by medium zooplankton",&
+                   'h','L','s','mol Fe kg-1 s-1','f')
     zoo(2)%id_jprod_fedet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_fedet_Lgz","Production of iron detritus by large zooplankton, layer integral",&
-                   'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_fedet_Lgz","Production of iron detritus by large zooplankton",&
+                   'h','L','s','mol Fe kg-1 s-1','f')
     zoo(3)%id_jprod_fedet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -797,146 +796,146 @@ module COBALT_reg_diag
     ! Register dissolved organic/inorganic production terms for zooplankton
     !
     ! Labile dissolved organic nitrogen
-    vardesc_temp = vardesc("jprod_ldon_Smz","Production of labile dissolved organic nitrogen by small zooplankton, layer integral",&
-                   'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_ldon_Smz","Production of labile dissolved organic nitrogen by small zooplankton",&
+                   'h','L','s','mol N kg-1 s-1','f')
     zoo(1)%id_jprod_ldon = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_ldon_Mdz","Production of labile dissolved organic nitrogen by medium zooplankton, layer integral",&
-                   'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_ldon_Mdz","Production of labile dissolved organic nitrogen by medium zooplankton",&
+                   'h','L','s','mol N kg-1 s-1','f')
     zoo(2)%id_jprod_ldon = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_ldon_Lgz","Production of labile dissolved organic nitrogen by large zooplankton, layer integral",&
-                   'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_ldon_Lgz","Production of labile dissolved organic nitrogen by large zooplankton",&
+                   'h','L','s','mol N kg-1 s-1','f')
     zoo(3)%id_jprod_ldon = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     ! Labile dissolved organic phosphorous
-    vardesc_temp = vardesc("jprod_ldop_Smz","Production of labile dissolved organic phosphorous by small zooplankton, layer integral",&
-                   'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_ldop_Smz","Production of labile dissolved organic phosphorous by small zooplankton",&
+                   'h','L','s','mol P kg-1 s-1','f')
     zoo(1)%id_jprod_ldop = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_ldop_Mdz","Production of labile dissolved organic phosphorous by medium zooplankton, layer integral",&
-                   'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_ldop_Mdz","Production of labile dissolved organic phosphorous by medium zooplankton",&
+                   'h','L','s','mol P kg-1 s-1','f')
     zoo(2)%id_jprod_ldop = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_ldop_Lgz","Production of labile dissolved organic phosphorous by large zooplankton, layer integral",&
-                   'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_ldop_Lgz","Production of labile dissolved organic phosphorous by large zooplankton",&
+                   'h','L','s','mol P kg-1 s-1','f')
     zoo(3)%id_jprod_ldop = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     ! Refractory dissolved organic nitrogen
-    vardesc_temp = vardesc("jprod_srdon_Smz","Production of semi-refractory dissolved organic nitrogen by small zooplankton, layer integral",&
-                   'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_srdon_Smz","Production of semi-refractory dissolved organic nitrogen by small zooplankton",&
+                   'h','L','s','mol N kg-1 s-1','f')
     zoo(1)%id_jprod_srdon = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_srdon_Mdz","Production of semi-refractory dissolved organic nitrogen by medium zooplankton, layer integral",&
-                   'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_srdon_Mdz","Production of semi-refractory dissolved organic nitrogen by medium zooplankton",&
+                   'h','L','s','mol N kg-1 s-1','f')
     zoo(2)%id_jprod_srdon = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_srdon_Lgz","Production of semi-refractory dissolved organic nitrogen by large zooplankton, layer integral",&
-                   'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_srdon_Lgz","Production of semi-refractory dissolved organic nitrogen by large zooplankton",&
+                   'h','L','s','mol N kg-1 s-1','f')
     zoo(3)%id_jprod_srdon = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     ! Labile dissolved organic phosphorous
-    vardesc_temp = vardesc("jprod_srdop_Smz","Production of semi-refractory dissolved organic phosphorous by small zooplankton, layer integral",&
-                   'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_srdop_Smz","Production of semi-refractory dissolved organic phosphorous by small zooplankton",&
+                   'h','L','s','mol P kg-1 s-1','f')
     zoo(1)%id_jprod_srdop = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_srdop_Mdz","Production of semi-refractory dissolved organic phosphorous by medium zooplankton, layer integral",&
-                   'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_srdop_Mdz","Production of semi-refractory dissolved organic phosphorous by medium zooplankton",&
+                   'h','L','s','mol P kg-1 s-1','f')
     zoo(2)%id_jprod_srdop = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_srdop_Lgz","Production of semi-refractory dissolved organic phosphorous by large zooplankton, layer integral",&
-                   'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_srdop_Lgz","Production of semi-refractory dissolved organic phosphorous by large zooplankton",&
+                   'h','L','s','mol P kg-1 s-1','f')
     zoo(3)%id_jprod_srdop = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     ! semi-labile dissolved organic nitrogen
-    vardesc_temp = vardesc("jprod_sldon_Smz","Production of semi-labile dissolved organic nitrogen by small zooplankton, layer integral",&
-                   'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_sldon_Smz","Production of semi-labile dissolved organic nitrogen by small zooplankton",&
+                   'h','L','s','mol N kg-1 s-1','f')
     zoo(1)%id_jprod_sldon = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_sldon_Mdz","Production of semi-labile dissolved organic nitrogen by medium zooplankton, layer integral",&
-                   'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_sldon_Mdz","Production of semi-labile dissolved organic nitrogen by medium zooplankton",&
+                   'h','L','s','mol N kg-1 s-1','f')
     zoo(2)%id_jprod_sldon = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_sldon_Lgz","Production of semi-labile dissolved organic nitrogen by large zooplankton, layer integral",&
-                   'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_sldon_Lgz","Production of semi-labile dissolved organic nitrogen by large zooplankton",&
+                   'h','L','s','mol N kg-1 s-1','f')
     zoo(3)%id_jprod_sldon = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     ! semi-labile dissolved organic phosphorous
-    vardesc_temp = vardesc("jprod_sldop_Smz","Production of semi-labile dissolved organic phosphorous by small zooplankton, layer integral",&
-                   'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_sldop_Smz","Production of semi-labile dissolved organic phosphorous by small zooplankton",&
+                   'h','L','s','mol P kg-1 s-1','f')
     zoo(1)%id_jprod_sldop = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_sldop_Mdz","Production of semi-labile dissolved organic phosphorous by medium zooplankton, layer integral",&
-                   'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_sldop_Mdz","Production of semi-labile dissolved organic phosphorous by medium zooplankton",&
+                   'h','L','s','mol P kg-1 s-1','f')
     zoo(2)%id_jprod_sldop = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_sldop_Lgz","Production of semi-labile dissolved organic phosphorous by large zooplankton, layer integral",&
-                   'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_sldop_Lgz","Production of semi-labile dissolved organic phosphorous by large zooplankton",&
+                   'h','L','s','mol P kg-1 s-1','f')
     zoo(3)%id_jprod_sldop = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     ! dissolved iron
-    vardesc_temp = vardesc("jprod_fed_Smz","Production of dissolved iron by small zooplankton, layer integral",&
-                   'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_fed_Smz","Production of dissolved iron by small zooplankton",&
+                   'h','L','s','mol Fe kg-1 s-1','f')
     zoo(1)%id_jprod_fed = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_fed_Mdz","Production of dissolved iron by medium-sized zooplankton, layer integral",&
-                   'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_fed_Mdz","Production of dissolved iron by medium-sized zooplankton",&
+                   'h','L','s','mol Fe kg-1 s-1','f')
     zoo(2)%id_jprod_fed = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_fed_Lgz","Production of dissolved iron by large zooplankton, layer integral",&
-                   'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_fed_Lgz","Production of dissolved iron by large zooplankton",&
+                   'h','L','s','mol Fe kg-1 s-1','f')
     zoo(3)%id_jprod_fed = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     ! phosphate
-    vardesc_temp = vardesc("jprod_po4_Smz","Production of phosphate by small zooplankton, layer integral",&
-                   'h','L','s','mol PO4 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_po4_Smz","Production of phosphate by small zooplankton",&
+                   'h','L','s','mol PO4 kg-1 s-1','f')
     zoo(1)%id_jprod_po4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_po4_Mdz","Production of phosphate by medium-sized zooplankton, layer integral",&
-                   'h','L','s','mol PO4 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_po4_Mdz","Production of phosphate by medium-sized zooplankton",&
+                   'h','L','s','mol PO4 kg-1 s-1','f')
     zoo(2)%id_jprod_po4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_po4_Lgz","Production of phosphate by large zooplankton, layer integral",&
-                   'h','L','s','mol PO4 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_po4_Lgz","Production of phosphate by large zooplankton",&
+                   'h','L','s','mol PO4 kg-1 s-1','f')
     zoo(3)%id_jprod_po4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     ! ammonia
-    vardesc_temp = vardesc("jprod_nh4_Smz","Production of ammonia by small zooplankton, layer integral",&
-                   'h','L','s','mol NH4 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_nh4_Smz","Production of ammonia by small zooplankton",&
+                   'h','L','s','mol NH4 kg-1 s-1','f')
     zoo(1)%id_jprod_nh4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_nh4_Mdz","Production of ammonia by medium-sized zooplankton, layer integral",&
-                   'h','L','s','mol NH4 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_nh4_Mdz","Production of ammonia by medium-sized zooplankton",&
+                   'h','L','s','mol NH4 kg-1 s-1','f')
     zoo(2)%id_jprod_nh4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_nh4_Lgz","Production of ammonia by large zooplankton, layer integral",&
-                   'h','L','s','mol NH4 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_nh4_Lgz","Production of ammonia by large zooplankton",&
+                   'h','L','s','mol NH4 kg-1 s-1','f')
     zoo(3)%id_jprod_nh4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -944,18 +943,18 @@ module COBALT_reg_diag
     ! Register zooplankton production terms
     !
 
-    vardesc_temp = vardesc("jprod_nsmz","Production of new biomass (nitrogen) by small zooplankton, layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_nsmz","Production of new biomass (nitrogen) by small zooplankton",&
+                           'h','L','s','mol N kg-1 s-1','f')
     zoo(1)%id_jprod_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_nmdz","Production of new biomass (nitrogen) by medium-sized zooplankton, layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_nmdz","Production of new biomass (nitrogen) by medium-sized zooplankton",&
+                           'h','L','s','mol N kg-1 s-1','f')
     zoo(2)%id_jprod_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_nlgz","Production of new biomass (nitrogen) by large zooplankton, layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_nlgz","Production of new biomass (nitrogen) by large zooplankton",&
+                           'h','L','s','mol N kg-1 s-1','f')
     zoo(3)%id_jprod_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -987,8 +986,8 @@ module COBALT_reg_diag
     ! Register bacterial diagnostics, starting with losses of bacteria to ingestion by zooplankton
     ! CAS: limit loss terms to N
 
-    vardesc_temp = vardesc("jzloss_n_Bact","Bacterial nitrogen loss to zooplankton layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jzloss_n_Bact","Bacterial nitrogen loss to zooplankton",&
+                           'h','L','s','mol N kg-1 s-1','f')
     bact(1)%id_jzloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -996,8 +995,8 @@ module COBALT_reg_diag
     ! Register diagnostics for bacteria loss terms: viruses
     !
 
-    vardesc_temp = vardesc("jvirloss_n_Bact","Bacterial nitrogen loss to viruses layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jvirloss_n_Bact","Bacterial nitrogen loss to viruses",&
+                           'h','L','s','mol N kg-1 s-1','f')
     bact(1)%id_jvirloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -1005,11 +1004,11 @@ module COBALT_reg_diag
     ! Register bacterial uptake terms
     !
 
-    vardesc_temp = vardesc("juptake_ldon","Bacterial uptake of labile dissolved organic nitrogen",'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_ldon","Bacterial uptake of labile dissolved organic nitrogen",'h','L','s','mol N kg-1 s-1','f')
     bact(1)%id_juptake_ldon = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_ldop","Bacterial uptake of labile dissolved organic phosphorous",'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_ldop","Bacterial uptake of labile dissolved organic phosphorous",'h','L','s','mol P kg-1 s-1','f')
     bact(1)%id_juptake_ldop = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -1017,14 +1016,14 @@ module COBALT_reg_diag
     ! Register dissolved inorganic production terms for bacteria
     !
     ! phosphate
-    vardesc_temp = vardesc("jprod_po4_Bact","Production of phosphate by bacteria, layer integral",&
-                   'h','L','s','mol PO4 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_po4_Bact","Production of phosphate by bacteria",&
+                   'h','L','s','mol PO4 kg-1 s-1','f')
     bact(1)%id_jprod_po4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     ! ammonia
-    vardesc_temp = vardesc("jprod_nh4_Bact","Production of ammonia by bacteria, layer integral",&
-                   'h','L','s','mol NH4 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_nh4_Bact","Production of ammonia by bacteria",&
+                   'h','L','s','mol NH4 kg-1 s-1','f')
     bact(1)%id_jprod_nh4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -1032,8 +1031,8 @@ module COBALT_reg_diag
     ! Register bacterial production terms
     !
 
-    vardesc_temp = vardesc("jprod_nbact","Production of new biomass (nitrogen) by bacteria, layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_nbact","Production of new biomass (nitrogen) by bacteria",&
+                           'h','L','s','mol N kg-1 s-1','f')
     bact(1)%id_jprod_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -1069,87 +1068,83 @@ module COBALT_reg_diag
     cobalt%id_omega_calc = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("rho_test","testing density",'h','L','s','kg-1 m-3','f')
-    cobalt%id_rho_test = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
     !
     ! A few overall production diagnostics
     !
 
-    vardesc_temp = vardesc("jprod_cadet_arag","Aragonite CaCO3 production layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_cadet_arag","Aragonite CaCO3 production",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jprod_cadet_arag = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_cadet_calc","Calcite CaCO3 production layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_cadet_calc","Calcite CaCO3 production",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jprod_cadet_calc = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_lithdet","Lithogenic detritus production layer integral",'h','L','s','g m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_lithdet","Lithogenic detritus production",'h','L','s','g kg-1 s-1','f')
     cobalt%id_jprod_lithdet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_sidet","opal detritus production layer integral",'h','L','s','mol SiO2 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_sidet","opal detritus production",'h','L','s','mol SiO2 kg-1 s-1','f')
     cobalt%id_jprod_sidet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_sio4","sio4 production layer integral",'h','L','s','mol SiO2 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_sio4","sio4 production",'h','L','s','mol SiO2 kg-1 s-1','f')
     cobalt%id_jprod_sio4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_fedet","Detrital Fedet production layer integral",'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_fedet","Detrital Fedet production",'h','L','s','mol Fe kg-1 s-1','f')
     cobalt%id_jprod_fedet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_ndet","Detrital PON production layer integral",'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_ndet","Detrital PON production",'h','L','s','mol N kg-1 s-1','f')
     cobalt%id_jprod_ndet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_pdet","Detrital phosphorus production layer integral",'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_pdet","Detrital phosphorus production",'h','L','s','mol P kg-1 s-1','f')
     cobalt%id_jprod_pdet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_ldon","labile dissolved organic nitrogen production layer integral",&
-                            'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_ldon","labile dissolved organic nitrogen production",&
+                            'h','L','s','mol N kg-1 s-1','f')
     cobalt%id_jprod_ldon = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_ldop","labile dissolved organic phosphorous production layer integral",&
-                            'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_ldop","labile dissolved organic phosphorous production",&
+                            'h','L','s','mol P kg-1 s-1','f')
     cobalt%id_jprod_ldop = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_srdon","refractory dissolved organic nitrogen production layer integral",&
-                            'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_srdon","refractory dissolved organic nitrogen production",&
+                            'h','L','s','mol N kg-1 s-1','f')
     cobalt%id_jprod_srdon = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_srdop","refractory dissolved organic phosphorous production layer integral",&
-                            'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_srdop","refractory dissolved organic phosphorous production",&
+                            'h','L','s','mol P kg-1 s-1','f')
     cobalt%id_jprod_srdop = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_sldon","semi-labile dissolved organic nitrogen production layer integral",&
-                            'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_sldon","semi-labile dissolved organic nitrogen production",&
+                            'h','L','s','mol N kg-1 s-1','f')
     cobalt%id_jprod_sldon = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_sldop","semi-labile dissolved organic phosphorous production layer integral",&
-                            'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_sldop","semi-labile dissolved organic phosphorous production",&
+                            'h','L','s','mol P kg-1 s-1','f')
     cobalt%id_jprod_sldop = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_po4","phosphate production layer integral",&
-                            'h','L','s','mol PO4 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_po4","phosphate production",&
+                            'h','L','s','mol PO4 kg-1 s-1','f')
     cobalt%id_jprod_po4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jprod_nh4","NH4 production layer integral",'h','L','s','mol NH4 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_nh4","NH4 production",'h','L','s','mol NH4 kg-1 s-1','f')
     cobalt%id_jprod_nh4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
 ! CAS added a "plus_btm" version of jprod_nh4 to use for the remoc CMIP variable
-    vardesc_temp = vardesc("jprod_nh4_plus_btm","NH4 production layer integral plus bottom fluxes",'h','L','s','mol NH4 m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_nh4_plus_btm","NH4 production plus bottom fluxes",'h','L','s','mol NH4 kg-1 s-1','f')
     cobalt%id_jprod_nh4_plus_btm = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -1157,13 +1152,13 @@ module COBALT_reg_diag
     ! loss diagnostics: detrital loss terms
     !
 
-    vardesc_temp = vardesc("det_jzloss_n","nitrogen detritus loss to zooplankton layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("det_jzloss_n","nitrogen detritus loss to zooplankton",&
+                           'h','L','s','mol N kg-1 s-1','f')
     cobalt%id_det_jzloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
        init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("det_jhploss_n","nitrogen detritus loss to higher predators layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("det_jhploss_n","nitrogen detritus loss to higher predators",&
+                           'h','L','s','mol N kg-1 s-1','f')
     cobalt%id_det_jhploss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
        init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -1171,45 +1166,45 @@ module COBALT_reg_diag
     ! Loss diagnostics: dissolution and remineralization
     !
 
-    vardesc_temp = vardesc("jdiss_sidet","SiO2 detritus dissolution, layer integral",&
-                           'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jdiss_sidet","SiO2 detritus dissolution",&
+                           'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jdiss_sidet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jdiss_cadet_arag","CaCO3 detritus dissolution, layer integral", &
-                           'h','L','s','mol CaCO3 m-2 s-1','f')
+    vardesc_temp = vardesc("jdiss_cadet_arag","CaCO3 detritus dissolution", &
+                           'h','L','s','mol CaCO3 kg-1 s-1','f')
     cobalt%id_jdiss_cadet_arag = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     ! CAS added diagnostic including bottom fluxes for cmip5
-    vardesc_temp = vardesc("jdiss_cadet_arag_plus_btm","CaCO3 detritus dissolution plus bottom dissolution, layer integral", &
-                           'h','L','s','mol CaCO3 m-2 s-1','f')
+    vardesc_temp = vardesc("jdiss_cadet_arag_plus_btm","CaCO3 detritus dissolution plus bottom dissolution", &
+                           'h','L','s','mol CaCO3 kg-1 s-1','f')
     cobalt%id_jdiss_cadet_arag_plus_btm = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jdiss_cadet_calc","CaCO3 detritus dissolution, layer integral", &
-                           'h','L','s','mol CaCO3 m-2 s-1','f')
+    vardesc_temp = vardesc("jdiss_cadet_calc","CaCO3 detritus dissolution", &
+                           'h','L','s','mol CaCO3 kg-1 s-1','f')
     cobalt%id_jdiss_cadet_calc = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     ! CAS added diagnostic including bottom fluxes for cmip5
-    vardesc_temp = vardesc("jdiss_cadet_calc_plus_btm","CaCO3 detritus dissolution plus bottom dissolution, layer integral", &
-                           'h','L','s','mol CaCO3 m-2 s-1','f')
+    vardesc_temp = vardesc("jdiss_cadet_calc_plus_btm","CaCO3 detritus dissolution plus bottom dissolution", &
+                           'h','L','s','mol CaCO3 kg-1 s-1','f')
     cobalt%id_jdiss_cadet_calc_plus_btm = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jremin_ndet","Nitrogen detritus remineralization, layer integral",&
-                           'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jremin_ndet","Nitrogen detritus remineralization",&
+                           'h','L','s','mol N kg-1 s-1','f')
     cobalt%id_jremin_ndet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jremin_pdet","Phosphorous detritus remineralization, layer integral",&
-                           'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jremin_pdet","Phosphorous detritus remineralization",&
+                           'h','L','s','mol P kg-1 s-1','f')
     cobalt%id_jremin_pdet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jremin_fedet","Iron detritus remineralization, layer integral",&
-                           'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jremin_fedet","Iron detritus remineralization",&
+                           'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jremin_fedet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -1217,36 +1212,32 @@ module COBALT_reg_diag
     ! iron cycling diagnostics
     !
 
-    vardesc_temp = vardesc("jprod_fed","dissolved iron production layer integral",&
-                            'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_fed","dissolved iron production",&
+                            'h','L','s','mol Fe kg-1 s-1','f')
     cobalt%id_jprod_fed = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jfed","Dissolved Iron Change layer integral",'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("jfed","Dissolved Iron Change",'h','L','s','mol Fe kg-1 s-1','f')
     cobalt%id_jfed = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jfedc","Dissolved Iron Change concentration",'h','L','s','mol Fe kg-1 s-1','f')
-    cobalt%id_jfedc = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
-    vardesc_temp = vardesc("jfe_ads","Iron adsorption layer integral",'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("jfe_ads","Iron adsorption",'h','L','s','mol Fe kg-1 s-1','f')
     cobalt%id_jfe_ads = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jfe_coast","Coastal iron efflux layer integral",'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("jfe_coast","Coastal iron efflux",'h','L','s','mol Fe kg-1 s-1','f')
     cobalt%id_jfe_coast = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jfe_iceberg","iceberg iron efflux layer integral",'h','L','s','mol Fe m-2 s-1','f')
+    vardesc_temp = vardesc("jfe_iceberg","iceberg iron efflux",'h','L','s','mol Fe kg-1 s-1','f')
     cobalt%id_jfe_iceberg = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jno3_iceberg","iceberg nitrate efflux layer integral",'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("jno3_iceberg","iceberg nitrate efflux",'h','L','s','mol N kg-1 s-1','f')
     cobalt%id_jno3_iceberg = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jpo4_iceberg","iceberg phosphate efflux layer integral",'h','L','s','mol P m-2 s-1','f')
+    vardesc_temp = vardesc("jpo4_iceberg","iceberg phosphate efflux",'h','L','s','mol P kg-1 s-1','f')
     cobalt%id_jpo4_iceberg = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -1306,27 +1297,27 @@ module COBALT_reg_diag
     ! Nitrification/Denitrification/Anammox diagnostics
     !
 
-    vardesc_temp = vardesc("jprod_no3nitrif","Nitrification layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jprod_no3nitrif","Nitrification",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jprod_no3nitrif = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_nh4nitrif","NH4 uptake via Nitrification layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_nh4nitrif","NH4 uptake via Nitrification",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_juptake_nh4nitrif = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jno3denit_wc","Water column Denitrification layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jno3denit_wc","Water column Denitrification",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jno3denit_wc = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jnamx","Fixed N loss via Anammox layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jnamx","Fixed N loss via Anammox",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jnamx = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_nh4amx","NH4 uptake via Anammox layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_nh4amx","NH4 uptake via Anammox",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_juptake_nh4amx = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
              init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("juptake_no3amx","NO3 uptake via Anammox layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("juptake_no3amx","NO3 uptake via Anammox",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_juptake_no3amx = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
              init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -1334,47 +1325,47 @@ module COBALT_reg_diag
     ! Track total aerobic respiration in the water column
     !
 
-    vardesc_temp = vardesc("jo2resp_wc","Water column aerobic respiration layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jo2resp_wc","Water column aerobic respiration",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jo2resp_wc = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     !
-    ! Some useful total layer integrals
+    ! Some useful totals (change to moles kg-1 for MOM6?)
     !
 
     vardesc_temp = vardesc("nphyto_tot","Total N: Di+Lg+Md+Sm",'h','L','s','mol m-2 s-1','f')
     cobalt%id_nphyto_tot = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("tot_layer_int_c","Total Carbon (DIC+OC+IC) boxwise layer integral",'h','L','s','mol m-2','f')
+    vardesc_temp = vardesc("tot_layer_int_c","Total Carbon (DIC+OC+IC) boxwise",'h','L','s','mol m-2','f')
     cobalt%id_tot_layer_int_c = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("tot_layer_int_fe","Total Iron (Fed_OFe) boxwise layer integral",'h','L','s','mol m-2','f')
+    vardesc_temp = vardesc("tot_layer_int_fe","Total Iron (Fed_OFe) boxwise",'h','L','s','mol m-2','f')
     cobalt%id_tot_layer_int_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("tot_layer_int_n","Total Nitrogen (NO3+NH4+ON) boxwise layer integral",'h','L','s','mol m-2','f')
+    vardesc_temp = vardesc("tot_layer_int_n","Total Nitrogen (NO3+NH4+ON) boxwise",'h','L','s','mol m-2','f')
     cobalt%id_tot_layer_int_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("tot_layer_int_p","Total Phosphorus (PO4+OP) boxwise layer integral",'h','L','s','mol m-2','f')
+    vardesc_temp = vardesc("tot_layer_int_p","Total Phosphorus (PO4+OP) boxwise",'h','L','s','mol m-2','f')
     cobalt%id_tot_layer_int_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("tot_layer_int_si","Total Silicon (SiO4+SiO2) boxwise layer integral",'h','L','s','mol m-2','f')
+    vardesc_temp = vardesc("tot_layer_int_si","Total Silicon (SiO4+SiO2) boxwise",'h','L','s','mol m-2','f')
     cobalt%id_tot_layer_int_si = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("tot_layer_int_o2","Total oxygen boxwise layer integral",'h','L','s','mol m-2','f')
+    vardesc_temp = vardesc("tot_layer_int_o2","Total oxygen boxwise",'h','L','s','mol m-2','f')
     cobalt%id_tot_layer_int_o2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("tot_layer_int_alk","Total alkalinity boxwise layer integral",'h','L','s','mol m-2','f')
+    vardesc_temp = vardesc("tot_layer_int_alk","Total alkalinity boxwise",'h','L','s','mol m-2','f')
     cobalt%id_tot_layer_int_alk = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("total_filter_feeding","Total filter feeding by large organisms",'h','L','s','mol N m-2 s-1','f')
+    vardesc_temp = vardesc("total_filter_feeding","Total filter feeding by large organisms",'h','L','s','mol N kg-1 s-1','f')
     cobalt%id_total_filter_feeding = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -1823,16 +1814,8 @@ module COBALT_reg_diag
     cobalt%id_btm_temp = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("btm_temp_old","Bottom Temperature (k=nk)",'h','1','s','deg C','f')
-    cobalt%id_btm_temp_old = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
     vardesc_temp = vardesc("btm_o2","Bottom Oxygen",'h','1','s','mol kg-1','f')
     cobalt%id_btm_o2 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
-    vardesc_temp = vardesc("btm_o2_old","Bottom Oxygen (k = nk)",'h','1','s','mol kg-1','f')
-    cobalt%id_btm_o2_old = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("btm_no3","Bottom NO3",'h','1','s','mol kg-1','f')
@@ -1851,32 +1834,16 @@ module COBALT_reg_diag
     cobalt%id_btm_htotal = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("btm_htotal_old","Bottom Htotal (k=nk)",'h','1','s','mol kg-1','f')
-    cobalt%id_btm_htotal_old = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
     vardesc_temp = vardesc("btm_co3_ion","Bottom Carbonate Ion",'h','1','s','mol kg-1','f')
     cobalt%id_btm_co3_ion = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
-    vardesc_temp = vardesc("btm_co3_ion_old","Bottom Carbonate Ion (k=nk)",'h','1','s','mol kg-1','f')
-    cobalt%id_btm_co3_ion_old = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("btm_co3_sol_arag","Bottom Aragonite Solubility",'h','1','s','mol kg-1','f')
     cobalt%id_btm_co3_sol_arag = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("btm_co3_sol_arag_old","Bottom Aragonite Solubility (k=nk)",'h','1','s','mol kg-1','f')
-    cobalt%id_btm_co3_sol_arag_old = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
     vardesc_temp = vardesc("btm_co3_sol_calc","Bottom Calcite Solubility",'h','1','s','mol kg-1','f')
     cobalt%id_btm_co3_sol_calc = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
-    vardesc_temp = vardesc("btm_co3_sol_calc_old","Bottom Calcite Solubility (k=nk)",'h','1','s','mol kg-1','f')
-    cobalt%id_btm_co3_sol_calc_old = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("btm_omega_arag","Bottom saturation state for aragonite",'h','1','s','none','f')
@@ -2476,7 +2443,7 @@ module COBALT_reg_diag
     cobalt%id_f_don_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("mesozoo_200","Mesozooplankton biomass, 200m integral",'h','1','s','mol m-2','f')
+    vardesc_temp = vardesc("mesozoo_200","Mesozooplankton biomass as nitrogen, 200m integral",'h','1','s','mol N m-2','f')
     cobalt%id_f_mesozoo_200 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -2619,23 +2586,23 @@ module COBALT_reg_diag
     cobalt%id_fpo14c = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
     vardesc_temp = vardesc&
-    ("j14c_decay_dic","DI14C radioactive decay layer integral",'h','L','s','mol m-2 s-1','f')
+    ("j14c_decay_dic","DI14C radioactive decay",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_j14c_decay_dic = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
     vardesc_temp = vardesc&
-    ("j14c_decay_doc","DO14C radioactive decay layer integral",'h','L','s','mol m-2 s-1','f')
+    ("j14c_decay_doc","DO14C radioactive decay",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_j14c_decay_doc = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
     vardesc_temp = vardesc&
-    ("j14c_reminp","Sinking PO14C remineralization layer integral",'h','L','s','mol m-2 s-1','f')
+    ("j14c_reminp","Sinking PO14C remineralization",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_j14c_reminp = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
     vardesc_temp = vardesc&
-    ("jdi14c","DI14C source layer integral",'h','L','s','mol m-2 s-1','f')
+    ("jdi14c","DI14C source",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jdi14c = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
     vardesc_temp = vardesc&
-    ("jdo14c","DO14C source layer integral",'h','L','s','mol m-2 s-1','f')
+    ("jdo14c","DO14C source",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jdo14c = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
       endif                                                   !RADIOCARBON>>
@@ -2645,65 +2612,54 @@ module COBALT_reg_diag
     ! Additional diagnostics added for debugging jgj 2015/10/26
     !
 
-    vardesc_temp = vardesc("jalk","Alkalinity source layer integral",'h','L','s','eq m-2 s-1','f')
+    vardesc_temp = vardesc("jalk","Alkalinity source",'h','L','s','mole eq kg-1 s-1','f')
     cobalt%id_jalk = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jalkc","Alkalinity source layer concentration",'h','L','s','eq kg-1 s-1','f')
-    cobalt%id_jalkc = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
-    vardesc_temp = vardesc("jalk_plus_btm","Alkalinity source plus btm layer integral",'h','L','s','eq m-2 s-1','f')
+    vardesc_temp = vardesc("jalk_plus_btm","Alkalinity source plus btm",'h','L','s','mole eq kg-1 s-1','f')
     cobalt%id_jalk_plus_btm = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jdic","Dissolved Inorganic Carbon source layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jdic","Dissolved Inorganic Carbon source",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jdic = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jdicc","Dissolved Inorganic Carbon source concentration",'h','L','s','mol kg-1 s-1','f')
-    cobalt%id_jdicc = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+    vardesc_temp = vardesc("jno3","no3 source",'h','L','s','mol kg-1 s-1','f')
+    cobalt%id_jno3 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jno3c","no3 source concentration",'h','L','s','mol kg-1 s-1','f')
-    cobalt%id_jno3c = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+    vardesc_temp = vardesc("jpo4","po4 source",'h','L','s','mol kg-1 s-1','f')
+    cobalt%id_jpo4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jpo4c","po4 source concentration",'h','L','s','mol kg-1 s-1','f')
-    cobalt%id_jpo4c = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+    vardesc_temp = vardesc("jsio4","sio4 source",'h','L','s','mol kg-1 s-1','f')
+    cobalt%id_jsio4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jsio4c","sio4 source concentration",'h','L','s','mol kg-1 s-1','f')
-    cobalt%id_jsio4c = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
-    vardesc_temp = vardesc("jdic_plus_btm","Dissolved Inorganic Carbon source plus btm layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jdic_plus_btm","Dissolved Inorganic Carbon source plus btm",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jdic_plus_btm = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jnh4","NH4 source layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jnh4","NH4 source",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jnh4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jndet","NDET source layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jndet","NDET source",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jndet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jnh4_plus_btm","NH4 source plus btm layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jnh4_plus_btm","NH4 source plus btm",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jnh4_plus_btm = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jo2_plus_btm","O2 source plus btm layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jo2_plus_btm","O2 source plus btm",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jo2_plus_btm = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jo2","O2 source concentration layer integral",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("jo2","O2 source",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jo2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jo2c","O2 source concentration",'h','L','s','mol kg-1 s-1','f')
-    cobalt%id_jo2c = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
 !==============================================================================================================
 ! 2016/07/05 jgj register and send temperature as a test

--- a/generic_tracers/cobalt_reg_diag.F90
+++ b/generic_tracers/cobalt_reg_diag.F90
@@ -373,6 +373,66 @@ module COBALT_reg_diag
     phyto(SMALL)%id_jzloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
+    vardesc_temp = vardesc("jzloss_p_Di","Diazotroph phosphorus loss to zooplankton",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(DIAZO)%id_jzloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jzloss_p_Lg","Large phyto phosphorus loss to zooplankton",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(LARGE)%id_jzloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jzloss_p_Md","Medium phyto phosphorus loss to zooplankton",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(MEDIUM)%id_jzloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jzloss_p_Sm","Small phyto phosphorus loss to zooplankton",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(SMALL)%id_jzloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jzloss_fe_Di","Diazotroph iron loss to zooplankton",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(DIAZO)%id_jzloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jzloss_fe_Lg","Large phyto iron loss to zooplankton",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(LARGE)%id_jzloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jzloss_fe_Md","Medium phyto iron loss to zooplankton",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(MEDIUM)%id_jzloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jzloss_fe_Sm","Small phyto iron loss to zooplankton",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(SMALL)%id_jzloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jzloss_sio2_Di","Diazotroph silica loss to zooplankton",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(DIAZO)%id_jzloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jzloss_sio2_Lg","Large phyto silica loss to zooplankton",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(LARGE)%id_jzloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jzloss_sio2_Md","Medium phyto silica loss to zooplankton",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(MEDIUM)%id_jzloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jzloss_sio2_Sm","Small phyto silica loss to zooplankton",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(SMALL)%id_jzloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
     !
     !  Register diagnostics for phytoplankton loss terms: aggregation
     !
@@ -397,6 +457,66 @@ module COBALT_reg_diag
     phyto(SMALL)%id_jaggloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
+    vardesc_temp = vardesc("jaggloss_p_Di","Diazotroph phosphorus loss to aggregation",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(DIAZO)%id_jaggloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jaggloss_p_Lg","Large phyto phosphorus loss to aggregation",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(LARGE)%id_jaggloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jaggloss_p_Md","Medium phyto phosphorus loss to aggregation",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(MEDIUM)%id_jaggloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jaggloss_p_Sm","Small phyto phosphorus loss to aggregation",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(SMALL)%id_jaggloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+     vardesc_temp = vardesc("jaggloss_fe_Di","Diazotroph iron loss to aggregation",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(DIAZO)%id_jaggloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jaggloss_fe_Lg","Large phyto iron loss to aggregation",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(LARGE)%id_jaggloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jaggloss_fe_Md","Medium phyto iron loss to aggregation",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(MEDIUM)%id_jaggloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jaggloss_fe_Sm","Small phyto iron loss to aggregation",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(SMALL)%id_jaggloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+     vardesc_temp = vardesc("jaggloss_sio2_Di","Diazotroph silica loss to aggregation",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(DIAZO)%id_jaggloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jaggloss_sio2_Lg","Large phyto silica loss to aggregation",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(LARGE)%id_jaggloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jaggloss_sio2_Md","Medium phyto silica loss to aggregation",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(MEDIUM)%id_jaggloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jaggloss_sio2_Sm","Small phyto silica loss to aggregation",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(SMALL)%id_jaggloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
     vardesc_temp = vardesc("stress_fac_Di","Diazotroph stress factor",&
                            'h','L','s','dimensionless','f')
     phyto(DIAZO)%id_stress_fac = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
@@ -417,11 +537,9 @@ module COBALT_reg_diag
     phyto(SMALL)%id_stress_fac = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-
     !
     !  Register diagnostics for phytoplankton loss terms: viruses
     !
-
     vardesc_temp = vardesc("jvirloss_n_Di","Diazotroph nitrogen loss to viruses",&
                            'h','L','s','mol N kg-1 s-1','f')
     phyto(DIAZO)%id_jvirloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
@@ -440,6 +558,66 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("jvirloss_n_Sm","Small phyto nitrogen loss to viruses",&
                            'h','L','s','mol N kg-1 s-1','f')
     phyto(SMALL)%id_jvirloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jvirloss_p_Di","Diazotroph phosphorus loss to viruses",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(DIAZO)%id_jvirloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jvirloss_p_Lg","Large phyto phosphorus loss to viruses",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(LARGE)%id_jvirloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jvirloss_p_Md","Medium phyto phosphorus loss to viruses",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(MEDIUM)%id_jvirloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jvirloss_p_Sm","Small phyto phosphorus loss to viruses",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(SMALL)%id_jvirloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jvirloss_fe_Di","Diazotroph iron loss to viruses",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(DIAZO)%id_jvirloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jvirloss_fe_Lg","Large phyto iron loss to viruses",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(LARGE)%id_jvirloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jvirloss_fe_Md","Medium phyto iron loss to viruses",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(MEDIUM)%id_jvirloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jvirloss_fe_Sm","Small phyto iron loss to viruses",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(SMALL)%id_jvirloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jvirloss_sio2_Di","Diazotroph silica loss to viruses",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(DIAZO)%id_jvirloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jvirloss_sio2_Lg","Large phyto silica loss to viruses",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(LARGE)%id_jvirloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jvirloss_sio2_Md","Medium phyto silica loss to viruses",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(MEDIUM)%id_jvirloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jvirloss_sio2_Sm","Small phyto silica loss to viruses",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(SMALL)%id_jvirloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     !
@@ -466,6 +644,65 @@ module COBALT_reg_diag
     phyto(SMALL)%id_jmortloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
+    vardesc_temp = vardesc("jmortloss_p_Di","Diazotroph phosphorus loss to mortality",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(DIAZO)%id_jmortloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jmortloss_p_Lg","Large phyto phosphorus loss to mortality",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(LARGE)%id_jmortloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jmortloss_p_Md","Medium phyto phosphorus loss to mortality",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(MEDIUM)%id_jmortloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jmortloss_p_Sm","Small phyto phosphorus loss to mortality",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(SMALL)%id_jmortloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jmortloss_fe_Di","Diazotroph iron loss to mortality",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(DIAZO)%id_jmortloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jmortloss_fe_Lg","Large phyto iron loss to mortality",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(LARGE)%id_jmortloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jmortloss_fe_Md","Medium phyto iron loss to mortality",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(MEDIUM)%id_jmortloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jmortloss_fe_Sm","Small phyto iron loss to mortality",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(SMALL)%id_jmortloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jmortloss_sio2_Di","Diazotroph silica loss to mortality",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(DIAZO)%id_jmortloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jmortloss_sio2_Lg","Large phyto silica loss to mortality",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(LARGE)%id_jmortloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jmortloss_sio2_Md","Medium phyto silica loss to mortality",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(MEDIUM)%id_jmortloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jmortloss_sio2_Sm","Small phyto silica loss to mortality",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(SMALL)%id_jmortloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
     !
     ! Register diagnostics for phytoplankton exudation
     !
@@ -487,6 +724,129 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("jexuloss_n_Sm","Small phyto nitrogen loss via exudation",&
                            'h','L','s','mol N kg-1 s-1','f')
     phyto(SMALL)%id_jexuloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jexuloss_p_Di","Diazotroph phosphorus loss via exudation",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(DIAZO)%id_jexuloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jexuloss_p_Lg","Large phyto phosphorus loss via exudation",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(LARGE)%id_jexuloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jexuloss_p_Md","Medium phyto phosphorus loss via exudation",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(MEDIUM)%id_jexuloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jexuloss_p_Sm","Small phyto phosphorus loss via exudation",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(SMALL)%id_jexuloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jexuloss_fe_Di","Diazotroph iron loss via exudation",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(DIAZO)%id_jexuloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jexuloss_fe_Lg","Large phyto iron loss via exudation",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(LARGE)%id_jexuloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jexuloss_fe_Md","Medium phyto iron loss via exudation",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(MEDIUM)%id_jexuloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jexuloss_fe_Sm","Small phyto iron loss via exudation",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(SMALL)%id_jexuloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    !
+    ! Phytoplankton losses to higher predators (0 by default)
+    !
+    vardesc_temp = vardesc("jhploss_n_Di","Diazotroph nitrogen loss to higher predators",&
+                           'h','L','s','mol N kg-1 s-1','f')
+    phyto(DIAZO)%id_jhploss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_n_Lg","Large phyto nitrogen loss to higher predators",&
+                           'h','L','s','mol N kg-1 s-1','f')
+    phyto(LARGE)%id_jhploss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_n_Md","Medium phyto nitrogen loss to higher predators",&
+                           'h','L','s','mol N kg-1 s-1','f')
+    phyto(MEDIUM)%id_jhploss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_n_Sm","Small phyto nitrogen loss to higher predators",&
+                           'h','L','s','mol N kg-1 s-1','f')
+    phyto(SMALL)%id_jhploss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_p_Di","Diazotroph phosphorus loss to higher predators",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(DIAZO)%id_jhploss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_p_Lg","Large phyto phosphorus loss to higher predators",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(LARGE)%id_jhploss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_p_Md","Medium phyto phosphorus loss to higher predators",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(MEDIUM)%id_jhploss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_p_Sm","Small phyto phosphorus loss to higher predators",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    phyto(SMALL)%id_jhploss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_fe_Di","Diazotroph iron loss to higher predators",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(DIAZO)%id_jhploss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_fe_Lg","Large phyto iron loss to higher predators",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(LARGE)%id_jhploss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_fe_Md","Medium phyto iron loss to higher predators",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(MEDIUM)%id_jhploss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_fe_Sm","Small phyto iron loss to higher predators",&
+                           'h','L','s','mol Fe kg-1 s-1','f')
+    phyto(SMALL)%id_jhploss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_sio2_Di","Diazotroph silica loss to higher predators",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(DIAZO)%id_jhploss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_sio2_Lg","Large phyto silica loss to higher predators",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(LARGE)%id_jhploss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jploss_sio2_Md","Medium phyto silica loss to higher predators",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(MEDIUM)%id_jhploss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_sio2_Sm","Small phyto silica loss to higher predators",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(SMALL)%id_jhploss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     !
@@ -630,6 +990,21 @@ module COBALT_reg_diag
     zoo(3)%id_jzloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
+    vardesc_temp = vardesc("jzloss_p_Smz","Small zooplankton phosphorus loss to zooplankton",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    zoo(1)%id_jzloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jzloss_p_Mdz","Medium-sized zooplankton phosphorus loss to zooplankton",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    zoo(2)%id_jzloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jzloss_p_Lgz","Large zooplankton phosphorus loss to zooplankton",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    zoo(3)%id_jzloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
     !
     ! Register diagnostics for zooplankton loss terms: higher predators
     !
@@ -647,6 +1022,21 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("jhploss_n_Lgz","Large zooplankton nitrogen loss to higher predators",&
                            'h','L','s','mol N kg-1 s-1','f')
     zoo(3)%id_jhploss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_p_Smz","Small zooplankton phosphorus loss to higher predators",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    zoo(1)%id_jhploss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_p_Mdz","Medium-sized zooplankton phosphorus loss to higher predators",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    zoo(2)%id_jhploss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_p_Lgz","Large zooplankton phosphorus loss to higher predators",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    zoo(3)%id_jhploss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     !
@@ -790,6 +1180,20 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("jprod_fedet_Lgz","Production of iron detritus by large zooplankton",&
                    'h','L','s','mol Fe kg-1 s-1','f')
     zoo(3)%id_jprod_fedet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    !
+    ! Detrus losses to zooplankton and higher predators.  These are 0 by default but could be made non-zero with the
+    ! introduction of detrivory.  These are N diagnostics for this, but may want to add P, Si, Fe etc.
+    !
+    vardesc_temp = vardesc("det_jzloss_n","Loss of nitrogen detritus to zooplankton",&
+                   'h','L','s','mol N kg-1 s-1','f')
+    cobalt%id_det_jzloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("det_jhploss_n","Loss of nitrogen detritus to higher predators",&
+                   'h','L','s','mol N kg-1 s-1','f')
+    cobalt%id_det_jhploss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     !
@@ -991,6 +1395,11 @@ module COBALT_reg_diag
     bact(1)%id_jzloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
+    vardesc_temp = vardesc("jzloss_p_Bact","Bacterial phosphorus loss to zooplankton",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    bact(1)%id_jzloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
     !
     ! Register diagnostics for bacteria loss terms: viruses
     !
@@ -998,6 +1407,25 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("jvirloss_n_Bact","Bacterial nitrogen loss to viruses",&
                            'h','L','s','mol N kg-1 s-1','f')
     bact(1)%id_jvirloss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jvirloss_p_Bact","Bacterial phosphorus loss to viruses",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    bact(1)%id_jvirloss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    !
+    ! Register diagnostics for bacteria loss terms: higher predators (0 by default)
+    !
+
+    vardesc_temp = vardesc("jhploss_n_Bact","Bacterial nitrogen loss to higher predators",&
+                           'h','L','s','mol N kg-1 s-1','f')
+    bact(1)%id_jhploss_n = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jhploss_p_Bact","Bacterial phosphorus loss to higher predators",&
+                           'h','L','s','mol P kg-1 s-1','f')
+    bact(1)%id_jhploss_p = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     !
@@ -1291,6 +1719,14 @@ module COBALT_reg_diag
 
     vardesc_temp = vardesc("irr_aclm_inst","Instantaneous light, avg over photoadapt layer",'h','L','s','W m-2','f')
     cobalt%id_irr_aclm_inst = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("irr_aclm_z","Acclimation irradiance with vertical structure preserved in mixed layer",'h','L','s','W m-2','f')
+    cobalt%id_irr_aclm_z = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("irr_aclm","Acclimation irradiance",'h','L','s','W m-2','f')
+    cobalt%id_irr_aclm = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     !
@@ -1734,8 +2170,24 @@ module COBALT_reg_diag
     cobalt%id_pco2surf = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
+    vardesc_temp = vardesc("co2_alpha","Solubility of CO2 for air",'h','1','s','mol/kg/atm','f')
+    cobalt%id_co2_alpha = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("co2_csurf","H2CO3+CO2(aq) (H2CO3*) in water",'h','1','s','mol kg-1','f')
+    cobalt%id_co2_csurf = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
     vardesc_temp = vardesc("pnh3surf","Oceanic pNH3",'h','1','s','uatm','f')
     cobalt%id_pnh3surf = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("nh3_alpha","Solubility of NH3 for air",'h','1','s','mol/kg/atm','f')
+    cobalt%id_nh3_alpha = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("nh3_csurf","concentration of nh3 in water",'h','1','s','mol kg-1','f')
+    cobalt%id_nh3_csurf = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("sfc_alk","Surface Alkalinity",'h','1','s','eq kg-1','f')
@@ -1852,6 +2304,23 @@ module COBALT_reg_diag
 
     vardesc_temp = vardesc("btm_omega_calc","Bottom saturation state for calcite",'h','1','s','none','f')
     cobalt%id_btm_omega_calc = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+ ! Diagnostics to assess averaging over the bottom mixed layer.
+    vardesc_temp = vardesc("grid_kmt_diag","The k-index of the bottom grid cell",'h','1','s','none','f')
+    cobalt%id_grid_kmt_diag = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+    
+    vardesc_temp = vardesc("rho_dzt_kmt_diag","The thickness of the bottom grid cell",'h','1','s','kg m-2','f')
+    cobalt%id_rho_dzt_kmt_diag = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("k_bot_diag","The k-index of shallowest grid cell included in the bottom boundary",'h','1','s','none','f')
+    cobalt%id_k_bot_diag = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("rho_dzt_bot_diag","The thickness that contributes to the bottom boundary layer calculation",'h','1','s','kg m-2','f')
+    cobalt%id_rho_dzt_bot_diag = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("cased_2d","calcium carbonate in sediment",'h','1','s','mol m-3','f')
@@ -2323,6 +2792,30 @@ module COBALT_reg_diag
     cobalt%id_jprod_mesozoo_200 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
+    vardesc_temp = vardesc("jalk_100","integrated alkalinity tendency in the top 100m",'h','1','s','mol m-2 s-1','f')
+    cobalt%id_jalk_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jdic_100","integrated dissolved organic carbon tendency in the top 100m",'h','1','s','mol m-2 s-1','f')
+    cobalt%id_jdic_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jdin_100","integrated dissolved inorganic nitrogen tendency in the top 100m",'h','1','s','mol m-2 s-1','f')
+    cobalt%id_jdin_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jfed_100","integrated dissolved iron tendency in the top 100m",'h','1','s','mol m-2 s-1','f')
+    cobalt%id_jfed_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jpo4_100","integrated phosphate tendency in the top 100m",'h','1','s','mol m-2 s-1','f')
+    cobalt%id_jpo4_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jsio4_100","integrated silicate tendency in the top 100m",'h','1','s','mol m-2 s-1','f')
+    cobalt%id_jsio4_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
     vardesc_temp = vardesc("daylength","daylength",'h','1','s','hours','f')
     cobalt%id_daylength = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -2394,6 +2887,30 @@ module COBALT_reg_diag
     !
     ! 100m integrated biomass
     !
+
+    vardesc_temp = vardesc("f_alk_int_100","integrated alkalinity in the top 100m",'h','1','s','mol equiv. m-2','f')
+    cobalt%id_f_alk_int_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("f_dic_int_100","integrated DIC in the top 100m",'h','1','s','mol m-2','f')
+    cobalt%id_f_dic_int_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("f_din_int_100","integrated DIN in the top 100m",'h','1','s','mol m-2','f')
+    cobalt%id_f_din_int_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("f_fed_int_100","integrated dissolved iron in the top 100m",'h','1','s','mol m-2','f')
+    cobalt%id_f_fed_int_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("f_po4_int_100","integrated phosphate in the top 100m",'h','1','s','mol m-2','f')
+    cobalt%id_f_po4_int_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+     vardesc_temp = vardesc("f_sio4_int_100","integrated silicate in the top 100m",'h','1','s','mol m-2','f')
+     cobalt%id_f_sio4_int_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("nsmp_100","Small phytoplankton nitrogen biomass in upper 100m",'h','1','s','mol m-2','f')
     phyto(SMALL)%id_f_n_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
@@ -2546,23 +3063,6 @@ module COBALT_reg_diag
     cobalt%id_o2min = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("z_o2min","Depth of Oxygen minimum",'h','1','s','m','f')
-    cobalt%id_z_o2min = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
-    !
-    ! Calcite and aragonite saturation depths
-    !
-
-    vardesc_temp = vardesc("z_sat_arag","Depth of Aragonite Saturation",'h','1','s','m','f')
-    cobalt%id_z_sat_arag = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
-         mask_variant=.TRUE.)
-
-    vardesc_temp = vardesc("z_sat_calc","Depth of Calcite Saturation",'h','1','s','m','f')
-    cobalt%id_z_sat_calc = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
-         mask_variant=.TRUE.)
 
       if (do_14c) then                                        !<<RADIOCARBON
     vardesc_temp = vardesc&

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -199,6 +199,8 @@ module COBALT_send_diag
             model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_omega_calc, cobalt%omega_calc, &
             model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_thetao, Temp, &
+            model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           ! Derived tracers
           used = g_send_data(cobalt%id_nphyto_tot, (cobalt%p_ndi(:,:,:,tau) +  &
             cobalt%p_nlg(:,:,:,tau) + cobalt%p_nmd(:,:,:,tau) + cobalt%p_nsm(:,:,:,tau)), &
@@ -207,17 +209,21 @@ module COBALT_send_diag
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_nmd_diatoms,cobalt%nmd_diatoms,&
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_nlg_misc,cobalt%nlg_misc,&
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_nmd_misc,cobalt%nmd_misc,&
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           ! These diagnostics have not generally been used or tested and can generally be derived from 3D diagnostics
           ! Check in CMIP7 requests.  If so, confirm functionality
           used = g_send_data(cobalt%id_o2min, cobalt%o2min, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_z_o2min, cobalt%z_o2min, &
+          used = g_send_data(cobalt%id_zo2min, cobalt%zo2min, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_z_sat_arag, cobalt%z_sat_arag, &
-            model_time, mask = cobalt%mask_z_sat_arag, rmask = grid_tmask(:,:,1), &
+          used = g_send_data(cobalt%id_zsatarag, cobalt%zsatarag, &
+            model_time, mask = cobalt%mask_zsatarag, rmask = grid_tmask(:,:,1), &
             is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_z_sat_calc, cobalt%z_sat_calc, &
-            model_time, mask = cobalt%mask_z_sat_calc, rmask = grid_tmask(:,:,1), &
+          used = g_send_data(cobalt%id_zsatcalc, cobalt%zsatcalc, &
+            model_time, mask = cobalt%mask_zsatcalc, rmask = grid_tmask(:,:,1), &
             is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
 
           ! Surface tracers (could remove if instead extracted from 3D files in the diagnostic table?)
@@ -251,6 +257,8 @@ module COBALT_send_diag
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_sfc_po4, cobalt%p_po4(:,:,1,tau), &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_sio4, cobalt%p_sio4(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_sfc_o2, cobalt%p_o2(:,:,1,tau), &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_sfc_temp, Temp(:,:,1), &
@@ -273,8 +281,6 @@ module COBALT_send_diag
           used = g_send_data(cobalt%id_pnh3surf, cobalt%pnh3_csurf, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_co2_csurf, cobalt%co2_csurf, &
-            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_pco2_csurf, cobalt%pco2_csurf, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_co2_alpha, cobalt%co2_alpha, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
@@ -722,7 +728,18 @@ module COBALT_send_diag
           !
           ! Send integrated tracer diagnostics
           !
-           used = g_send_data(cobalt%id_f_ndet_100, cobalt%f_ndet_100, &
+
+          do n = 1, NUM_PHYTO  !{
+            used = g_send_data(phyto(n)%id_f_n_100, phyto(n)%f_n_100, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          enddo
+          do n = 1, NUM_ZOO  !{
+            used = g_send_data(zoo(n)%id_f_n_100, zoo(n)%f_n_100, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          enddo
+          used = g_send_data(bact(1)%id_f_n_100, bact(1)%f_n_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_f_ndet_100, cobalt%f_ndet_100, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_f_don_100, cobalt%f_don_100, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
@@ -732,8 +749,20 @@ module COBALT_send_diag
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_f_mesozoo_200, cobalt%f_mesozoo_200,         &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_f_dic_int_100, cobalt%f_dic_int_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_f_din_int_100, cobalt%f_din_int_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_f_po4_int_100, cobalt%f_po4_int_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_f_fed_int_100, cobalt%f_fed_int_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_f_sio4_int_100, cobalt%f_sio4_int_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_f_alk_int_100, cobalt%f_alk_int_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           !
-          ! 100m flux diagnostics (handle through diagnostic table)
+          ! 100m flux diagnostics (handle through diagnostic table?)
           !
           used = g_send_data(cobalt%id_fndet_100, cobalt%fndet_100, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
@@ -1014,7 +1043,7 @@ module COBALT_send_diag
           used = g_send_data(cobalt%id_chlpicoos,  phyto(SMALL)%theta(:,:,1) * cobalt%p_nsm(:,:,1,tau) * &
             cobalt%c_2_n * cobalt%Rho_0 * 12.0e-3, model_time, rmask = grid_tmask(:,:,1), &
             is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_chldiatos,  (phyto(LARGE)%theta(:,:,1) * cobalt%nlg_misc(:,:,1) + &
+          used = g_send_data(cobalt%id_chlmiscos,  (phyto(LARGE)%theta(:,:,1) * cobalt%nlg_misc(:,:,1) + &
             phyto(MEDIUM)%theta(:,:,1) * cobalt%nmd_misc(:,:,1)) * cobalt%c_2_n * cobalt%Rho_0 * 12.0e-3, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_ponos, (cobalt%p_ndi(:,:,1,tau)+cobalt%p_nlg(:,:,1,tau)+ &
@@ -1109,8 +1138,7 @@ module COBALT_send_diag
           used = g_send_data(cobalt%id_epcalc100,  cobalt%fcadet_calc_100,   &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_eparag100, cobalt%fcadet_arag_100,   &
-            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           !
           ! Vertical integrals (kg m-2)
           !
@@ -1119,22 +1147,6 @@ module COBALT_send_diag
           used = g_send_data(cobalt%id_intdoc, cobalt%wc_vert_int_doc*12.0e-3,   &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_intpoc, cobalt%wc_vert_int_poc*12.0e-3,   &
-            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-          !
-          ! Additional 100m integrals
-          !
-          used = g_send_data(cobalt%id_f_dic_int_100, cobalt%f_dic_int_100, &
-            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_f_din_int_100, cobalt%f_din_int_100, &
-            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_f_po4_int_100, cobalt%f_po4_int_100, &
-            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_f_fed_int_100, cobalt%f_fed_int_100, &
-            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_f_sio4_int_100, cobalt%f_sio4_int_100, &
-            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_f_alk_int_100, cobalt%f_alk_int_100, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
 
         case (.false.)
@@ -1164,6 +1176,7 @@ module COBALT_send_diag
               model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
             used = g_send_data(phyto(n)%id_irrlim, phyto(n)%irrlim, &
               model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            ! N loss and mortality
             used = g_send_data(phyto(n)%id_jzloss_n, phyto(n)%jzloss_n, &
               model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
             used = g_send_data(phyto(n)%id_jaggloss_n, phyto(n)%jaggloss_n, &
@@ -1174,6 +1187,46 @@ module COBALT_send_diag
               model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
             used = g_send_data(phyto(n)%id_jexuloss_n, phyto(n)%jexuloss_n, &
               model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jhploss_n, phyto(n)%jhploss_n, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            ! P loss and mortality
+            used = g_send_data(phyto(n)%id_jzloss_p, phyto(n)%jzloss_p, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jaggloss_p, phyto(n)%jaggloss_p, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jvirloss_p, phyto(n)%jvirloss_p, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jmortloss_p, phyto(n)%jmortloss_p, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jexuloss_p, phyto(n)%jexuloss_p, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jhploss_p, phyto(n)%jhploss_p, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            ! Fe loss and mortality
+            used = g_send_data(phyto(n)%id_jzloss_fe, phyto(n)%jzloss_fe, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jaggloss_fe, phyto(n)%jaggloss_fe, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jvirloss_fe, phyto(n)%jvirloss_fe, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jmortloss_fe, phyto(n)%jmortloss_fe, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jexuloss_fe, phyto(n)%jexuloss_fe, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jhploss_fe, phyto(n)%jhploss_fe, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            ! Si loss and mortality
+            used = g_send_data(phyto(n)%id_jzloss_sio2, phyto(n)%jzloss_sio2, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jaggloss_sio2, phyto(n)%jaggloss_sio2, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jvirloss_sio2, phyto(n)%jvirloss_sio2, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jmortloss_sio2, phyto(n)%jmortloss_sio2, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jhploss_sio2, phyto(n)%jhploss_sio2, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            ! Uptake
             used = g_send_data(phyto(n)%id_juptake_fe, phyto(n)%juptake_fe, &
               model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
             used = g_send_data(phyto(n)%id_juptake_nh4, phyto(n)%juptake_nh4, &
@@ -1234,6 +1287,10 @@ module COBALT_send_diag
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(bact(1)%id_jvirloss_n, bact(1)%jvirloss_n, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(bact(1)%id_jzloss_p, bact(1)%jzloss_p, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(bact(1)%id_jvirloss_p, bact(1)%jvirloss_p, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(bact(1)%id_juptake_ldon, bact(1)%juptake_ldon, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(bact(1)%id_juptake_ldop, bact(1)%juptake_ldop, &
@@ -1258,6 +1315,10 @@ module COBALT_send_diag
             used = g_send_data(zoo(n)%id_jzloss_n, zoo(n)%jzloss_n, &
               model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
             used = g_send_data(zoo(n)%id_jhploss_n, zoo(n)%jhploss_n, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jzloss_p, zoo(n)%jzloss_p, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jhploss_p, zoo(n)%jhploss_p, &
               model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
             used = g_send_data(zoo(n)%id_jingest_n, zoo(n)%jingest_n, &
               model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
@@ -1353,6 +1414,10 @@ module COBALT_send_diag
           used = g_send_data(cobalt%id_jremin_pdet, cobalt%jremin_pdet, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jremin_fedet, cobalt%jremin_fedet, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_det_jzloss_n, cobalt%det_jzloss_n, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_det_jhploss_n, cobalt%det_jhploss_n, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jfed, cobalt%jfed, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
@@ -1703,6 +1768,10 @@ module COBALT_send_diag
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jalk_plus_btm, cobalt%jalk_plus_btm, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jdiss_cadet_arag_plus_btm, cobalt%jdiss_cadet_arag_plus_btm, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jdiss_cadet_calc_plus_btm, cobalt%jdiss_cadet_calc_plus_btm, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk) 
           used = g_send_data(cobalt%id_jdic, cobalt%jdic, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jno3, cobalt%jno3, &

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -126,7 +126,7 @@ module COBALT_send_diag
           ! tracer values at the end of the time step.  If this is set to .False., variables are saved in
           ! update_from_source and apply to conditions prior to mixing and sinking.
           ! To do: Move nh3 exchange calculations here as well?
-          if (cobalt%recalculate_carbon == .True.) then
+          if (cobalt%recalculate_carbon) then
             k=1
             do j = jsc, jec ; do i = isc, iec  !{
               cobalt%htotallo(i,j) = cobalt%htotal_scale_lo * cobalt%f_htotal(i,j,k)

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -1,45 +1,68 @@
-!> The COBALT_send_diag module contains a subroutine
-!! to handle sending diagnostics.
-!<----------------------------------------------------------------
+! The cobalt_send_diag module contains the subroutine that handles the sending of COBALT diagnostics.
+!
+! Flux and limitation diagnostics associated with the biological source and sink terms are saved at the end of the
+! "ocean_cobalt_update_from_source" routine.  They thus reflect the biological source and sink terms that were based on
+! and applied to the tracer concentrations at the beginning of the time step.  This is prior to the application of
+! vertical mixing and sinking for that time step.  This is specified by setting "post_vertdiff" to false or omitting it
+! from the cobalt_send_diag call.
+!
+! Prognostic tracer diagnostics are saved after vertical diffusion and mixing is applied (post_vertdiff = true).  This
+! ensures that prognostic tracers take the values at the end of the time step.
+! 
+! Sinking and mixing diagnostics are also saved after the update to align with the implicit mixing and sinking 
+! formulation.
+!
 module COBALT_send_diag
 
   use cobalt_types 
 
   use time_manager_mod,  only: time_type
 
-  use g_tracer_utils, only : g_send_data,g_tracer_get_pointer
+  use g_tracer_utils, only : g_send_data,g_tracer_get_pointer,g_tracer_set_values
   use g_tracer_utils, only : g_tracer_type
+  use FMS_co2calc_mod, only : FMS_co2calc, CO2_dope_vector
 
   implicit none; private
   public cobalt_send_diagnostics
 
+  type(CO2_dope_vector) :: CO2_dope_vec
+
   contains
 
     !> subroutine that handles send_diag calls for COBALT phyto, zoo, and bact      
-    subroutine cobalt_send_diagnostics(tracer_list, model_time,grid_tmask,Temp,rho_dzt,dzt,&
-                                 isc,iec,jsc,jec,nk,tau,phyto,zoo,bact,cobalt,&
+    subroutine cobalt_send_diagnostics(tracer_list, model_time,grid_tmask,Temp,Salt,rho_dzt,dzt,&
+                                 isc,iec,jsc,jec,isd,ied,jsd,jed,nk,grid_kmt,tau,phyto,zoo,bact,cobalt,&
                                  post_vertdiff)         
       type(g_tracer_type),                       pointer :: tracer_list
       type(time_type),                           intent(in) :: model_time
       real, dimension(:,:,:),                    pointer :: grid_tmask
-      real, dimension(isc:,jsc:,:),                    intent(in) :: Temp
-      real, dimension(isc:,jsc:,:),                    intent(in) :: rho_dzt
-      real, dimension(isc:,jsc:,:),                    intent(in) :: dzt
+      real, dimension(isc:,jsc:,:),              intent(in) :: Temp, Salt
+      real, dimension(isc:,jsc:,:),              intent(in) :: rho_dzt
+      real, dimension(isc:,jsc:,:),              intent(in) :: dzt
       integer,                                   intent(in) :: isc
       integer,                                   intent(in) :: iec
       integer,                                   intent(in) :: jsc
       integer,                                   intent(in) :: jec
-      integer,                                   intent(in) :: nk 
+      integer,                                   intent(in) :: isd
+      integer,                                   intent(in) :: ied
+      integer,                                   intent(in) :: jsd
+      integer,                                   intent(in) :: jed
+      integer,                                   intent(in) :: nk
+      integer, dimension(isc:,jsc:),             intent(in) :: grid_kmt
       integer,                                   intent(in) :: tau
-      type(phytoplankton), dimension(NUM_PHYTO), intent(in) :: phyto
-      type(zooplankton), dimension(NUM_ZOO),     intent(in) :: zoo
-      type(bacteria), dimension(NUM_BACT),       intent(in) :: bact
+      type(phytoplankton), dimension(NUM_PHYTO), intent(inout) :: phyto
+      type(zooplankton), dimension(NUM_ZOO),     intent(inout) :: zoo
+      type(bacteria), dimension(NUM_BACT),       intent(inout) :: bact
       type(generic_COBALT_type),                 intent(inout) :: cobalt
       logical,                                   intent(in), optional :: post_vertdiff
       !> local variables
       integer :: n,i,j,k
       logical :: used  
       logical :: is_post_vertdiff
+      real :: drho_dzt
+      integer, dimension(:,:), Allocatable :: k_bot
+      real, dimension(:,:), Allocatable :: rho_dzt_100,rho_dzt_200,rho_dzt_bot
+      integer :: k_100,k_200
 
       ! Set default value
       is_post_vertdiff = .false.
@@ -48,2406 +71,1818 @@ module COBALT_send_diag
       if (present(post_vertdiff)) then
         is_post_vertdiff = post_vertdiff
       endif
-      
-      !
-      ! Determine the case (default to .false. if post_vertdiff is not present)
+     
+      ! Determine whether the cobalt_send_diagnostics is saving in update_from_source or after vertdiff 
+      ! (default to .false. if post_vertdiff is not present)
       select case (is_post_vertdiff)
-        case (.true.)
-        ! Logic for "post_vertdiff" case     
-!
-!---------------------------------------------------------------------
-! Save water column vertical integrals
-!---------------------------------------------------------------------
-!
-         !Calculate layer integrals
-         ! First get prognostics tracer fields via their pointers 
-         call g_tracer_get_pointer(tracer_list,'alk'    ,'field',cobalt%p_alk    )
-         call g_tracer_get_pointer(tracer_list,'cadet_arag','field',cobalt%p_cadet_arag)
-         call g_tracer_get_pointer(tracer_list,'cadet_calc','field',cobalt%p_cadet_calc)
-         call g_tracer_get_pointer(tracer_list,'dic'    ,'field',cobalt%p_dic    )
-         call g_tracer_get_pointer(tracer_list,'fed'    ,'field',cobalt%p_fed    )
-         call g_tracer_get_pointer(tracer_list,'fedi'   ,'field',cobalt%p_fedi   )
-         call g_tracer_get_pointer(tracer_list,'felg'   ,'field',cobalt%p_felg   )
-         call g_tracer_get_pointer(tracer_list,'femd'   ,'field',cobalt%p_femd   )
-         call g_tracer_get_pointer(tracer_list,'fesm'   ,'field',cobalt%p_fesm )
-         call g_tracer_get_pointer(tracer_list,'fedet'  ,'field',cobalt%p_fedet  )
-         call g_tracer_get_pointer(tracer_list,'ldon'   ,'field',cobalt%p_ldon   )
-         call g_tracer_get_pointer(tracer_list,'ldop'   ,'field',cobalt%p_ldop   )
-         call g_tracer_get_pointer(tracer_list,'nbact'  ,'field',cobalt%p_nbact  )
-         call g_tracer_get_pointer(tracer_list,'ndet'   ,'field',cobalt%p_ndet   )
-         call g_tracer_get_pointer(tracer_list,'ndi'    ,'field',cobalt%p_ndi    )
-         call g_tracer_get_pointer(tracer_list,'nlg'    ,'field',cobalt%p_nlg    )
-         call g_tracer_get_pointer(tracer_list,'nmd'    ,'field',cobalt%p_nmd    )
-         call g_tracer_get_pointer(tracer_list,'nsm' ,'field',cobalt%p_nsm ) 
-         call g_tracer_get_pointer(tracer_list,'nh4'    ,'field',cobalt%p_nh4    )
-         call g_tracer_get_pointer(tracer_list,'no3'    ,'field',cobalt%p_no3    )
-         call g_tracer_get_pointer(tracer_list,'o2'     ,'field',cobalt%p_o2     )
-         call g_tracer_get_pointer(tracer_list,'pdi'    ,'field',cobalt%p_pdi    )
-         call g_tracer_get_pointer(tracer_list,'plg'    ,'field',cobalt%p_plg    )
-         call g_tracer_get_pointer(tracer_list,'pmd'    ,'field',cobalt%p_pmd    )
-         call g_tracer_get_pointer(tracer_list,'psm'    ,'field',cobalt%p_psm    )
-         call g_tracer_get_pointer(tracer_list,'pdet'   ,'field',cobalt%p_pdet   )
-         call g_tracer_get_pointer(tracer_list,'po4'    ,'field',cobalt%p_po4    )
-         call g_tracer_get_pointer(tracer_list,'srdon'   ,'field',cobalt%p_srdon   )
-         call g_tracer_get_pointer(tracer_list,'srdop'   ,'field',cobalt%p_srdop   )
-         call g_tracer_get_pointer(tracer_list,'sldon'   ,'field',cobalt%p_sldon   )
-         call g_tracer_get_pointer(tracer_list,'sldop'   ,'field',cobalt%p_sldop   )
-         call g_tracer_get_pointer(tracer_list,'sidet'  ,'field',cobalt%p_sidet  )
-         call g_tracer_get_pointer(tracer_list,'silg'   ,'field',cobalt%p_silg   )
-         call g_tracer_get_pointer(tracer_list,'simd'   ,'field',cobalt%p_simd   )
-         call g_tracer_get_pointer(tracer_list,'sio4'   ,'field',cobalt%p_sio4   )
-         call g_tracer_get_pointer(tracer_list,'nsmz'   ,'field',cobalt%p_nsmz   )
-         call g_tracer_get_pointer(tracer_list,'nmdz'   ,'field',cobalt%p_nmdz   )
-         call g_tracer_get_pointer(tracer_list,'nlgz'   ,'field',cobalt%p_nlgz   )
-         ! Not sure if we also have to update the following?
-         !call g_tracer_get_pointer(tracer_list,'lith'   ,'field',cobalt%p_lith   )
-         !call g_tracer_get_pointer(tracer_list,'lithdet','field',cobalt%p_lithdet)
+        case (.true.)     ! Saving prognostic tracers after update from vertical diffusion and sinking
 
-         ! The carbon layer integral (organic + inorganic).  Note that this can be calculated with or without a constant
-         ! background level of recalcitrant dissolved organic carbon by setting cobalt%doc_background.  This is included
-         ! at a level of 40 micromoles kg-1 by default.
-         cobalt%tot_layer_int_c(:,:,:) = (cobalt%p_dic(:,:,:,tau) + cobalt%doc_background + cobalt%p_cadet_arag(:,:,:,tau) +&
-             cobalt%p_cadet_calc(:,:,:,tau) + cobalt%c_2_n * (cobalt%p_ndi(:,:,:,tau) + cobalt%p_nlg(:,:,:,tau) + &
-             cobalt%p_nmd(:,:,:,tau) + cobalt%p_nsm(:,:,:,tau) + cobalt%p_nbact(:,:,:,tau) + cobalt%p_ldon(:,:,:,tau) + &
-             cobalt%p_sldon(:,:,:,tau) + cobalt%p_srdon(:,:,:,tau) + cobalt%p_ndet(:,:,:,tau) + cobalt%p_nsmz(:,:,:,tau) + &
-             cobalt%p_nmdz(:,:,:,tau) + cobalt%p_nlgz(:,:,:,tau))) * rho_dzt(:,:,:)
+          !call g_tracer_get_common(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,&
+          !     grid_tmask=grid_tmask,grid_mask_coast=mask_coast,grid_kmt=grid_kmt)
 
-         ! dissolved organic component also includes an optional background doc
-         cobalt%tot_layer_int_doc(:,:,:) = (cobalt%c_2_n * (cobalt%p_ldon(:,:,:,tau) + cobalt%p_sldon(:,:,:,tau) + &
-             cobalt%p_srdon(:,:,:,tau)) + cobalt%doc_background) * rho_dzt(:,:,:)
+          ! Get prognostics tracer fields via their pointers 
+          call g_tracer_get_pointer(tracer_list,'alk'    ,'field',cobalt%p_alk    )
+          call g_tracer_get_pointer(tracer_list,'cadet_arag','field',cobalt%p_cadet_arag)
+          call g_tracer_get_pointer(tracer_list,'cadet_calc','field',cobalt%p_cadet_calc)
+          call g_tracer_get_pointer(tracer_list,'dic'    ,'field',cobalt%p_dic    )
+          call g_tracer_get_pointer(tracer_list,'fed'    ,'field',cobalt%p_fed    )
+          call g_tracer_get_pointer(tracer_list,'fedi'   ,'field',cobalt%p_fedi   )
+          call g_tracer_get_pointer(tracer_list,'felg'   ,'field',cobalt%p_felg   )
+          call g_tracer_get_pointer(tracer_list,'femd'   ,'field',cobalt%p_femd   )
+          call g_tracer_get_pointer(tracer_list,'fesm'   ,'field',cobalt%p_fesm   )
+          call g_tracer_get_pointer(tracer_list,'fedet'  ,'field',cobalt%p_fedet  )
+          call g_tracer_get_pointer(tracer_list,'ldon'   ,'field',cobalt%p_ldon   )
+          call g_tracer_get_pointer(tracer_list,'ldop'   ,'field',cobalt%p_ldop   )
+          call g_tracer_get_pointer(tracer_list,'nbact'  ,'field',cobalt%p_nbact  )
+          call g_tracer_get_pointer(tracer_list,'ndet'   ,'field',cobalt%p_ndet   )
+          call g_tracer_get_pointer(tracer_list,'ndi'    ,'field',cobalt%p_ndi    )
+          call g_tracer_get_pointer(tracer_list,'nlg'    ,'field',cobalt%p_nlg    )
+          call g_tracer_get_pointer(tracer_list,'nmd'    ,'field',cobalt%p_nmd    )
+          call g_tracer_get_pointer(tracer_list,'nsm'    ,'field',cobalt%p_nsm    ) 
+          call g_tracer_get_pointer(tracer_list,'nh4'    ,'field',cobalt%p_nh4    )
+          call g_tracer_get_pointer(tracer_list,'no3'    ,'field',cobalt%p_no3    )
+          call g_tracer_get_pointer(tracer_list,'o2'     ,'field',cobalt%p_o2     )
+          call g_tracer_get_pointer(tracer_list,'pdi'    ,'field',cobalt%p_pdi    )
+          call g_tracer_get_pointer(tracer_list,'plg'    ,'field',cobalt%p_plg    )
+          call g_tracer_get_pointer(tracer_list,'pmd'    ,'field',cobalt%p_pmd    )
+          call g_tracer_get_pointer(tracer_list,'psm'    ,'field',cobalt%p_psm    )
+          call g_tracer_get_pointer(tracer_list,'pdet'   ,'field',cobalt%p_pdet   )
+          call g_tracer_get_pointer(tracer_list,'po4'    ,'field',cobalt%p_po4    )
+          call g_tracer_get_pointer(tracer_list,'srdon'  ,'field',cobalt%p_srdon )
+          call g_tracer_get_pointer(tracer_list,'srdop'  ,'field',cobalt%p_srdop )
+          call g_tracer_get_pointer(tracer_list,'sldon'  ,'field',cobalt%p_sldon )
+          call g_tracer_get_pointer(tracer_list,'sldop'  ,'field',cobalt%p_sldop )
+          call g_tracer_get_pointer(tracer_list,'sidet'  ,'field',cobalt%p_sidet  )
+          call g_tracer_get_pointer(tracer_list,'silg'   ,'field',cobalt%p_silg   )
+          call g_tracer_get_pointer(tracer_list,'simd'   ,'field',cobalt%p_simd   )
+          call g_tracer_get_pointer(tracer_list,'sio4'   ,'field',cobalt%p_sio4   )
+          call g_tracer_get_pointer(tracer_list,'nsmz'   ,'field',cobalt%p_nsmz   )
+          call g_tracer_get_pointer(tracer_list,'nmdz'   ,'field',cobalt%p_nmdz   )
+          call g_tracer_get_pointer(tracer_list,'nlgz'   ,'field',cobalt%p_nlgz   )
+          call g_tracer_get_pointer(tracer_list,'lith'   ,'field',cobalt%p_lith   )
+          call g_tracer_get_pointer(tracer_list,'lithdet','field',cobalt%p_lithdet)
 
-         cobalt%tot_layer_int_poc(:,:,:) = (cobalt%p_ndi(:,:,:,tau) + cobalt%p_nlg(:,:,:,tau) + cobalt%p_nmd(:,:,:,tau) + &
-             cobalt%p_nsm(:,:,:,tau) + cobalt%p_nbact(:,:,:,tau) + cobalt%p_ndet(:,:,:,tau) + cobalt%p_nsmz(:,:,:,tau) + &
-             cobalt%p_nmdz(:,:,:,tau) + cobalt%p_nlgz(:,:,:,tau))*cobalt%c_2_n*rho_dzt(:,:,:)
+          ! Flag to recalculate the carbon-system parameters at the end of the time step to align with the prognostic
+          ! tracer values at the end of the time step.  If this is set to .False., variables are saved in
+          ! update_from_source and apply to conditions prior to mixing and sinking.
+          ! To do: Move nh3 exchange calculations here as well?
+          if (cobalt%recalculate_carbon == .True.) then
+            k=1
+            do j = jsc, jec ; do i = isc, iec  !{
+              cobalt%htotallo(i,j) = cobalt%htotal_scale_lo * cobalt%f_htotal(i,j,k)
+              cobalt%htotalhi(i,j) = cobalt%htotal_scale_hi * cobalt%f_htotal(i,j,k)
+            enddo; enddo ; !} i, j
 
-         cobalt%tot_layer_int_dic(:,:,:) = cobalt%p_dic(:,:,:,tau)*rho_dzt(:,:,:)
+            ! Use pointers
+            call FMS_co2calc(CO2_dope_vec,grid_tmask(:,:,k),&
+              Temp(:,:,k), Salt(:,:,k), &
+              cobalt%p_dic(:,:,k,tau), &
+              cobalt%p_po4(:,:,k,tau), &
+              cobalt%p_sio4(:,:,k,tau), &
+              cobalt%p_alk(:,:,k,tau), &
+              cobalt%htotallo, cobalt%htotalhi,&
+                                !InOut
+              cobalt%f_htotal(:,:,k), &
+                                !Optional In
+              zt=cobalt%zt(:,:,k), &
+                                !OUT
+              co2star=cobalt%co2_csurf(:,:), alpha=cobalt%co2_alpha(:,:), &
+              pCO2surf=cobalt%pco2_csurf(:,:), &
+              co3_ion=cobalt%f_co3_ion(:,:,k), &
+              omega_arag=cobalt%omega_arag(:,:,k), &
+              omega_calc=cobalt%omega_calc(:,:,k))
 
-         cobalt%tot_layer_int_fe(:,:,:) = (cobalt%p_fed(:,:,:,tau) + cobalt%p_fedi(:,:,:,tau) + cobalt%p_felg(:,:,:,tau) + &
-             cobalt%p_femd(:,:,:,tau) + cobalt%p_fesm(:,:,:,tau) + cobalt%p_fedet(:,:,:,tau)) * rho_dzt(:,:,:)
+            do k = 2, nk
+              do j = jsc, jec ; do i = isc, iec  !{
+                cobalt%htotallo(i,j) = cobalt%htotal_scale_lo * cobalt%f_htotal(i,j,k)
+                cobalt%htotalhi(i,j) = cobalt%htotal_scale_hi * cobalt%f_htotal(i,j,k)
+              enddo; enddo ; !} i, j
 
-         cobalt%tot_layer_int_n(:,:,:) = (cobalt%p_no3(:,:,:,tau) + cobalt%p_nh4(:,:,:,tau) + cobalt%p_ndi(:,:,:,tau) + &
-             cobalt%p_nlg(:,:,:,tau) + cobalt%p_nmd(:,:,:,tau) + cobalt%p_nsm(:,:,:,tau) + cobalt%p_nbact(:,:,:,tau) + &
-             cobalt%p_ldon(:,:,:,tau) + cobalt%p_sldon(:,:,:,tau) + cobalt%p_srdon(:,:,:,tau) +  cobalt%p_ndet(:,:,:,tau) + &
-             cobalt%p_nsmz(:,:,:,tau) + cobalt%p_nmdz(:,:,:,tau) + cobalt%p_nlgz(:,:,:,tau)) * rho_dzt(:,:,:)
+              call FMS_co2calc(CO2_dope_vec,grid_tmask(:,:,k),&
+                Temp(:,:,k), Salt(:,:,k), &
+                cobalt%p_dic(:,:,k,tau), &
+                cobalt%p_po4(:,:,k,tau), &
+                cobalt%p_sio4(:,:,k,tau), &
+                cobalt%p_alk(:,:,k,tau), &
+                cobalt%htotallo, cobalt%htotalhi,&
+                                !InOut
+                cobalt%f_htotal(:,:,k), &
+                                !Optional In
+                zt=cobalt%zt(:,:,k), &
+                                !OUT
+                co3_ion=cobalt%f_co3_ion(:,:,k), &
+                omega_arag=cobalt%omega_arag(:,:,k), &
+                omega_calc=cobalt%omega_calc(:,:,k))
+            enddo
+            call g_tracer_set_values(tracer_list,'htotal','field',cobalt%f_htotal,isd,jsd)
+            call g_tracer_set_values(tracer_list,'co3_ion','field',cobalt%f_co3_ion,isd,jsd)
+            call g_tracer_set_values(tracer_list,'dic','alpha',cobalt%co2_alpha,isd,jsd)
+            call g_tracer_set_values(tracer_list,'dic','csurf',cobalt%co2_csurf,isd,jsd)
 
-         cobalt%tot_layer_int_p(:,:,:) = (cobalt%p_po4(:,:,:,tau) + cobalt%p_pdi(:,:,:,tau) + cobalt%p_plg(:,:,:,tau) + &
-             cobalt%p_pmd(:,:,:,tau) + cobalt%p_psm(:,:,:,tau) + cobalt%p_ldop(:,:,:,tau) + cobalt%p_sldop(:,:,:,tau) + &
-             cobalt%p_srdop(:,:,:,tau) + cobalt%p_pdet(:,:,:,tau) + bact(1)%q_p_2_n*cobalt%p_nbact(:,:,:,tau) + &
-             zoo(1)%q_p_2_n*cobalt%p_nsmz(:,:,:,tau) + zoo(2)%q_p_2_n*cobalt%p_nmdz(:,:,:,tau) + &
-             zoo(3)%q_p_2_n*cobalt%p_nlgz(:,:,:,tau))*rho_dzt(:,:,:)
+            do k = 1, nk ; do j = jsc, jec ; do i = isc, iec   !{
+              cobalt%co3_sol_arag(i,j,k) = cobalt%f_co3_ion(i,j,k) / max(cobalt%omega_arag(i,j,k),epsln)
+              cobalt%co3_sol_calc(i,j,k) = cobalt%f_co3_ion(i,j,k) / max(cobalt%omega_calc(i,j,k),epsln)
+              ! Update diatom and misc phytoplankton groups for diagnostics
+              cobalt%nlg_diatoms(i,j,k)=phyto(LARGE)%f_n(i,j,k)*phyto(LARGE)%silim(i,j,k)
+              cobalt%nmd_diatoms(i,j,k)=phyto(MEDIUM)%f_n(i,j,k)*phyto(MEDIUM)%silim(i,j,k)
+              cobalt%nlg_misc(i,j,k)=phyto(LARGE)%f_n(i,j,k) - phyto(LARGE)%f_n(i,j,k)*phyto(LARGE)%silim(i,j,k)
+              cobalt%nmd_misc(i,j,k)=phyto(MEDIUM)%f_n(i,j,k) - phyto(MEDIUM)%f_n(i,j,k)*phyto(MEDIUM)%silim(i,j,k)
+            enddo; enddo ; enddo !} i,j,k
 
-         cobalt%tot_layer_int_si(:,:,:) = (cobalt%p_sio4(:,:,:,tau) + cobalt%p_silg(:,:,:,tau) + &
-             cobalt%p_simd(:,:,:,tau) + cobalt%p_sidet(:,:,:,tau)) * rho_dzt(:,:,:)
+          endif !} recalculate carbon system properties
 
-         cobalt%tot_layer_int_o2(:,:,:) = cobalt%p_o2(:,:,:,tau)*rho_dzt(:,:,:)
+          used = g_send_data(cobalt%id_co3_sol_arag, cobalt%co3_sol_arag, &
+              model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_co3_sol_calc, cobalt%co3_sol_calc, &
+            model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_omega_arag, cobalt%omega_arag, &
+            model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_omega_calc, cobalt%omega_calc, &
+            model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! Derived tracers
+          used = g_send_data(cobalt%id_nphyto_tot, (cobalt%p_ndi(:,:,:,tau) +  &
+            cobalt%p_nlg(:,:,:,tau) + cobalt%p_nmd(:,:,:,tau) + cobalt%p_nsm(:,:,:,tau)), &
+            model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_nlg_diatoms,cobalt%nlg_diatoms,&
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_nmd_diatoms,cobalt%nmd_diatoms,&
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! These diagnostics have not generally been used or tested and can generally be derived from 3D diagnostics
+          ! Check in CMIP7 requests.  If so, confirm functionality
+          used = g_send_data(cobalt%id_o2min, cobalt%o2min, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_z_o2min, cobalt%z_o2min, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_z_sat_arag, cobalt%z_sat_arag, &
+            model_time, mask = cobalt%mask_z_sat_arag, rmask = grid_tmask(:,:,1), &
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_z_sat_calc, cobalt%z_sat_calc, &
+            model_time, mask = cobalt%mask_z_sat_calc, rmask = grid_tmask(:,:,1), &
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
 
-         cobalt%tot_layer_int_alk(:,:,:) = cobalt%p_alk(:,:,:,tau)*rho_dzt(:,:,:)
+          ! Surface tracers (could remove if instead extracted from 3D files in the diagnostic table?)
+          used = g_send_data(phyto(DIAZO)%id_sfc_f_n, cobalt%p_ndi(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(phyto(LARGE)%id_sfc_f_n, cobalt%p_nlg(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(phyto(MEDIUM)%id_sfc_f_n, cobalt%p_nmd(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(phyto(SMALL)%id_sfc_f_n, cobalt%p_nsm(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_alk, cobalt%p_alk(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_cadet_arag,cobalt%p_cadet_arag(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_cadet_calc,cobalt%p_cadet_calc(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_dic, cobalt%p_dic(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_fed, cobalt%p_fed(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_ldon, cobalt%p_ldon(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_sldon, cobalt%p_sldon(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_srdon, cobalt%p_srdon(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_no3, cobalt%p_no3(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_nh4, cobalt%p_nh4(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_po4, cobalt%p_po4(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_o2, cobalt%p_o2(:,:,1,tau), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_temp, Temp(:,:,1), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(phyto(DIAZO)%id_sfc_chl, cobalt%p_ndi(:,:,1,tau)*c2n*phyto(DIAZO)%theta(:,:,1), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(phyto(LARGE)%id_sfc_chl, cobalt%p_nlg(:,:,1,tau)*c2n*phyto(LARGE)%theta(:,:,1), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(phyto(MEDIUM)%id_sfc_chl, cobalt%p_nmd(:,:,1,tau)*c2n*phyto(MEDIUM)%theta(:,:,1), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(phyto(SMALL)%id_sfc_chl, cobalt%p_nsm(:,:,1,tau)*c2n*phyto(SMALL)%theta(:,:,1), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_chl, (cobalt%p_ndi(:,:,1,tau)*c2n*phyto(DIAZO)%theta(:,:,1) + &
+            cobalt%p_nlg(:,:,1,tau)*c2n*phyto(LARGE)%theta(:,:,1) + &
+            cobalt%p_nmd(:,:,1,tau)*c2n*phyto(MEDIUM)%theta(:,:,1) + &
+            cobalt%p_nsm(:,:,1,tau)*c2n*phyto(SMALL)%theta(:,:,1)), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_pco2surf, cobalt%pco2_csurf, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_pnh3surf, cobalt%pnh3_csurf, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_co2_csurf, cobalt%co2_csurf, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_pco2_csurf, cobalt%pco2_csurf, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_co2_alpha, cobalt%co2_alpha, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_nh3_csurf, cobalt%nh3_csurf, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_nh3_alpha, cobalt%nh3_alpha,              &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_htotal, cobalt%f_htotal(:,:,1), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_co3_ion, cobalt%f_co3_ion(:,:,1), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_co3_sol_arag, cobalt%co3_sol_arag(:,:,1),  &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_co3_sol_calc, cobalt%co3_sol_calc(:,:,1),  &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
 
-         do j = jsc, jec ; do i = isc, iec !{
-           cobalt%wc_vert_int_c(i,j) = 0.0
-           cobalt%wc_vert_int_dic(i,j) = 0.0
-           cobalt%wc_vert_int_doc(i,j) = 0.0
-           cobalt%wc_vert_int_poc(i,j) = 0.0
-           cobalt%wc_vert_int_n(i,j) = 0.0
-           cobalt%wc_vert_int_p(i,j) = 0.0
-           cobalt%wc_vert_int_fe(i,j) = 0.0
-           cobalt%wc_vert_int_si(i,j) = 0.0
-           cobalt%wc_vert_int_o2(i,j) = 0.0
-           cobalt%wc_vert_int_alk(i,j) = 0.0
-         enddo; enddo !} i,j
+          ! Calculate bottom layer values over a thickness defined by cobalt%bottom_thickness 
+          ! rather than the bottom-most layer as in MOM4/5.  This avoids numerical issues
+          ! generated in "vanishing" layers that overlie the benthos in most regions.
+          allocate(rho_dzt_bot(isc:iec,jsc:jec))
+          allocate(k_bot(isc:iec,jsc:jec))
+          do j = jsc, jec ; do i = isc, iec  !{
+            rho_dzt_bot(i,j) = 0.0
+            cobalt%btm_temp(i,j) = 0.0
+            cobalt%btm_o2(i,j) = 0.0
+            cobalt%btm_dic(i,j) = 0.0
+            cobalt%btm_alk(i,j) = 0.0
+            cobalt%btm_htotal(i,j) = 0.0
+            cobalt%btm_co3_sol_arag(i,j) = 0.0
+            cobalt%btm_co3_sol_calc(i,j) = 0.0
+            cobalt%btm_co3_ion(i,j) = 0.0
+            cobalt%btm_omega_calc(i,j) = 0.0
+            cobalt%btm_omega_arag(i,j) = 0.0
+            k_bot(i,j) = 0
+            k = grid_kmt(i,j)
+            if (k .gt. 0) then !{
+              cobalt%grid_kmt_diag(i,j) = float(k)
+              cobalt%rho_dzt_kmt_diag(i,j) = rho_dzt(i,j,k)
+              do k = grid_kmt(i,j),1,-1   !{
+                if (rho_dzt_bot(i,j).lt.cobalt%Rho_0*cobalt%bottom_thickness) then
+                  k_bot(i,j) = k
+                  rho_dzt_bot(i,j) = rho_dzt_bot(i,j) + rho_dzt(i,j,k)
+                  cobalt%k_bot_diag(i,j) = grid_kmt(i,j)-float(k)+1.0
+                  cobalt%btm_o2(i,j) = cobalt%btm_o2(i,j) + cobalt%p_o2(i,j,k,tau)*rho_dzt(i,j,k)
+                  cobalt%btm_alk(i,j) = cobalt%btm_alk(i,j) + cobalt%p_alk(i,j,k,tau)*rho_dzt(i,j,k)
+                  cobalt%btm_dic(i,j) = cobalt%btm_dic(i,j) + cobalt%p_dic(i,j,k,tau)*rho_dzt(i,j,k) 
+                  cobalt%btm_temp(i,j) = cobalt%btm_temp(i,j) + Temp(i,j,k)*rho_dzt(i,j,k)
+                  cobalt%btm_htotal(i,j) = cobalt%btm_htotal(i,j) + cobalt%f_htotal(i,j,k)*rho_dzt(i,j,k)
+                  cobalt%btm_co3_sol_arag(i,j) = cobalt%btm_co3_sol_arag(i,j) + & 
+                    cobalt%co3_sol_arag(i,j,k)*rho_dzt(i,j,k)
+                  cobalt%btm_co3_sol_calc(i,j) = cobalt%btm_co3_sol_calc(i,j) + &
+                    cobalt%co3_sol_calc(i,j,k)*rho_dzt(i,j,k)
+                  cobalt%btm_co3_ion(i,j) = cobalt%btm_co3_ion(i,j) + cobalt%f_co3_ion(i,j,k)*rho_dzt(i,j,k)
+                endif
+              enddo
+              ! diagnostic to assess how far up into the water column info is being drawn from
+              cobalt%rho_dzt_bot_diag(i,j) = rho_dzt_bot(i,j)
+              ! calculate overshoot and subtract off
+              drho_dzt = rho_dzt_bot(i,j) - cobalt%Rho_0*cobalt%bottom_thickness
+              cobalt%btm_temp(i,j)=cobalt%btm_temp(i,j)-Temp(i,j,k_bot(i,j))*drho_dzt
+              cobalt%btm_o2(i,j)=cobalt%btm_o2(i,j)-cobalt%p_o2(i,j,k_bot(i,j),tau)*drho_dzt
+              cobalt%btm_alk(i,j)=cobalt%btm_alk(i,j)-cobalt%p_alk(i,j,k_bot(i,j),tau)*drho_dzt
+              cobalt%btm_dic(i,j)=cobalt%btm_dic(i,j)-cobalt%p_dic(i,j,k_bot(i,j),tau)*drho_dzt
+              cobalt%btm_htotal(i,j)=cobalt%btm_htotal(i,j)-cobalt%f_htotal(i,j,k_bot(i,j))*drho_dzt
+              cobalt%btm_co3_sol_arag(i,j)=cobalt%btm_co3_sol_arag(i,j)-cobalt%co3_sol_arag(i,j,k_bot(i,j))*drho_dzt
+              cobalt%btm_co3_sol_calc(i,j)=cobalt%btm_co3_sol_calc(i,j)-cobalt%co3_sol_calc(i,j,k_bot(i,j))*drho_dzt
+              cobalt%btm_co3_ion(i,j)=cobalt%btm_co3_ion(i,j)-cobalt%f_co3_ion(i,j,k_bot(i,j))*drho_dzt
+              ! convert back to moles kg-1
+              cobalt%btm_temp(i,j)=cobalt%btm_temp(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
+              cobalt%btm_o2(i,j)=cobalt%btm_o2(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
+              cobalt%btm_alk(i,j)=cobalt%btm_alk(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
+              cobalt%btm_dic(i,j)=cobalt%btm_dic(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
+              cobalt%btm_htotal(i,j)=cobalt%btm_htotal(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
+              cobalt%btm_co3_sol_arag(i,j)=cobalt%btm_co3_sol_arag(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
+              cobalt%btm_co3_sol_calc(i,j)=cobalt%btm_co3_sol_calc(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
+              cobalt%btm_co3_ion(i,j)=cobalt%btm_co3_ion(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
+              ! calculate bottom saturation states
+              cobalt%btm_omega_calc(i,j) = cobalt%btm_co3_ion(i,j)/cobalt%btm_co3_sol_calc(i,j)
+              cobalt%btm_omega_arag(i,j) = cobalt%btm_co3_ion(i,j)/cobalt%btm_co3_sol_arag(i,j)
+            endif
+          enddo; enddo
+          deallocate(rho_dzt_bot)
+          deallocate(k_bot)
 
-         do j = jsc, jec ; do i = isc, iec ; do k = 1, nk  !{
-           ! Tracers ("tot_layer_int" variables already multiplied by "rho_dzt", so just sum over k to get moles m-2)
-           cobalt%wc_vert_int_c(i,j) = cobalt%wc_vert_int_c(i,j) + &
-               cobalt%tot_layer_int_c(i,j,k)*grid_tmask(i,j,k)
-           cobalt%wc_vert_int_dic(i,j) = cobalt%wc_vert_int_dic(i,j) + &
-               cobalt%tot_layer_int_dic(i,j,k)*grid_tmask(i,j,k)
-           cobalt%wc_vert_int_doc(i,j) = cobalt%wc_vert_int_doc(i,j) + &
-               cobalt%tot_layer_int_doc(i,j,k)*grid_tmask(i,j,k)
-           cobalt%wc_vert_int_poc(i,j) = cobalt%wc_vert_int_poc(i,j) + &
-               cobalt%tot_layer_int_poc(i,j,k)*grid_tmask(i,j,k)
-           cobalt%wc_vert_int_n(i,j) = cobalt%wc_vert_int_n(i,j) + &
-               cobalt%tot_layer_int_n(i,j,k)*grid_tmask(i,j,k)
-           cobalt%wc_vert_int_p(i,j) = cobalt%wc_vert_int_p(i,j) + &
-               cobalt%tot_layer_int_p(i,j,k)*grid_tmask(i,j,k)
-           cobalt%wc_vert_int_fe(i,j) = cobalt%wc_vert_int_fe(i,j) + & 
-               cobalt%tot_layer_int_fe(i,j,k)*grid_tmask(i,j,k)
-           cobalt%wc_vert_int_si(i,j) = cobalt%wc_vert_int_si(i,j) + &
-               cobalt%tot_layer_int_si(i,j,k)*grid_tmask(i,j,k)
-           cobalt%wc_vert_int_o2(i,j) = cobalt%wc_vert_int_o2(i,j) + &
-               cobalt%tot_layer_int_o2(i,j,k)*grid_tmask(i,j,k)
-           cobalt%wc_vert_int_alk(i,j) = cobalt%wc_vert_int_alk(i,j) + & 
-               cobalt%tot_layer_int_alk(i,j,k)*grid_tmask(i,j,k)
-         enddo; enddo; enddo  !} i,j,k  
+          ! CALCULATE BOTTOM PROGNOSTIC TRACERS
+          used = g_send_data(cobalt%id_btm_temp, cobalt%btm_temp, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_btm_o2, cobalt%btm_o2, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_btm_no3, cobalt%btm_no3, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_btm_alk, cobalt%btm_alk, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_btm_dic, cobalt%btm_dic, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          ! Diagnostics associated with the bottom calculation
+          used = g_send_data(cobalt%id_grid_kmt_diag, cobalt%grid_kmt_diag, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_k_bot_diag, cobalt%k_bot_diag, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_rho_dzt_bot_diag, cobalt%rho_dzt_bot_diag, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_rho_dzt_kmt_diag, cobalt%rho_dzt_kmt_diag, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          ! Bottom diagnosic tracers
+          used = g_send_data(cobalt%id_btm_htotal, cobalt%btm_htotal, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_btm_co3_ion, cobalt%btm_co3_ion,            &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_btm_co3_sol_arag, cobalt%btm_co3_sol_arag,  &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_btm_co3_sol_calc, cobalt%btm_co3_sol_calc,  &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_btm_omega_calc, cobalt%btm_omega_calc, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_btm_omega_arag, cobalt%btm_omega_arag,  &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
 
-         ! send layer integral diag
-         used = g_send_data(cobalt%id_tot_layer_int_c, cobalt%tot_layer_int_c,&
-         model_time, rmask = grid_tmask,&
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-         used = g_send_data(cobalt%id_tot_layer_int_fe,cobalt%tot_layer_int_fe,&
-         model_time, rmask = grid_tmask,&
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-         used = g_send_data(cobalt%id_tot_layer_int_n,cobalt%tot_layer_int_n,&
-         model_time, rmask = grid_tmask,&
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-         used = g_send_data(cobalt%id_tot_layer_int_p,cobalt%tot_layer_int_p,&
-         model_time, rmask = grid_tmask,& 
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-         used = g_send_data(cobalt%id_tot_layer_int_si,cobalt%tot_layer_int_si,&
-         model_time, rmask = grid_tmask,&
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-         used = g_send_data(cobalt%id_tot_layer_int_o2,cobalt%tot_layer_int_o2,&
-         model_time, rmask = grid_tmask,&
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-         used = g_send_data(cobalt%id_tot_layer_int_alk,cobalt%tot_layer_int_alk,&
-         model_time, rmask = grid_tmask,&
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! Sinking fluxes (todo: option to move to interfaces)
+          used = g_send_data(cobalt%id_fcadet_arag, cobalt%p_cadet_arag(:,:,:,tau) * cobalt%Rho_0 * &
+            cobalt%wsink * grid_tmask(:,:,:), model_time, rmask = grid_tmask, &
+            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_fcadet_calc, cobalt%p_cadet_calc(:,:,:,tau) * cobalt%Rho_0 * &
+            cobalt%wsink*grid_tmask(:,:,:), model_time, rmask = grid_tmask, &
+            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_ffedet, cobalt%p_fedet(:,:,:,tau) * cobalt%Rho_0 * &
+            cobalt%wsink * grid_tmask(:,:,:), model_time, rmask = grid_tmask, &
+            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_flithdet,      cobalt%p_lithdet(:,:,:,tau) * cobalt%Rho_0 * &
+            cobalt%wsink * grid_tmask(:,:,:), model_time, rmask = grid_tmask, &
+            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_fndet, cobalt%p_ndet(:,:,:,tau) * cobalt%Rho_0 * &
+            cobalt%wsink * grid_tmask(:,:,:), model_time, rmask = grid_tmask, &
+            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_fpdet, cobalt%p_pdet(:,:,:,tau) * cobalt%Rho_0 * &
+            cobalt%wsink * grid_tmask(:,:,:), model_time, rmask = grid_tmask, &
+            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_fsidet, cobalt%p_sidet(:,:,:,tau) * cobalt%Rho_0 * &
+            cobalt%wsink  * grid_tmask(:,:,:), model_time, rmask = grid_tmask, &
+            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_ffetot, (cobalt%p_fedet(:,:,:,tau)*cobalt%wsink + &
+            cobalt%p_fesm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + &
+            cobalt%p_femd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
+            cobalt%p_felg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + &
+            cobalt%p_fedi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:))*cobalt%Rho_0*grid_tmask(:,:,:), &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_fntot, (cobalt%p_ndet(:,:,:,tau)*cobalt%wsink + &
+            cobalt%p_nsm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + &
+            cobalt%p_nmd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
+            cobalt%p_nlg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + &
+            cobalt%p_ndi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:))*cobalt%Rho_0*grid_tmask(:,:,:), &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_fptot, (cobalt%p_pdet(:,:,:,tau)*cobalt%wsink + &
+            cobalt%p_psm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + &
+            cobalt%p_pmd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
+            cobalt%p_plg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + &
+            cobalt%p_pdi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:))*cobalt%Rho_0*grid_tmask(:,:,:), &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_fsitot, (cobalt%p_sidet(:,:,:,tau)*cobalt%wsink + &
+            cobalt%p_simd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
+            cobalt%p_silg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:))*cobalt%Rho_0*grid_tmask(:,:,:), &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_nphyto_tot, (cobalt%p_ndi(:,:,:,tau) +  &
+            cobalt%p_nlg(:,:,:,tau) + cobalt%p_nmd(:,:,:,tau) + cobalt%p_nsm(:,:,:,tau)), &
+            model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
 
-         ! send water column integral diag
-         used = g_send_data(cobalt%id_wc_vert_int_c,    cobalt%wc_vert_int_c,         &
-         model_time, rmask = grid_tmask(:,:,1),&
-         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-         used = g_send_data(cobalt%id_wc_vert_int_dic,    cobalt%wc_vert_int_dic,         &
-         model_time, rmask = grid_tmask(:,:,1),&
-         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-         used = g_send_data(cobalt%id_wc_vert_int_doc,    cobalt%wc_vert_int_doc,         &
-         model_time, rmask = grid_tmask(:,:,1),&
-         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-         used = g_send_data(cobalt%id_wc_vert_int_poc,    cobalt%wc_vert_int_poc,         &
-         model_time, rmask = grid_tmask(:,:,1),&
-         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-         used = g_send_data(cobalt%id_wc_vert_int_n,    cobalt%wc_vert_int_n,         &
-         model_time, rmask = grid_tmask(:,:,1),&
-         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-         used = g_send_data(cobalt%id_wc_vert_int_p,    cobalt%wc_vert_int_p,         &
-         model_time, rmask = grid_tmask(:,:,1),&
-         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-         used = g_send_data(cobalt%id_wc_vert_int_fe,    cobalt%wc_vert_int_fe,         &
-         model_time, rmask = grid_tmask(:,:,1),&
-         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-         used = g_send_data(cobalt%id_wc_vert_int_si,    cobalt%wc_vert_int_si,         &
-         model_time, rmask = grid_tmask(:,:,1),&
-         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-         used = g_send_data(cobalt%id_wc_vert_int_o2,    cobalt%wc_vert_int_o2,         &
-         model_time, rmask = grid_tmask(:,:,1),&
-         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-         used = g_send_data(cobalt%id_wc_vert_int_alk,    cobalt%wc_vert_int_alk,         &
-         model_time, rmask = grid_tmask(:,:,1),&
-         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+
+          ! The carbon layer integral (organic + inorganic).  Note that this can be calculated with or without a constant
+          ! background level of recalcitrant dissolved organic carbon by setting cobalt%doc_background.  This is included
+          ! at a level of 40 micromoles kg-1 by default.
+          cobalt%tot_layer_int_c(:,:,:) = (cobalt%p_dic(:,:,:,tau) + cobalt%doc_background + cobalt%p_cadet_arag(:,:,:,tau) +&
+            cobalt%p_cadet_calc(:,:,:,tau) + cobalt%c_2_n * (cobalt%p_ndi(:,:,:,tau) + cobalt%p_nlg(:,:,:,tau) + &
+            cobalt%p_nmd(:,:,:,tau) + cobalt%p_nsm(:,:,:,tau) + cobalt%p_nbact(:,:,:,tau) + cobalt%p_ldon(:,:,:,tau) + &
+            cobalt%p_sldon(:,:,:,tau) + cobalt%p_srdon(:,:,:,tau) + cobalt%p_ndet(:,:,:,tau) + cobalt%p_nsmz(:,:,:,tau) + &
+            cobalt%p_nmdz(:,:,:,tau) + cobalt%p_nlgz(:,:,:,tau))) * rho_dzt(:,:,:)
+
+          ! dissolved organic component also includes an optional background doc
+          cobalt%tot_layer_int_doc(:,:,:) = (cobalt%c_2_n * (cobalt%p_ldon(:,:,:,tau) + cobalt%p_sldon(:,:,:,tau) + &
+            cobalt%p_srdon(:,:,:,tau)) + cobalt%doc_background) * rho_dzt(:,:,:)
+
+          cobalt%tot_layer_int_poc(:,:,:) = (cobalt%p_ndi(:,:,:,tau) + cobalt%p_nlg(:,:,:,tau) + cobalt%p_nmd(:,:,:,tau) + &
+            cobalt%p_nsm(:,:,:,tau) + cobalt%p_nbact(:,:,:,tau) + cobalt%p_ndet(:,:,:,tau) + cobalt%p_nsmz(:,:,:,tau) + &
+            cobalt%p_nmdz(:,:,:,tau) + cobalt%p_nlgz(:,:,:,tau))*cobalt%c_2_n*rho_dzt(:,:,:)
+
+          cobalt%tot_layer_int_dic(:,:,:) = cobalt%p_dic(:,:,:,tau)*rho_dzt(:,:,:)
+
+          cobalt%tot_layer_int_fe(:,:,:) = (cobalt%p_fed(:,:,:,tau) + cobalt%p_fedi(:,:,:,tau) + cobalt%p_felg(:,:,:,tau) + &
+            cobalt%p_femd(:,:,:,tau) + cobalt%p_fesm(:,:,:,tau) + cobalt%p_fedet(:,:,:,tau)) * rho_dzt(:,:,:)
+
+          cobalt%tot_layer_int_n(:,:,:) = (cobalt%p_no3(:,:,:,tau) + cobalt%p_nh4(:,:,:,tau) + cobalt%p_ndi(:,:,:,tau) + &
+            cobalt%p_nlg(:,:,:,tau) + cobalt%p_nmd(:,:,:,tau) + cobalt%p_nsm(:,:,:,tau) + cobalt%p_nbact(:,:,:,tau) + &
+            cobalt%p_ldon(:,:,:,tau) + cobalt%p_sldon(:,:,:,tau) + cobalt%p_srdon(:,:,:,tau) +  cobalt%p_ndet(:,:,:,tau) + &
+            cobalt%p_nsmz(:,:,:,tau) + cobalt%p_nmdz(:,:,:,tau) + cobalt%p_nlgz(:,:,:,tau)) * rho_dzt(:,:,:)
+
+          cobalt%tot_layer_int_p(:,:,:) = (cobalt%p_po4(:,:,:,tau) + cobalt%p_pdi(:,:,:,tau) + cobalt%p_plg(:,:,:,tau) + &
+            cobalt%p_pmd(:,:,:,tau) + cobalt%p_psm(:,:,:,tau) + cobalt%p_ldop(:,:,:,tau) + cobalt%p_sldop(:,:,:,tau) + &
+            cobalt%p_srdop(:,:,:,tau) + cobalt%p_pdet(:,:,:,tau) + bact(1)%q_p_2_n*cobalt%p_nbact(:,:,:,tau) + &
+            zoo(1)%q_p_2_n*cobalt%p_nsmz(:,:,:,tau) + zoo(2)%q_p_2_n*cobalt%p_nmdz(:,:,:,tau) + &
+            zoo(3)%q_p_2_n*cobalt%p_nlgz(:,:,:,tau))*rho_dzt(:,:,:)
+
+          cobalt%tot_layer_int_si(:,:,:) = (cobalt%p_sio4(:,:,:,tau) + cobalt%p_silg(:,:,:,tau) + &
+            cobalt%p_simd(:,:,:,tau) + cobalt%p_sidet(:,:,:,tau)) * rho_dzt(:,:,:)
+
+          cobalt%tot_layer_int_o2(:,:,:) = cobalt%p_o2(:,:,:,tau)*rho_dzt(:,:,:)
+
+          cobalt%tot_layer_int_alk(:,:,:) = cobalt%p_alk(:,:,:,tau)*rho_dzt(:,:,:)
+
+          do j = jsc, jec ; do i = isc, iec !{
+            cobalt%wc_vert_int_c(i,j) = 0.0
+            cobalt%wc_vert_int_dic(i,j) = 0.0
+            cobalt%wc_vert_int_doc(i,j) = 0.0
+            cobalt%wc_vert_int_poc(i,j) = 0.0
+            cobalt%wc_vert_int_n(i,j) = 0.0
+            cobalt%wc_vert_int_p(i,j) = 0.0
+            cobalt%wc_vert_int_fe(i,j) = 0.0
+            cobalt%wc_vert_int_si(i,j) = 0.0
+            cobalt%wc_vert_int_o2(i,j) = 0.0
+            cobalt%wc_vert_int_alk(i,j) = 0.0
+          enddo; enddo !} i,j
+
+          do j = jsc, jec ; do i = isc, iec ; do k = 1, nk  !{
+            ! Tracers ("tot_layer_int" variables already multiplied by "rho_dzt", so just sum over k to get moles m-2)
+            cobalt%wc_vert_int_c(i,j) = cobalt%wc_vert_int_c(i,j) + &
+              cobalt%tot_layer_int_c(i,j,k)*grid_tmask(i,j,k)
+            cobalt%wc_vert_int_dic(i,j) = cobalt%wc_vert_int_dic(i,j) + &
+              cobalt%tot_layer_int_dic(i,j,k)*grid_tmask(i,j,k)
+            cobalt%wc_vert_int_doc(i,j) = cobalt%wc_vert_int_doc(i,j) + &
+              cobalt%tot_layer_int_doc(i,j,k)*grid_tmask(i,j,k)
+            cobalt%wc_vert_int_poc(i,j) = cobalt%wc_vert_int_poc(i,j) + &
+              cobalt%tot_layer_int_poc(i,j,k)*grid_tmask(i,j,k)
+            cobalt%wc_vert_int_n(i,j) = cobalt%wc_vert_int_n(i,j) + &
+              cobalt%tot_layer_int_n(i,j,k)*grid_tmask(i,j,k)
+            cobalt%wc_vert_int_p(i,j) = cobalt%wc_vert_int_p(i,j) + &
+              cobalt%tot_layer_int_p(i,j,k)*grid_tmask(i,j,k)
+            cobalt%wc_vert_int_fe(i,j) = cobalt%wc_vert_int_fe(i,j) + & 
+              cobalt%tot_layer_int_fe(i,j,k)*grid_tmask(i,j,k)
+            cobalt%wc_vert_int_si(i,j) = cobalt%wc_vert_int_si(i,j) + &
+              cobalt%tot_layer_int_si(i,j,k)*grid_tmask(i,j,k)
+            cobalt%wc_vert_int_o2(i,j) = cobalt%wc_vert_int_o2(i,j) + &
+              cobalt%tot_layer_int_o2(i,j,k)*grid_tmask(i,j,k)
+            cobalt%wc_vert_int_alk(i,j) = cobalt%wc_vert_int_alk(i,j) + & 
+              cobalt%tot_layer_int_alk(i,j,k)*grid_tmask(i,j,k)
+          enddo; enddo; enddo  !} i,j,k
+
+          ! send layer integral diag
+          used = g_send_data(cobalt%id_tot_layer_int_c, cobalt%tot_layer_int_c,&
+            model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_tot_layer_int_fe,cobalt%tot_layer_int_fe,&
+            model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_tot_layer_int_n,cobalt%tot_layer_int_n,&
+            model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_tot_layer_int_p,cobalt%tot_layer_int_p,&
+            model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_tot_layer_int_si,cobalt%tot_layer_int_si,&
+            model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_tot_layer_int_o2,cobalt%tot_layer_int_o2,&
+            model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_tot_layer_int_alk,cobalt%tot_layer_int_alk,&
+            model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+
+          ! send water column integral diag
+          used = g_send_data(cobalt%id_wc_vert_int_c, cobalt%wc_vert_int_c, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_dic,    cobalt%wc_vert_int_dic, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_doc,    cobalt%wc_vert_int_doc, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_poc,    cobalt%wc_vert_int_poc, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_n, cobalt%wc_vert_int_n, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_p, cobalt%wc_vert_int_p, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_fe, cobalt%wc_vert_int_fe, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_si, cobalt%wc_vert_int_si, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_o2, cobalt%wc_vert_int_o2, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_alk, cobalt%wc_vert_int_alk, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+
+          ! make generic?  _intz with user-specified integration depth
+          allocate(rho_dzt_100(isc:iec,jsc:jec))
+          ! Calculate 100m integrals of prognostic variables and and 100m fluxes
+          do j = jsc, jec ; do i = isc, iec !{
+            rho_dzt_100(i,j) = rho_dzt(i,j,1)
+            ! prognostic variables
+            cobalt%f_alk_int_100(i,j) = cobalt%p_alk(i,j,1,tau) * rho_dzt(i,j,1)
+            cobalt%f_dic_int_100(i,j) = cobalt%p_dic(i,j,1,tau) * rho_dzt(i,j,1)
+            cobalt%f_din_int_100(i,j) = (cobalt%p_no3(i,j,1,tau) + cobalt%p_nh4(i,j,1,tau)) * rho_dzt(i,j,1)
+            cobalt%f_fed_int_100(i,j) = cobalt%p_fed(i,j,1,tau) * rho_dzt(i,j,1)
+            cobalt%f_po4_int_100(i,j) = cobalt%p_po4(i,j,1,tau) * rho_dzt(i,j,1)
+            cobalt%f_sio4_int_100(i,j) = cobalt%p_sio4(i,j,1,tau) * rho_dzt(i,j,1)
+            phyto(DIAZO)%f_n_100(i,j) = cobalt%p_ndi(i,j,1,tau) * rho_dzt(i,j,1)
+            phyto(LARGE)%f_n_100(i,j) = cobalt%p_nlg(i,j,1,tau) * rho_dzt(i,j,1)
+            phyto(MEDIUM)%f_n_100(i,j) = cobalt%p_nmd(i,j,1,tau) * rho_dzt(i,j,1)
+            phyto(SMALL)%f_n_100(i,j) = cobalt%p_nsm(i,j,1,tau) * rho_dzt(i,j,1)
+            zoo(1)%f_n_100(i,j) = cobalt%p_nsmz(i,j,1,tau) * rho_dzt(i,j,1)
+            zoo(2)%f_n_100(i,j) = cobalt%p_nmdz(i,j,1,tau) * rho_dzt(i,j,1)
+            zoo(3)%f_n_100(i,j) = cobalt%p_nlgz(i,j,1,tau) * rho_dzt(i,j,1)
+            bact(1)%f_n_100(i,j) = cobalt%p_nbact(i,j,1,tau) * rho_dzt(i,j,1)
+            cobalt%f_ndet_100(i,j) = cobalt%p_ndet(i,j,1,tau) * rho_dzt(i,j,1)
+            cobalt%f_don_100(i,j) = (cobalt%p_ldon(i,j,1,tau)+cobalt%p_sldon(i,j,1,tau)+cobalt%p_srdon(i,j,1,tau))* &
+              rho_dzt(i,j,1)
+            cobalt%f_silg_100(i,j) = cobalt%p_silg(i,j,1,tau)*rho_dzt(i,j,1)
+            cobalt%f_simd_100(i,j) = cobalt%p_simd(i,j,1,tau)*rho_dzt(i,j,1)
+            ! sinking fluxes (should we just handle these with by remapping the appropriate 3D variable onto 100m?)
+            ! need to add fast sinking detritus
+            cobalt%fndet_100(i,j) = cobalt%p_ndet(i,j,1,tau) * cobalt%Rho_0 * cobalt%wsink
+            cobalt%fpdet_100(i,j) = cobalt%p_pdet(i,j,1,tau) * cobalt%Rho_0 * cobalt%wsink
+            cobalt%ffedet_100(i,j) = cobalt%p_fedet(i,j,1,tau) * cobalt%Rho_0 * cobalt%wsink
+            cobalt%flithdet_100(i,j) = cobalt%p_lithdet(i,j,1,tau) * cobalt%Rho_0 * cobalt%wsink
+            cobalt%fsidet_100(i,j) = cobalt%p_sidet(i,j,1,tau) * cobalt%Rho_0 * cobalt%wsink
+            cobalt%fcadet_arag_100(i,j) = cobalt%p_cadet_arag(i,j,1,tau) * cobalt%Rho_0 * cobalt%wsink
+            cobalt%fcadet_calc_100(i,j) = cobalt%p_cadet_calc(i,j,1,tau) * cobalt%Rho_0 * cobalt%wsink
+            cobalt%fntot_100(i,j) = (cobalt%p_ndet(i,j,1,tau)*cobalt%wsink + &
+              cobalt%p_nsm(i,j,1,tau)*phyto(SMALL)%vmove(i,j,1) + &
+              cobalt%p_nmd(i,j,1,tau)*phyto(MEDIUM)%vmove(i,j,1) + &
+              cobalt%p_nlg(i,j,1,tau)*phyto(LARGE)%vmove(i,j,1) + &
+              cobalt%p_ndi(i,j,1,tau)*phyto(DIAZO)%vmove(i,j,1))*cobalt%Rho_0
+            cobalt%fptot_100(i,j) = (cobalt%p_pdet(i,j,1,tau)*cobalt%wsink + &
+              cobalt%p_psm(i,j,1,tau)*phyto(SMALL)%vmove(i,j,1) + &
+              cobalt%p_pmd(i,j,1,tau)*phyto(MEDIUM)%vmove(i,j,1) + &
+              cobalt%p_plg(i,j,1,tau)*phyto(LARGE)%vmove(i,j,1) + &
+              cobalt%p_pdi(i,j,1,tau)*phyto(DIAZO)%vmove(i,j,1))*cobalt%Rho_0
+            cobalt%ffetot_100(i,j) = (cobalt%p_fedet(i,j,1,tau)*cobalt%wsink + &
+              cobalt%p_fesm(i,j,1,tau)*phyto(SMALL)%vmove(i,j,1) + &
+              cobalt%p_femd(i,j,1,tau)*phyto(MEDIUM)%vmove(i,j,1) + &
+              cobalt%p_felg(i,j,1,tau)*phyto(LARGE)%vmove(i,j,1) + &
+              cobalt%p_fedi(i,j,1,tau)*phyto(DIAZO)%vmove(i,j,1))*cobalt%Rho_0
+            cobalt%fsitot_100(i,j) = (cobalt%p_sidet(i,j,1,tau)*cobalt%wsink + &
+              cobalt%p_simd(i,j,1,tau)*phyto(MEDIUM)%vmove(i,j,1) + &
+              cobalt%p_silg(i,j,1,tau)*phyto(LARGE)%vmove(i,j,1))*cobalt%Rho_0
+          enddo; enddo !} i,j
+
+          do j = jsc, jec ; do i = isc, iec ; !{
+            k_100 = 1
+            do k = 2, grid_kmt(i,j)  !{
+              if (rho_dzt_100(i,j) .lt. cobalt%Rho_0 * 100.0) then
+                k_100 = k
+                rho_dzt_100(i,j) = rho_dzt_100(i,j) + rho_dzt(i,j,k)
+                cobalt%f_alk_int_100(i,j) = cobalt%f_alk_int_100(i,j) + cobalt%p_alk(i,j,k,tau) * rho_dzt(i,j,k)
+                cobalt%f_dic_int_100(i,j) = cobalt%f_dic_int_100(i,j) + cobalt%p_dic(i,j,k,tau) * rho_dzt(i,j,k)
+                cobalt%f_din_int_100(i,j) = cobalt%f_din_int_100(i,j) + (cobalt%p_no3(i,j,k,tau) +        &
+                  cobalt%p_nh4(i,j,k,tau)) * rho_dzt(i,j,k)
+                cobalt%f_fed_int_100(i,j) = cobalt%f_fed_int_100(i,j) + cobalt%p_fed(i,j,k,tau) * rho_dzt(i,j,k)
+                cobalt%f_po4_int_100(i,j) = cobalt%f_po4_int_100(i,j) + cobalt%p_po4(i,j,k,tau) * rho_dzt(i,j,k)
+                cobalt%f_sio4_int_100(i,j) = cobalt%f_sio4_int_100(i,j) + cobalt%p_sio4(i,j,k,tau) *  rho_dzt(i,j,k)
+                phyto(DIAZO)%f_n_100(i,j) = phyto(DIAZO)%f_n_100(i,j) + cobalt%p_ndi(i,j,k,tau) * rho_dzt(i,j,k)
+                phyto(LARGE)%f_n_100(i,j) = phyto(LARGE)%f_n_100(i,j) + cobalt%p_nlg(i,j,k,tau) * rho_dzt(i,j,k)
+                phyto(MEDIUM)%f_n_100(i,j) = phyto(MEDIUM)%f_n_100(i,j) + cobalt%p_nmd(i,j,k,tau) * rho_dzt(i,j,k)
+                phyto(SMALL)%f_n_100(i,j) = phyto(SMALL)%f_n_100(i,j) + cobalt%p_nsm(i,j,k,tau) * rho_dzt(i,j,k)
+                zoo(1)%f_n_100(i,j) = zoo(1)%f_n_100(i,j) + cobalt%p_nsmz(i,j,k,tau) * rho_dzt(i,j,k)
+                zoo(2)%f_n_100(i,j) = zoo(2)%f_n_100(i,j) + cobalt%p_nmdz(i,j,k,tau) * rho_dzt(i,j,k)
+                zoo(3)%f_n_100(i,j) = zoo(3)%f_n_100(i,j) + cobalt%p_nlgz(i,j,k,tau) * rho_dzt(i,j,k)
+                bact(1)%f_n_100(i,j) = bact(1)%f_n_100(i,j) + cobalt%p_nbact(i,j,k,tau) * rho_dzt(i,j,k)
+                cobalt%f_ndet_100(i,j) = cobalt%f_ndet_100(i,j) + cobalt%p_ndet(i,j,k,tau)*rho_dzt(i,j,k)
+                cobalt%f_don_100(i,j) = cobalt%f_don_100(i,j) + (cobalt%p_ldon(i,j,k,tau)+cobalt%p_sldon(i,j,k,tau) + &
+                  cobalt%p_srdon(i,j,k,tau))*rho_dzt(i,j,k)
+                cobalt%f_silg_100(i,j) = cobalt%f_silg_100(i,j) + cobalt%p_silg(i,j,k,tau)*rho_dzt(i,j,k)
+                cobalt%f_simd_100(i,j) = cobalt%f_simd_100(i,j) + cobalt%p_simd(i,j,k,tau)*rho_dzt(i,j,k)  ! Missed
+                ! sinking fluxes (should we just handle these with by remapping the appropriate 3D variable onto 100m?)
+                cobalt%fndet_100(i,j) = cobalt%p_ndet(i,j,k,tau) * cobalt%Rho_0 * cobalt%wsink
+                cobalt%fpdet_100(i,j) = cobalt%p_pdet(i,j,k,tau) * cobalt%Rho_0 * cobalt%wsink
+                cobalt%ffedet_100(i,j) = cobalt%p_fedet(i,j,k,tau) * cobalt%Rho_0 * cobalt%wsink
+                cobalt%flithdet_100(i,j) = cobalt%p_lithdet(i,j,k,tau) * cobalt%Rho_0 * cobalt%wsink
+                cobalt%fsidet_100(i,j) = cobalt%p_sidet(i,j,k,tau) * cobalt%Rho_0 * cobalt%wsink
+                cobalt%fcadet_arag_100(i,j) = cobalt%p_cadet_arag(i,j,k,tau) * cobalt%Rho_0 * cobalt%wsink
+                cobalt%fcadet_calc_100(i,j) = cobalt%p_cadet_calc(i,j,k,tau) * cobalt%Rho_0 * cobalt%wsink
+                cobalt%fntot_100(i,j) = (cobalt%p_ndet(i,j,k,tau)*cobalt%wsink + &
+                  cobalt%p_nsm(i,j,k,tau)*phyto(SMALL)%vmove(i,j,k) + &
+                  cobalt%p_nmd(i,j,k,tau)*phyto(MEDIUM)%vmove(i,j,k) + &
+                  cobalt%p_nlg(i,j,k,tau)*phyto(LARGE)%vmove(i,j,k) + &
+                  cobalt%p_ndi(i,j,k,tau)*phyto(DIAZO)%vmove(i,j,k))*cobalt%Rho_0
+                cobalt%fptot_100(i,j) = (cobalt%p_pdet(i,j,k,tau)*cobalt%wsink + &
+                  cobalt%p_psm(i,j,k,tau)*phyto(SMALL)%vmove(i,j,k) + &
+                  cobalt%p_pmd(i,j,k,tau)*phyto(MEDIUM)%vmove(i,j,k) + &
+                  cobalt%p_plg(i,j,k,tau)*phyto(LARGE)%vmove(i,j,k) + &
+                  cobalt%p_pdi(i,j,k,tau)*phyto(DIAZO)%vmove(i,j,k))*cobalt%Rho_0
+                cobalt%ffetot_100(i,j) = (cobalt%p_fedet(i,j,k,tau)*cobalt%wsink + &
+                  cobalt%p_fesm(i,j,k,tau)*phyto(SMALL)%vmove(i,j,k) + &
+                  cobalt%p_femd(i,j,k,tau)*phyto(MEDIUM)%vmove(i,j,k) + &
+                  cobalt%p_felg(i,j,k,tau)*phyto(LARGE)%vmove(i,j,k) + &
+                  cobalt%p_fedi(i,j,k,tau)*phyto(DIAZO)%vmove(i,j,k))*cobalt%Rho_0
+                cobalt%fsitot_100(i,j) = (cobalt%p_sidet(i,j,k,tau)*cobalt%wsink + &
+                  cobalt%p_simd(i,j,k,tau)*phyto(MEDIUM)%vmove(i,j,k) + &
+                  cobalt%p_silg(i,j,k,tau)*phyto(LARGE)%vmove(i,j,k))*cobalt%Rho_0
+              endif
+            enddo  !} k
+
+            if (k_100 .gt. 1 .and. k_100 .lt. grid_kmt(i,j)) then
+              drho_dzt = cobalt%Rho_0 * 100.0 - rho_dzt_100(i,j)
+              cobalt%f_alk_int_100(i,j) = cobalt%f_alk_int_100(i,j) + cobalt%p_alk(i,j,k_100,tau) * drho_dzt
+              cobalt%f_dic_int_100(i,j) = cobalt%f_dic_int_100(i,j) + cobalt%p_dic(i,j,k_100,tau) * drho_dzt
+              cobalt%f_din_int_100(i,j) = cobalt%f_din_int_100(i,j) + (cobalt%p_no3(i,j,k_100,tau) +       &
+               cobalt%p_nh4(i,j,k_100,tau)) * drho_dzt
+              cobalt%f_fed_int_100(i,j) = cobalt%f_fed_int_100(i,j) + cobalt%p_fed(i,j,k_100,tau) * drho_dzt
+              cobalt%f_po4_int_100(i,j) = cobalt%f_po4_int_100(i,j) + cobalt%p_po4(i,j,k_100,tau) * drho_dzt
+              cobalt%f_sio4_int_100(i,j) = cobalt%f_sio4_int_100(i,j) + cobalt%p_sio4(i,j,k_100,tau) * drho_dzt
+              phyto(DIAZO)%f_n_100(i,j) = phyto(DIAZO)%f_n_100(i,j) + cobalt%p_ndi(i,j,k_100,tau) * drho_dzt
+              phyto(LARGE)%f_n_100(i,j) = phyto(LARGE)%f_n_100(i,j) + cobalt%p_nlg(i,j,k_100,tau) * drho_dzt
+              phyto(MEDIUM)%f_n_100(i,j) = phyto(MEDIUM)%f_n_100(i,j) + cobalt%p_nmd(i,j,k_100,tau) * drho_dzt
+              phyto(SMALL)%f_n_100(i,j) = phyto(SMALL)%f_n_100(i,j) + cobalt%p_nsm(i,j,k_100,tau) * drho_dzt
+              zoo(1)%f_n_100(i,j) = zoo(1)%f_n_100(i,j) + cobalt%p_nsmz(i,j,k_100,tau) * drho_dzt
+              zoo(2)%f_n_100(i,j) = zoo(2)%f_n_100(i,j) + cobalt%p_nmdz(i,j,k_100,tau) * drho_dzt
+              zoo(3)%f_n_100(i,j) = zoo(3)%f_n_100(i,j) + cobalt%p_nlgz(i,j,k_100,tau) * drho_dzt
+              bact(1)%f_n_100(i,j) = bact(1)%f_n_100(i,j) + cobalt%p_nbact(i,j,k_100,tau) * drho_dzt
+              cobalt%f_ndet_100(i,j) = cobalt%f_ndet_100(i,j) + cobalt%p_ndet(i,j,k_100,tau)*drho_dzt
+              cobalt%f_don_100(i,j) = cobalt%f_don_100(i,j) + (cobalt%p_ldon(i,j,k_100,tau)+cobalt%p_sldon(i,j,k_100,tau) + &
+                cobalt%p_srdon(i,j,k_100,tau))*drho_dzt
+              cobalt%f_silg_100(i,j) = cobalt%f_silg_100(i,j) + cobalt%p_silg(i,j,k_100,tau)*drho_dzt
+              cobalt%f_simd_100(i,j) = cobalt%f_simd_100(i,j) + cobalt%p_simd(i,j,k_100,tau)*drho_dzt
+              ! sinking fluxes (should we just handle these with by remapping the appropriate 3D variable onto 100m?)
+              ! need to add fast sinking detritus
+              cobalt%fndet_100(i,j) = cobalt%p_ndet(i,j,k_100,tau) * cobalt%Rho_0 * cobalt%wsink
+              cobalt%fpdet_100(i,j) = cobalt%p_pdet(i,j,k_100,tau) * cobalt%Rho_0 * cobalt%wsink
+              cobalt%ffedet_100(i,j) = cobalt%p_fedet(i,j,k_100,tau) * cobalt%Rho_0 * cobalt%wsink
+              cobalt%flithdet_100(i,j) = cobalt%p_lithdet(i,j,k_100,tau) * cobalt%Rho_0 * cobalt%wsink
+              cobalt%fsidet_100(i,j) = cobalt%p_sidet(i,j,k_100,tau) * cobalt%Rho_0 * cobalt%wsink
+              cobalt%fcadet_arag_100(i,j) = cobalt%p_cadet_arag(i,j,k_100,tau) * cobalt%Rho_0 * cobalt%wsink
+              cobalt%fcadet_calc_100(i,j) = cobalt%p_cadet_calc(i,j,k_100,tau) * cobalt%Rho_0 * cobalt%wsink
+              cobalt%fntot_100(i,j) = (cobalt%p_ndet(i,j,k_100,tau)*cobalt%wsink + &
+                cobalt%p_nsm(i,j,k_100,tau)*phyto(SMALL)%vmove(i,j,k_100) + &
+                cobalt%p_nmd(i,j,k_100,tau)*phyto(MEDIUM)%vmove(i,j,k_100) + &
+                cobalt%p_nlg(i,j,k_100,tau)*phyto(LARGE)%vmove(i,j,k_100) + &
+                cobalt%p_ndi(i,j,k_100,tau)*phyto(DIAZO)%vmove(i,j,k_100))*cobalt%Rho_0
+              cobalt%fptot_100(i,j) = (cobalt%p_pdet(i,j,k_100,tau)*cobalt%wsink + &
+                cobalt%p_psm(i,j,k_100,tau)*phyto(SMALL)%vmove(i,j,k_100) + &
+                cobalt%p_pmd(i,j,k_100,tau)*phyto(MEDIUM)%vmove(i,j,k_100) + &
+                cobalt%p_plg(i,j,k_100,tau)*phyto(LARGE)%vmove(i,j,k_100) + &
+                cobalt%p_pdi(i,j,k_100,tau)*phyto(DIAZO)%vmove(i,j,k_100))*cobalt%Rho_0
+              cobalt%ffetot_100(i,j) = (cobalt%p_fedet(i,j,k_100,tau)*cobalt%wsink + &
+                cobalt%p_fesm(i,j,k_100,tau)*phyto(SMALL)%vmove(i,j,k_100) + &
+                cobalt%p_femd(i,j,k_100,tau)*phyto(MEDIUM)%vmove(i,j,k_100) + &
+                cobalt%p_felg(i,j,k_100,tau)*phyto(LARGE)%vmove(i,j,k_100) + &
+                cobalt%p_fedi(i,j,k_100,tau)*phyto(DIAZO)%vmove(i,j,k_100))*cobalt%Rho_0
+              cobalt%fsitot_100(i,j) = (cobalt%p_sidet(i,j,k_100,tau)*cobalt%wsink + &
+                cobalt%p_simd(i,j,k_100,tau)*phyto(MEDIUM)%vmove(i,j,k_100) + &
+                cobalt%p_silg(i,j,k_100,tau)*phyto(LARGE)%vmove(i,j,k_100))*cobalt%Rho_0
+            endif
+          enddo ; enddo  !} i,j
+          deallocate(rho_dzt_100)
+
+          !
+          ! Send integrated tracer diagnostics
+          !
+           used = g_send_data(cobalt%id_f_ndet_100, cobalt%f_ndet_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_f_don_100, cobalt%f_don_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_f_silg_100, cobalt%f_silg_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_f_simd_100, cobalt%f_simd_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_f_mesozoo_200, cobalt%f_mesozoo_200,         &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !
+          ! 100m flux diagnostics (handle through diagnostic table)
+          !
+          used = g_send_data(cobalt%id_fndet_100, cobalt%fndet_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fpdet_100, cobalt%fpdet_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fsidet_100, cobalt%fsidet_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_flithdet_100, cobalt%flithdet_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fcadet_calc_100, cobalt%fcadet_calc_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fcadet_arag_100, cobalt%fcadet_arag_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_ffedet_100, cobalt%ffedet_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fntot_100, cobalt%fntot_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fptot_100, cobalt%fptot_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fsitot_100, cobalt%fsitot_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_ffetot_100, cobalt%ffetot_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+
+          allocate(rho_dzt_200(isc:iec,jsc:jec))
+          do j = jsc, jec ; do i = isc, iec !{
+            rho_dzt_200(i,j) = rho_dzt(i,j,1)
+            cobalt%f_mesozoo_200(i,j) = (zoo(2)%f_n(i,j,1)+zoo(3)%f_n(i,j,1))*rho_dzt(i,j,1)
+          enddo; enddo !} i,j
+
+          do j = jsc, jec ; do i = isc, iec ; !{
+            k_200 = 1
+            do k = 2, grid_kmt(i,j)  !{
+              if (rho_dzt_200(i,j) .lt. cobalt%Rho_0 * 200.0) then
+                k_200 = k
+                rho_dzt_200(i,j) = rho_dzt_200(i,j) + rho_dzt(i,j,k)
+                cobalt%f_mesozoo_200(i,j) = cobalt%f_mesozoo_200(i,j) + &
+                  (zoo(2)%f_n(i,j,k)+zoo(3)%f_n(i,j,k))*rho_dzt(i,j,k)
+              endif
+            enddo  !} k
+
+            if (k_200 .gt. 1 .and. k_200 .lt. grid_kmt(i,j)) then
+              drho_dzt = cobalt%Rho_0 * 200.0 - rho_dzt_200(i,j)
+              cobalt%f_mesozoo_200(i,j) = cobalt%f_mesozoo_200(i,j) + &
+                (zoo(2)%f_n(i,j,k_200)+zoo(3)%f_n(i,j,k_200))*drho_dzt
+            endif
+          enddo ; enddo  !} i,j
+          deallocate(rho_dzt_200)
+
+          !
+          ! 3D CMIP Variables derived from prognostic tracer and updated diagnostic tracer variables
+          !
+          ! Carbon pools
+          used = g_send_data(cobalt%id_dissic, cobalt%p_dic(:,:,:,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! Does not include background organic carbon values in accordance with CMIP request
+          cobalt%dissoc(:,:,:) = cobalt%c_2_n * (cobalt%p_ldon(:,:,:,tau) + cobalt%p_sldon(:,:,:,tau) + &
+            cobalt%p_srdon(:,:,:,tau) )
+          used = g_send_data(cobalt%id_dissoc,  cobalt%dissoc * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_phyc, (cobalt%p_nlg(:,:,:,tau) + cobalt%p_nmd(:,:,:,tau) + &
+            cobalt%p_nsm(:,:,:,tau) + cobalt%p_ndi(:,:,:,tau)) * cobalt%c_2_n * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_zooc, (cobalt%p_nlgz(:,:,:,tau) + cobalt%p_nmdz(:,:,:,tau) + &
+            cobalt%p_nsmz(:,:,:,tau)) * cobalt%c_2_n * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_bacc,  cobalt%p_nbact(:,:,:,tau) * cobalt%c_2_n * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! need to add fast sinking detritus once implemented
+          used = g_send_data(cobalt%id_detoc,  cobalt%p_ndet(:,:,:,tau) * cobalt%c_2_n * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! Includes on calcite and aragonite detritus, not comparable to total calcite/aragonite st surface
+          used = g_send_data(cobalt%id_calc,  cobalt%p_cadet_calc(:,:,:,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_arag,  cobalt%p_cadet_arag(:,:,:,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_phydiat, (cobalt%nlg_diatoms+cobalt%nmd_diatoms)*cobalt%c_2_n*cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_phydiaz,  cobalt%p_ndi(:,:,:,tau) * cobalt%c_2_n * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_phypico,  cobalt%p_nsm(:,:,:,tau) * cobalt%c_2_n * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_phymisc,  (cobalt%nlg_misc + cobalt%nmd_misc) * cobalt%c_2_n*cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_zmicro,  cobalt%p_nsmz(:,:,:,tau) * cobalt%c_2_n * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_zmeso,  (cobalt%p_nlgz(:,:,:,tau)+cobalt%p_nmdz(:,:,:,tau)) * &
+            cobalt%c_2_n * cobalt%Rho_0, model_time, rmask = grid_tmask, &
+            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! alkalinity, pH, Carbonate system and O2
+          used = g_send_data(cobalt%id_talk, cobalt%p_alk(:,:,:,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_ph, log10(cobalt%f_htotal+epsln) * (-1.0), &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_o2_cmip, cobalt%p_o2(:,:,:,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_o2sat, cobalt%o2sat, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_co3, cobalt%f_co3_ion*cobalt%Rho_0, &
+            model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_co3satcalc, cobalt%co3_sol_calc * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_co3satarag, cobalt%co3_sol_arag * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! Nutrients
+          used = g_send_data(cobalt%id_no3_cmip, cobalt%p_no3(:,:,:,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_nh4_cmip, cobalt%p_nh4(:,:,:,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_po4_cmip, cobalt%p_po4(:,:,:,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_dfe, cobalt%p_fed(:,:,:,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_si, cobalt%p_sio4(:,:,:,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! Chlorophyll: CMIP asks for in kg Chl m-3
+          used = g_send_data(cobalt%id_chl_cmip, cobalt%f_chl * cobalt%Rho_0 / 1.0e9, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_chldiat, (phyto(LARGE)%theta * cobalt%nlg_diatoms + &
+            phyto(MEDIUM)%theta * cobalt%nmd_diatoms) * cobalt%c_2_n * cobalt%Rho_0 * 12.0e-3, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_chldiaz,  phyto(DIAZO)%theta * cobalt%p_ndi(:,:,:,tau) * &
+            cobalt%c_2_n * cobalt%Rho_0 * 12.0e-3, &
+            model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_chlpico,  phyto(SMALL)%theta * cobalt%p_nsm(:,:,:,tau) * &
+            cobalt%c_2_n * cobalt%Rho_0 * 12.0e-3, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_chlmisc, (phyto(LARGE)%theta * cobalt%nlg_misc + &
+            phyto(MEDIUM)%theta * cobalt%nmd_misc) * cobalt%c_2_n*cobalt%Rho_0*12.0e-3, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! Aggregate Particulate C, N, P, Fe and Si pools
+          used = g_send_data(cobalt%id_poc, (cobalt%p_ndi(:,:,:,tau)+cobalt%p_nlg(:,:,:,tau)+ &
+            cobalt%p_nmd(:,:,:,tau)+cobalt%p_nsm(:,:,:,tau)+cobalt%p_nbact(:,:,:,tau)+cobalt%p_ndet(:,:,:,tau) + &
+            cobalt%p_nsmz(:,:,:,tau)+cobalt%p_nmdz(:,:,:,tau)+cobalt%p_nlgz(:,:,:,tau))*cobalt%Rho_0*cobalt%c_2_n, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_pon, (cobalt%p_ndi(:,:,:,tau)+cobalt%p_nlg(:,:,:,tau)+ &
+            cobalt%p_nmd(:,:,:,tau)+cobalt%p_nsm(:,:,:,tau)+cobalt%p_nbact(:,:,:,tau)+cobalt%p_ndet(:,:,:,tau)+ &
+            cobalt%p_nsmz(:,:,:,tau)+cobalt%p_nmdz(:,:,:,tau)+cobalt%p_nlgz(:,:,:,tau))*cobalt%Rho_0, &
+            model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_pop, (cobalt%p_pdi(:,:,:,tau)+cobalt%p_plg(:,:,:,tau)+ &
+            cobalt%p_pmd(:,:,:,tau)+cobalt%p_psm(:,:,:,tau)+bact(1)%q_p_2_n*cobalt%p_nbact(:,:,:,tau)+ &
+            cobalt%p_pdet(:,:,:,tau)+zoo(1)%q_p_2_n*cobalt%p_nsmz(:,:,:,tau)+zoo(2)%q_p_2_n*cobalt%p_nmdz(:,:,:,tau)+ &
+            zoo(3)%q_p_2_n*cobalt%p_nlgz(:,:,:,tau))*cobalt%Rho_0,  &
+            model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_bfe, (cobalt%p_fedi(:,:,:,tau) + cobalt%p_felg(:,:,:,tau) + &
+            cobalt%p_femd(:,:,:,tau) + cobalt%p_fesm(:,:,:,tau) + cobalt%p_fedet(:,:,:,tau))*cobalt%Rho_0, &
+            model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_bsi, (cobalt%p_silg(:,:,:,tau) + cobalt%p_simd(:,:,:,tau) + &
+            cobalt%p_sidet(:,:,:,tau))*cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! Phytoplankton partitioned by nutrients
+          used = g_send_data(cobalt%id_phyn, (cobalt%p_nlg(:,:,:,tau) + cobalt%p_nmd(:,:,:,tau) +  &
+            cobalt%p_nsm(:,:,:,tau) + cobalt%p_ndi(:,:,:,tau)) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_phyp, (cobalt%p_pdi(:,:,:,tau) + cobalt%p_plg(:,:,:,tau) + &
+            cobalt%p_pmd(:,:,:,tau) + cobalt%p_psm(:,:,:,tau))*cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_phyfe,  (cobalt%p_fedi(:,:,:,tau) + cobalt%p_felg(:,:,:,tau) +  &
+            cobalt%p_femd(:,:,:,tau) + cobalt%p_fesm(:,:,:,tau)) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_physi, (cobalt%p_silg(:,:,:,tau) + cobalt%p_simd(:,:,:,tau))*cobalt%Rho_0, & 
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! PENDING: Does CMIP want this?  Do we have them?
+          !used = g_send_data(cobalt%id_dissicnat, (define quantity),  &
+          !  model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          !used = g_send_data(cobalt%id_dissicabio, (define quantity), &      
+          !  model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          !used = g_send_data(cobalt%id_dissi14cabio, (define quantity), &
+          !  model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          !used = g_send_data(cobalt%id_talknat, (define quantity), &
+          !  model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          !used = g_send_data(cobalt%id_phnat, (define quantity), &
+          !  model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          !used = g_send_data(cobalt%id_phabio, (define quantity), &
+          !  model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          !used = g_send_data(cobalt%id_co3nat, (define quantity),  &
+          !  model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          !used = g_send_data(cobalt%id_co3abio, (define quantity),  &
+          !  model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          !used = g_send_data(cobalt%id_co3nat, (define quantity),  &
+          !  model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          !used = g_send_data(cobalt%id_co3abio, (define quantity),  &
+          !  model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+
+          !
+          ! CMIP 3D Sinking Variables
+          !
+          used = g_send_data(cobalt%id_expc, (cobalt%p_ndet(:,:,:,tau)*cobalt%wsink + &
+            cobalt%p_nsm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + cobalt%p_nmd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
+            cobalt%p_nlg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + cobalt%p_ndi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:)) * &
+            cobalt%c_2_n*cobalt%Rho_0*grid_tmask(:,:,:), model_time, rmask = grid_tmask, &
+            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_expn, (cobalt%p_ndet(:,:,:,tau)*cobalt%wsink + &
+            cobalt%p_nsm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + cobalt%p_nmd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
+            cobalt%p_nlg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + cobalt%p_ndi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:)) * &
+            cobalt%Rho_0*grid_tmask(:,:,:), model_time, rmask = grid_tmask, &
+            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_expp, (cobalt%p_pdet(:,:,:,tau)*cobalt%wsink + &
+            cobalt%p_psm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + cobalt%p_pmd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + & 
+            cobalt%p_plg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + cobalt%p_pdi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:)) * & 
+            cobalt%Rho_0*grid_tmask(:,:,:), model_time, rmask = grid_tmask, & 
+            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_expfe, (cobalt%p_fedet(:,:,:,tau)*cobalt%wsink + &
+            cobalt%p_fesm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + cobalt%p_femd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
+            cobalt%p_felg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + cobalt%p_fedi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:)) * &
+            cobalt%Rho_0*grid_tmask(:,:,:), model_time, rmask = grid_tmask, &
+            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_expsi, (cobalt%p_sidet(:,:,:,tau)*cobalt%wsink + &
+            cobalt%p_simd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:)+cobalt%p_silg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:)) * &
+            cobalt%Rho_0*grid_tmask(:,:,:),model_time, rmask = grid_tmask, &
+            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_expcalc, cobalt%p_cadet_calc(:,:,:,tau)*cobalt%Rho_0*cobalt%wsink, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_exparag, cobalt%p_cadet_arag(:,:,:,tau)*cobalt%Rho_0*cobalt%wsink, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          !
+          ! Surface CMIP variables (extract directly at specified depth from 3D fields?)
+          !
+          used = g_send_data(cobalt%id_dissicos, cobalt%p_dic(:,:,1,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_dissocos, cobalt%dissoc(:,:,1) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_phycos, (cobalt%p_nlg(:,:,1,tau) + cobalt%p_nmd(:,:,1,tau) +  &
+            cobalt%p_nsm(:,:,1,tau) + cobalt%p_ndi(:,:,1,tau)) * cobalt%c_2_n * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_zoocos, (cobalt%p_nlgz(:,:,1,tau) + cobalt%p_nsmz(:,:,1,tau) +  &
+            cobalt%p_nmdz(:,:,1,tau)) * cobalt%c_2_n * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_baccos, cobalt%p_nbact(:,:,1,tau) * cobalt%c_2_n * cobalt%Rho_0,  &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_detocos, cobalt%p_ndet(:,:,1,tau) * cobalt%c_2_n * cobalt%Rho_0,  &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_calcos, cobalt%p_cadet_calc(:,:,1,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_aragos, cobalt%p_cadet_arag(:,:,1,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_phydiatos, (cobalt%nlg_diatoms(:,:,1) + cobalt%nmd_diatoms(:,:,1)) * &
+            cobalt%c_2_n * cobalt%Rho_0, model_time, rmask = grid_tmask(:,:,1), &
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_phydiazos, cobalt%p_ndi(:,:,1,tau) * cobalt%c_2_n * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_phypicoos, cobalt%p_nsm(:,:,1,tau) * cobalt%c_2_n * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_phymiscos, (cobalt%nlg_misc(:,:,1) + cobalt%nmd_misc(:,:,1)) * &
+            cobalt%c_2_n * cobalt%Rho_0, model_time, rmask = grid_tmask(:,:,1), &
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_zmicroos, cobalt%p_nsmz(:,:,1,tau) * cobalt%c_2_n * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_zmesoos, (cobalt%p_nlgz(:,:,1,tau)+cobalt%p_nmdz(:,:,1,tau)) * &
+            cobalt%c_2_n * cobalt%Rho_0, model_time, rmask = grid_tmask(:,:,1), &
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_talkos,  cobalt%p_alk(:,:,1,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_phos,  log10(cobalt%f_htotal(:,:,1)+epsln) * (-1.0), &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_o2os, cobalt%p_o2(:,:,1,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_o2satos,  cobalt%o2sat(:,:,1), &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_no3os,  cobalt%p_no3(:,:,1,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_nh4os,  cobalt%p_nh4(:,:,1,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_po4os,  cobalt%p_po4(:,:,1,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_dfeos,  cobalt%p_fed(:,:,1,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sios,  cobalt%p_sio4(:,:,1,tau) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_chlos,  cobalt%f_chl(:,:,1) * cobalt%Rho_0 / 1.0e9, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_chldiatos,  (phyto(LARGE)%theta(:,:,1) * cobalt%nlg_diatoms(:,:,1) + &
+            phyto(MEDIUM)%theta(:,:,1) * cobalt%nmd_diatoms(:,:,1)) * cobalt%c_2_n * cobalt%Rho_0 * 12.0e-3, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_chldiazos,  phyto(DIAZO)%theta(:,:,1) * cobalt%p_ndi(:,:,1,tau) * &
+            cobalt%c_2_n * cobalt%Rho_0 * 12.0e-3, model_time, rmask = grid_tmask(:,:,1), &
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_chlpicoos,  phyto(SMALL)%theta(:,:,1) * cobalt%p_nsm(:,:,1,tau) * &
+            cobalt%c_2_n * cobalt%Rho_0 * 12.0e-3, model_time, rmask = grid_tmask(:,:,1), &
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_chldiatos,  (phyto(LARGE)%theta(:,:,1) * cobalt%nlg_misc(:,:,1) + &
+            phyto(MEDIUM)%theta(:,:,1) * cobalt%nmd_misc(:,:,1)) * cobalt%c_2_n * cobalt%Rho_0 * 12.0e-3, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_ponos, (cobalt%p_ndi(:,:,1,tau)+cobalt%p_nlg(:,:,1,tau)+ &
+            cobalt%p_nmd(:,:,1,tau)+cobalt%p_nsm(:,:,1,tau)+cobalt%p_nbact(:,:,1,tau)+cobalt%p_ndet(:,:,1,tau)+ &
+            cobalt%p_nsmz(:,:,1,tau)+cobalt%p_nmdz(:,:,1,tau)+cobalt%p_nlgz(:,:,1,tau))*cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_popos, (cobalt%p_pdi(:,:,1,tau)+cobalt%p_plg(:,:,1,tau)+ & 
+            cobalt%p_pmd(:,:,1,tau)+cobalt%p_psm(:,:,1,tau)+bact(1)%q_p_2_n*cobalt%p_nbact(:,:,1,tau)+ &
+            cobalt%p_pdet(:,:,1,tau)+zoo(1)%q_p_2_n*cobalt%p_nsmz(:,:,1,tau)+ &
+            zoo(2)%q_p_2_n*cobalt%p_nmdz(:,:,1,tau)+zoo(3)%q_p_2_n*cobalt%p_nlgz(:,:,1,tau))*cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_bfeos, (cobalt%p_fedi(:,:,1,tau) + cobalt%p_felg(:,:,1,tau) + &
+            cobalt%p_femd(:,:,1,tau) + cobalt%p_fesm(:,:,1,tau) + cobalt%p_fedet(:,:,1,tau))*cobalt%Rho_0, & 
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_bsios,  (cobalt%p_silg(:,:,1,tau) + cobalt%p_simd(:,:,1,tau) + &
+            cobalt%p_sidet(:,:,1,tau)) * cobalt%Rho_0, model_time, rmask = grid_tmask(:,:,1), &
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_phynos,  (cobalt%p_nlg(:,:,1,tau) + cobalt%p_nmd(:,:,1,tau) +  &
+            cobalt%p_nsm(:,:,1,tau) + cobalt%p_ndi(:,:,1,tau)) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_phypos, (cobalt%p_pdi(:,:,1,tau) + cobalt%p_plg(:,:,1,tau) + &
+            cobalt%p_pmd(:,:,1,tau) + cobalt%p_psm(:,:,1,tau))*cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_phyfeos,  (cobalt%p_fedi(:,:,1,tau) + cobalt%p_felg(:,:,1,tau) + &
+            cobalt%p_femd(:,:,1,tau) + cobalt%p_fesm(:,:,1,tau)) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_physios, (cobalt%p_silg(:,:,1,tau) + cobalt%p_simd(:,:,1,tau))*cobalt%Rho_0, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_co3os,  cobalt%f_co3_ion(:,:,1) * cobalt%Rho_0,  &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_co3satcalcos,  cobalt%co3_sol_calc(:,:,1) * cobalt%Rho_0,  &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_co3sataragos,  cobalt%co3_sol_arag(:,:,1) * cobalt%Rho_0,  &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          ! PENDING: Does CMIP want this?  Do we have them?
+          !used = g_send_data(cobalt%id_dissicnatos, (define quantity), &
+          !  model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !used = g_send_data(cobalt%id_dissicabioos,  (define quantity), &
+          !  model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !used = g_send_data(cobalt%id_dissi14cabioos, (define quantity), &
+          !  model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !used = g_send_data(cobalt%id_talknatos, (define quantity), &
+          !  model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !used = g_send_data(cobalt%id_phnatos,  log10(cobalt%f_htotal(:,:,1)+epsln) * -1.0, &
+          !  model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !used = g_send_data(cobalt%id_phabioos,  log10(cobalt%f_htotal(:,:,1)+epsln) * -1.0, &
+          !  model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          ! used = g_send_data(cobalt%id_co3natos,  cobalt%f_co3_ion(:,:,1) * cobalt%Rho_0,  &
+          !   model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !used = g_send_data(cobalt%id_co3abioos,  cobalt%f_co3_ion(:,:,1) * cobalt%Rho_0,  &
+          !  model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+
+          ! Air-Sea flux variables - here or with fluxes?
+          used = g_send_data(cobalt%id_spco2,  cobalt%pco2_csurf * 0.1013, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_dpco2,  cobalt%deltap_dic * 0.1013, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_dpo2, cobalt%deltap_o2 * 0.1013, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fgco2,  cobalt%stf_gas_dic * 12.0e-3, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fgo2, cobalt%stf_gas_o2, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !used = g_send_data(cobalt%id_spco2nat,  cobalt%pco2_csurf * 0.1013, &
+          !  model_time, rmask = grid_tmask(:,:,1),  is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !used = g_send_data(cobalt%id_spco2abio,  cobalt%pco2_csurf * 0.1013,   &
+          !  model_time, rmask = grid_tmask(:,:,1),  is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !used = g_send_data(cobalt%id_dpco2nat,  cobalt%dic_deltap * 0.1013,   &
+          !  model_time, rmask = grid_tmask(:,:,1),  is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !used = g_send_data(cobalt%id_dpco2abio,  cobalt%dic_deltap * 0.1013,   &
+          !  model_time, rmask = grid_tmask(:,:,1),  is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !used = g_send_data(cobalt%id_fgco2nat,
+          !  model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !used = g_send_data(cobalt%id_fgco2abio,
+          !  model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !used = g_send_data(cobalt%id_fg14co2abio,
+          !  model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+
+          !
+          ! 100m sinking flux (should derive 3D field and MOM6 interpolation?)
+          !
+          used = g_send_data(cobalt%id_epc100, cobalt%fntot_100 * cobalt%c_2_n,  &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_epn100, cobalt%fntot_100, &
+            model_time, rmask = grid_tmask(:,:,1),  is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_epp100, cobalt%fptot_100, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_epfe100, cobalt%ffetot_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_epsi100, cobalt%fsitot_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_epcalc100,  cobalt%fcadet_calc_100,   &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_eparag100, cobalt%fcadet_arag_100,   &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+
+          !
+          ! Vertical integrals (kg m-2)
+          !
+          used = g_send_data(cobalt%id_intdic, cobalt%wc_vert_int_dic*12.0e-3,   &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intdoc, cobalt%wc_vert_int_doc*12.0e-3,   &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intpoc, cobalt%wc_vert_int_poc*12.0e-3,   &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+
+          !
+          ! Additional 100m integrals
+          !
+          used = g_send_data(cobalt%id_f_dic_int_100, cobalt%f_dic_int_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_f_din_int_100, cobalt%f_din_int_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_f_po4_int_100, cobalt%f_po4_int_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_f_fed_int_100, cobalt%f_fed_int_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_f_sio4_int_100, cobalt%f_sio4_int_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_f_alk_int_100, cobalt%f_alk_int_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
 
         case (.false.)
         ! Logic for "update_from_source" case
-!
-!---------------------------------------------------------------------
-!
-! Send phytoplankton diagnostic data
 
-      do n= 1, NUM_PHYTO
-            used = g_send_data(phyto(n)%id_P_C_max,   phyto(n)%P_C_max,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_alpha,     phyto(n)%alpha,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_bresp,     phyto(n)%bresp,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_def_fe,     phyto(n)%def_fe,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_felim,      phyto(n)%felim,            &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_irrlim,     phyto(n)%irrlim,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_jzloss_n, phyto(n)%jzloss_n*rho_dzt,      &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_jaggloss_n, phyto(n)%jaggloss_n*rho_dzt,   &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_jvirloss_n, phyto(n)%jvirloss_n*rho_dzt,   &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_jmortloss_n, phyto(n)%jmortloss_n*rho_dzt,   &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_jexuloss_n, phyto(n)%jexuloss_n*rho_dzt,   &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_juptake_fe, phyto(n)%juptake_fe*rho_dzt,   &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_juptake_nh4, phyto(n)%juptake_nh4*rho_dzt,   &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_juptake_no3, phyto(n)%juptake_no3*rho_dzt,   &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_juptake_po4, phyto(n)%juptake_po4*rho_dzt,   &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
- 
-            used = g_send_data(phyto(n)%id_jprod_n, phyto(n)%jprod_n*rho_dzt,   &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_liebig_lim,phyto(n)%liebig_lim,          &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_mu,        phyto(n)%mu,                  &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_nh4lim,     phyto(n)%nh4lim,             &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_no3lim,     phyto(n)%no3lim,             &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_po4lim,     phyto(n)%po4lim,             &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_o2lim,     phyto(n)%o2lim,             &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_q_fe_2_n,   phyto(n)%q_fe_2_n,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_q_p_2_n,   phyto(n)%q_p_2_n,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_silim, phyto(n)%silim,       &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_q_si_2_n, phyto(n)%q_si_2_n,       &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_theta,      phyto(n)%theta,              &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_chl,      phyto(n)%chl,              &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_f_mu_mem,      phyto(n)%f_mu_mem,              &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_mu_mix,      phyto(n)%mu_mix,            &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_stress_fac, phyto(n)%stress_fac,         &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_vmove,    phyto(n)%vmove,              &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-      enddo
-
-      do n=2,3
-            used = g_send_data(phyto(n)%id_juptake_sio4, phyto(n)%juptake_sio4*rho_dzt,   &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-      enddo 
-
-      used = g_send_data(phyto(DIAZO)%id_juptake_n2, phyto(DIAZO)%juptake_n2*rho_dzt,   &
-      model_time, rmask = grid_tmask,&
-      is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-    !--------------------------------------------------------------------------------------
-    ! Send bacterial diagnostic data
-    !
-
-       used = g_send_data(bact(1)%id_jzloss_n, bact(1)%jzloss_n*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(bact(1)%id_jvirloss_n, bact(1)%jvirloss_n*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(bact(1)%id_juptake_ldon, bact(1)%juptake_ldon*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(bact(1)%id_juptake_ldop, bact(1)%juptake_ldop*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(bact(1)%id_jprod_nh4, bact(1)%jprod_nh4*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(bact(1)%id_jprod_po4, bact(1)%jprod_po4*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(bact(1)%id_jprod_n, bact(1)%jprod_n*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(bact(1)%id_o2lim, bact(1)%o2lim,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(bact(1)%id_ldonlim, bact(1)%ldonlim,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(bact(1)%id_temp_lim, bact(1)%temp_lim,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-    !--------------------------------------------------------------------------------------
-    ! Send zooplankton diagnostic data
-    !
-
-       do n= 1, NUM_ZOO
-            used = g_send_data(zoo(n)%id_jzloss_n, zoo(n)%jzloss_n*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jhploss_n, zoo(n)%jhploss_n*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jingest_n, zoo(n)%jingest_n*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jingest_p, zoo(n)%jingest_p*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jingest_sio2, zoo(n)%jingest_sio2*rho_dzt,      &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jingest_fe, zoo(n)%jingest_fe*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jprod_ndet, zoo(n)%jprod_ndet*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jprod_pdet, zoo(n)%jprod_pdet*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jprod_ldon, zoo(n)%jprod_ldon*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jprod_ldop, zoo(n)%jprod_ldop*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jprod_sldon, zoo(n)%jprod_sldon*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jprod_sldop, zoo(n)%jprod_sldop*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jprod_srdon, zoo(n)%jprod_srdon*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jprod_srdop, zoo(n)%jprod_srdop*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jprod_fed,  zoo(n)%jprod_fed*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jprod_fedet, zoo(n)%jprod_fedet*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jprod_sidet, zoo(n)%jprod_sidet*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jprod_sio4, zoo(n)%jprod_sio4*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jprod_po4,  zoo(n)%jprod_po4*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jprod_nh4,  zoo(n)%jprod_nh4*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_jprod_n,   zoo(n)%jprod_n*rho_dzt,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_o2lim, zoo(n)%o2lim,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(zoo(n)%id_temp_lim, zoo(n)%temp_lim,           &
-            model_time, rmask = grid_tmask,&
-            is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       enddo
-
-    !
-    ! Production diagnostics
-    !
-       used = g_send_data(cobalt%id_jprod_cadet_arag, cobalt%jprod_cadet_arag * rho_dzt, &
-       model_time, rmask = grid_tmask(:,:,:),&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jprod_cadet_calc, cobalt%jprod_cadet_calc * rho_dzt, &
-       model_time, rmask = grid_tmask(:,:,:),&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jprod_ndet, cobalt%jprod_ndet*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-    !    used = g_send_data(cobalt%id_jprod_pdet, cobalt%jprod_pdet*rho_dzt,           &
-    !    model_time, rmask = grid_tmask,&
-    !    is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-    !    used = g_send_data(cobalt%id_jprod_srdon, cobalt%jprod_srdon*rho_dzt,           &
-    !    model_time, rmask = grid_tmask,&
-    !    is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-    !    used = g_send_data(cobalt%id_jprod_sldon, cobalt%jprod_sldon*rho_dzt,           &
-    !    model_time, rmask = grid_tmask,&
-    !    is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-    !    used = g_send_data(cobalt%id_jprod_ldon, cobalt%jprod_ldon*rho_dzt,           &
-    !    model_time, rmask = grid_tmask,&
-    !    is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-    !    used = g_send_data(cobalt%id_jprod_srdop, cobalt%jprod_srdop*rho_dzt,           &
-    !    model_time, rmask = grid_tmask,&
-    !    is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-    !    used = g_send_data(cobalt%id_jprod_sldop, cobalt%jprod_sldop*rho_dzt,           &
-    !    model_time, rmask = grid_tmask,&
-    !    is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-    !    used = g_send_data(cobalt%id_jprod_ldop, cobalt%jprod_ldop*rho_dzt,           &
-    !    model_time, rmask = grid_tmask,&
-    !    is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jprod_nh4, cobalt%jprod_nh4*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jprod_nh4_plus_btm, cobalt%jprod_nh4_plus_btm*rho_dzt, &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jprod_po4, cobalt%jprod_po4*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jprod_fed, cobalt%jprod_fed*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jprod_fedet,  cobalt%jprod_fedet*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jprod_sidet, cobalt%jprod_sidet*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jprod_sio4, cobalt%jprod_sio4*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jprod_lithdet, cobalt%jprod_lithdet*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jdiss_cadet_arag, cobalt%jdiss_cadet_arag*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jdiss_cadet_calc, cobalt%jdiss_cadet_calc*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jdiss_sidet, cobalt%jdiss_sidet*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jremin_ndet, cobalt%jremin_ndet*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jremin_pdet, cobalt%jremin_pdet*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jremin_fedet, cobalt%jremin_fedet*rho_dzt,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jfed,       cobalt%jfed*rho_dzt,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jfedc,       cobalt%jfed,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jfe_ads,       cobalt%jfe_ads*rho_dzt,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jfe_coast, cobalt%jfe_coast*rho_dzt,         &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jfe_iceberg, cobalt%jfe_iceberg*rho_dzt,         &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jno3_iceberg, cobalt%jno3_iceberg*rho_dzt,         &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_jpo4_iceberg, cobalt%jpo4_iceberg*rho_dzt,         &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_kfe_eq_lig, log10(cobalt%kfe_eq_lig+epsln),         &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_feprime, cobalt%feprime,         &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_ligand, cobalt%ligand,         &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_fe_sol, cobalt%fe_sol,         &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_expkT,       cobalt%expkT,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_expkreminT,       cobalt%expkreminT,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_hp_o2lim, cobalt%hp_o2lim,         &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_hp_temp_lim, cobalt%hp_temp_lim,         &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_irr_inst,      cobalt%irr_inst,              &
-       model_time, rmask = grid_tmask(:,:,:),&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_irr_mix,       cobalt%irr_mix,               &
-       model_time, rmask = grid_tmask(:,:,:),&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_irr_aclm_inst,  cobalt%irr_aclm_inst,        &
-       model_time, rmask = grid_tmask(:,:,:),&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_irr_aclm,       cobalt%f_irr_aclm,               &
-       model_time, rmask = grid_tmask(:,:,:),&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_irr_aclm_z,       cobalt%f_irr_aclm_z,               &
-       model_time, rmask = grid_tmask(:,:,:),&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-        used = g_send_data(cobalt%id_jno3denit_wc,  cobalt%jno3denit_wc*rho_dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-        used = g_send_data(cobalt%id_juptake_nh4amx, cobalt%juptake_nh4amx*rho_dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-        used = g_send_data(cobalt%id_juptake_no3amx, cobalt%juptake_no3amx*rho_dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-        used = g_send_data(cobalt%id_jo2resp_wc,  cobalt%jo2resp_wc*rho_dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-        used = g_send_data(cobalt%id_jprod_no3nitrif, cobalt%jprod_no3nitrif*rho_dzt,       &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-        used = g_send_data(cobalt%id_juptake_nh4nitrif, cobalt%juptake_nh4nitrif*rho_dzt,       &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-        used = g_send_data(cobalt%id_jnamx, cobalt%jnamx*rho_dzt,       &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-!        used = g_send_data(cobalt%id_tot_layer_int_c, cobalt%tot_layer_int_c,&
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-!        used = g_send_data(cobalt%id_tot_layer_int_fe,cobalt%tot_layer_int_fe,&
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-!        used = g_send_data(cobalt%id_tot_layer_int_n,cobalt%tot_layer_int_n,&
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-!        used = g_send_data(cobalt%id_tot_layer_int_p,cobalt%tot_layer_int_p,&
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-!        used = g_send_data(cobalt%id_tot_layer_int_si,cobalt%tot_layer_int_si,&
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-!        used = g_send_data(cobalt%id_tot_layer_int_o2,cobalt%tot_layer_int_o2,&
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-!        used = g_send_data(cobalt%id_tot_layer_int_alk,cobalt%tot_layer_int_alk,&
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-        used = g_send_data(cobalt%id_total_filter_feeding,cobalt%total_filter_feeding,&
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-        used = g_send_data(cobalt%id_nlg_diatoms,cobalt%nlg_diatoms,&
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-        used = g_send_data(cobalt%id_nmd_diatoms,cobalt%nmd_diatoms,&
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-        used = g_send_data(cobalt%id_q_si_2_n_lg_diatoms,cobalt%q_si_2_n_lg_diatoms,&
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-        used = g_send_data(cobalt%id_q_si_2_n_md_diatoms,cobalt%q_si_2_n_md_diatoms,&
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-        used = g_send_data(cobalt%id_co2_csurf,      cobalt%co2_csurf,              &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_pco2_csurf,      cobalt%pco2_csurf,              &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_co2_alpha,      cobalt%co2_alpha,              &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_nh3_csurf,      cobalt%nh3_csurf,              &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_nh3_alpha,      cobalt%nh3_alpha,              &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-   !     used = g_send_data(cobalt%id_fcadet_arag_btm,   cobalt%fcadet_arag_btm,      &
-   !     model_time, rmask = grid_tmask(:,:,1),&
-   !     is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-   !     used = g_send_data(cobalt%id_fcadet_calc_btm,   cobalt%fcadet_calc_btm,      &
-   !     model_time, rmask = grid_tmask(:,:,1),&
-   !     is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-   !     used = g_send_data(cobalt%id_ffedet_btm,   cobalt%ffedet_btm,             &
-   !     model_time, rmask = grid_tmask(:,:,1),&
-   !     is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-   !     used = g_send_data(cobalt%id_fndet_btm,    cobalt%fndet_btm,              &
-   !     model_time, rmask = grid_tmask(:,:,1),&
-   !     is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-   !     used = g_send_data(cobalt%id_fpdet_btm,    cobalt%fpdet_btm,              &
-   !     model_time, rmask = grid_tmask(:,:,1),&
-   !     is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-   !     used = g_send_data(cobalt%id_fsidet_btm,   cobalt%fsidet_btm,             &
-   !     model_time, rmask = grid_tmask(:,:,1),&
-   !     is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_b_alk,    -cobalt%b_alk,              &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_b_dic,    -cobalt%b_dic,              &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_b_fed,    -cobalt%b_fed,              &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_b_nh4,    -cobalt%b_nh4,              &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_b_no3,    -cobalt%b_no3,              &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_b_o2,    -cobalt%b_o2,                &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_b_po4,    -cobalt%b_po4,              &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_b_sio4,    -cobalt%b_sio4,            &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_ffetot_btm,   cobalt%ffetot_btm,             &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_fntot_btm,    cobalt%fntot_btm,              &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_fptot_btm,    cobalt%fptot_btm,              &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_fsitot_btm,   cobalt%fsitot_btm,             &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_flithdet_btm,   cobalt%flithdet_btm,             &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_fcased_burial, cobalt%fcased_burial,         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_fcased_redis,  cobalt%fcased_redis,          &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_fcased_redis_surfresp,cobalt%fcased_redis_surfresp, &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_cased_redis_coef,  cobalt%cased_redis_coef, &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_cased_redis_delz,  cobalt%cased_redis_delz, &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_ffe_sed,       cobalt%ffe_sed,               &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_ffe_geotherm,  cobalt%ffe_geotherm,          &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_ffe_iceberg,  cobalt%ffe_iceberg,          &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_fnso4red_sed,cobalt%fnso4red_sed,        &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_fno3denit_sed, cobalt%fno3denit_sed,         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_fnoxic_sed,    cobalt%fnoxic_sed,            &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_frac_burial,    cobalt%frac_burial,          &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_fn_burial,    cobalt%fn_burial,        &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_fp_burial,    cobalt%fp_burial,            &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_co3_sol_arag,  cobalt%co3_sol_arag,             &
-       model_time, rmask = grid_tmask(:,:,:),&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_co3_sol_calc,  cobalt%co3_sol_calc,             &
-       model_time, rmask = grid_tmask(:,:,:),&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_omega_arag,  cobalt%omega_arag,                 &
-       model_time, rmask = grid_tmask(:,:,:),&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_omega_calc,  cobalt%omega_calc,                 &
-       model_time, rmask = grid_tmask(:,:,:),&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_rho_test,  cobalt%rho_test,                 &
-       model_time, rmask = grid_tmask(:,:,:),&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_fcadet_arag, cobalt%p_cadet_arag(:,:,:,tau) * cobalt%Rho_0 * &
-       cobalt%wsink * grid_tmask(:,:,:), &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_fcadet_calc, cobalt%p_cadet_calc(:,:,:,tau) * cobalt%Rho_0 * &
-       cobalt%wsink*grid_tmask(:,:,:), &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_ffedet,        cobalt%p_fedet(:,:,:,tau) * cobalt%Rho_0 * &
-       cobalt%wsink * grid_tmask(:,:,:),&
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_flithdet,      cobalt%p_lithdet(:,:,:,tau) * cobalt%Rho_0 * &
-       cobalt%wsink * grid_tmask(:,:,:),&
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_fndet,         cobalt%p_ndet(:,:,:,tau) * cobalt%Rho_0 * &
-       cobalt%wsink * grid_tmask(:,:,:),&
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_fpdet,         cobalt%p_pdet(:,:,:,tau) * cobalt%Rho_0 * &
-       cobalt%wsink * grid_tmask(:,:,:),&
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_fsidet,        cobalt%p_sidet(:,:,:,tau)  * cobalt%Rho_0 * &
-       cobalt%wsink  *grid_tmask(:,:,:),&
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_ffetot,(cobalt%p_fedet(:,:,:,tau)*cobalt%wsink + &
-       cobalt%p_fesm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + &
-       cobalt%p_femd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
-       cobalt%p_felg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + &
-       cobalt%p_fedi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:))*cobalt%Rho_0*grid_tmask(:,:,:), &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_fntot,(cobalt%p_ndet(:,:,:,tau)*cobalt%wsink + &
-       cobalt%p_nsm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + &
-       cobalt%p_nmd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
-       cobalt%p_nlg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + &
-       cobalt%p_ndi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:))*cobalt%Rho_0*grid_tmask(:,:,:), &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_fptot,(cobalt%p_pdet(:,:,:,tau)*cobalt%wsink + &
-       cobalt%p_psm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + &
-       cobalt%p_pmd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
-       cobalt%p_plg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + &
-       cobalt%p_pdi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:))*cobalt%Rho_0*grid_tmask(:,:,:), &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_fsitot,(cobalt%p_sidet(:,:,:,tau)*cobalt%wsink + &
-       cobalt%p_simd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
-       cobalt%p_silg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:))*cobalt%Rho_0*grid_tmask(:,:,:), &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       used = g_send_data(cobalt%id_nphyto_tot,   (cobalt%p_ndi(:,:,:,tau) +  &
-       cobalt%p_nlg(:,:,:,tau) + cobalt%p_nmd(:,:,:,tau) + cobalt%p_nsm(:,:,:,tau)), &
-       model_time, rmask = grid_tmask(:,:,:),&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-!
-! Radiocarbon fields
-!
-       if (do_14c) then
-         used = g_send_data(cobalt%id_b_di14c,        cobalt%b_di14c,                &
-         model_time, rmask = grid_tmask(:,:,1),                                  &
-         is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-         used = g_send_data(cobalt%id_c14_2_n,        cobalt%c14_2_n,                &
-         model_time, rmask = grid_tmask,                                         &
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-         used = g_send_data(cobalt%id_c14o2_csurf,    cobalt%c14o2_csurf,            &
-         model_time, rmask = grid_tmask(:,:,1),                                  &
-         is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-         used = g_send_data(cobalt%id_c14o2_alpha,    cobalt%c14o2_alpha,            &
-         model_time, rmask = grid_tmask(:,:,1),                                  &
-         is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-         used = g_send_data(cobalt%id_fpo14c,         cobalt%fpo14c,                 &
-         model_time, rmask = grid_tmask,                                         &
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-         used = g_send_data(cobalt%id_j14c_decay_dic, cobalt%j14c_decay_dic*rho_dzt, &
-         model_time, rmask = grid_tmask,                                         &
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-         used = g_send_data(cobalt%id_j14c_decay_doc, cobalt%j14c_decay_doc*rho_dzt, &
-         model_time, rmask = grid_tmask,&
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-         used = g_send_data(cobalt%id_j14c_reminp,    cobalt%j14c_reminp*rho_dzt,    &
-         model_time, rmask = grid_tmask,                                         &
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-         used = g_send_data(cobalt%id_jdi14c,         cobalt%jdi14c*rho_dzt,         &
-         model_time, rmask = grid_tmask,&
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-         used = g_send_data(cobalt%id_jdo14c,         cobalt%jdo14c*rho_dzt,         &
-         model_time, rmask = grid_tmask,                                         &
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-       endif
-!
-! 2D COBALT fields
-!
-       used = g_send_data(cobalt%id_pco2surf,      cobalt%pco2_csurf,           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_pnh3surf,      cobalt%pnh3_csurf,           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_alk,       cobalt%p_alk(:,:,1,tau),         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_cadet_arag,cobalt%p_cadet_arag(:,:,1,tau),  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_cadet_calc,cobalt%p_cadet_calc(:,:,1,tau),  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_dic,       cobalt%p_dic(:,:,1,tau),         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_fed,       cobalt%p_fed(:,:,1,tau),         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_ldon,       cobalt%p_ldon(:,:,1,tau),         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_sldon,       cobalt%p_sldon(:,:,1,tau),         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_srdon,       cobalt%p_srdon(:,:,1,tau),         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_no3,       cobalt%p_no3(:,:,1,tau),         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_nh4,       cobalt%p_nh4(:,:,1,tau),         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_po4,       cobalt%p_po4(:,:,1,tau),         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_sio4,      cobalt%p_sio4(:,:,1,tau),        &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_htotal,    cobalt%f_htotal(:,:,1),          &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_o2,       cobalt%p_o2(:,:,1,tau),           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_chl,       cobalt%f_chl(:,:,1),             &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_irr,      cobalt%irr_inst(:,:,1),        &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_irr_aclm,  cobalt%f_irr_aclm_sfc(:,:,1),       &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_mld_aclm,  cobalt%mld_aclm,       &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_temp,      Temp(:,:,1),                    &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_temp,      cobalt%btm_temp,                &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_temp_old,      cobalt%btm_temp_old,        &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_o2,      cobalt%btm_o2,                &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_o2_old,  cobalt%btm_o2_old,            &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_no3,      cobalt%btm_no3,                &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_alk,      cobalt%btm_alk,                &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_dic,      cobalt%btm_dic,                &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_grid_kmt_diag, cobalt%grid_kmt_diag,                &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_k_bot_diag, cobalt%k_bot_diag,                &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_rho_dzt_bot_diag, cobalt%rho_dzt_bot_diag,    &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_rho_dzt_kmt_diag, cobalt%rho_dzt_kmt_diag,    &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_htotal,      cobalt%btm_htotal,        &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_htotal_old,  cobalt%btm_htotal_old,    &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_cased_2d,      cobalt%cased_2d,                &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_co3_ion, cobalt%f_co3_ion(:,:,1),            &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_co3_sol_arag, cobalt%co3_sol_arag(:,:,1),  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_sfc_co3_sol_calc, cobalt%co3_sol_calc(:,:,1),  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_co3_ion, cobalt%btm_co3_ion,            &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_co3_ion_old, cobalt%btm_co3_ion_old,    &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_co3_sol_arag, cobalt%btm_co3_sol_arag,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_co3_sol_arag_old, cobalt%btm_co3_sol_arag_old,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_co3_sol_calc, cobalt%btm_co3_sol_calc,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_co3_sol_calc_old, cobalt%btm_co3_sol_calc_old,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_omega_calc, cobalt%btm_omega_calc,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_btm_omega_arag, cobalt%btm_omega_arag,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
-
-       do n= 1, NUM_PHYTO
-          used = g_send_data(phyto(n)%id_sfc_f_n, phyto(n)%f_n(:,:,1),            &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_sfc_chl, phyto(n)%chl(:,:,1),      &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_sfc_def_fe, phyto(n)%def_fe(:,:,1),      &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_sfc_felim, phyto(n)%felim(:,:,1),      &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_sfc_irrlim, phyto(n)%irrlim(:,:,1),      &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_sfc_theta, phyto(n)%theta(:,:,1),      &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_sfc_mu, phyto(n)%mu(:,:,1),      &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_sfc_po4lim, phyto(n)%po4lim(:,:,1),      &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_sfc_q_fe_2_n, phyto(n)%q_fe_2_n(:,:,1),      &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_sfc_q_p_2_n, phyto(n)%q_p_2_n(:,:,1),      &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_sfc_nh4lim, phyto(n)%nh4lim(:,:,1),      &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_sfc_no3lim, phyto(n)%no3lim(:,:,1),      &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-     !     used = g_send_data(phyto(n)%id_fn_btm, phyto(n)%fn_btm,      &
-     !     model_time, rmask = grid_tmask(:,:,1),&
-     !     is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-     !     used = g_send_data(phyto(n)%id_fp_btm, phyto(n)%fp_btm,      &
-     !     model_time, rmask = grid_tmask(:,:,1),&
-     !     is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-     !     used = g_send_data(phyto(n)%id_fsi_btm, phyto(n)%fsi_btm,      &
-     !     model_time, rmask = grid_tmask(:,:,1),&
-     !     is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-     !     used = g_send_data(phyto(n)%id_ffe_btm, phyto(n)%ffe_btm,      &
-     !     model_time, rmask = grid_tmask(:,:,1),&
-     !     is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       enddo
-
-!
-! Save river, depositon and bulk elemental fluxes
-!
-       used = g_send_data(cobalt%id_dep_dry_fed, cobalt%dry_fed,                          &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_dep_dry_lith, cobalt%dry_lith,                        &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_dep_dry_nh4, cobalt%dry_nh4,                          &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_dep_dry_no3, cobalt%dry_no3,                          &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_dep_dry_po4, cobalt%dry_po4,                          &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_dep_wet_fed, cobalt%wet_fed,                          &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_dep_wet_lith, cobalt%wet_lith,                        &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_dep_wet_nh4, cobalt%wet_nh4,                          &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_dep_wet_no3, cobalt%wet_no3,                          &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_dep_wet_po4, cobalt%wet_po4,                          &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_runoff_flux_alk, cobalt%runoff_flux_alk,           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_runoff_flux_dic, cobalt%runoff_flux_dic,           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_runoff_flux_di14c, cobalt%runoff_flux_di14c,           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_runoff_flux_fed, cobalt%runoff_flux_fed,           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_runoff_flux_lith, cobalt%runoff_flux_lith,         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_runoff_flux_no3, cobalt%runoff_flux_no3,           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_runoff_flux_ldon, cobalt%runoff_flux_ldon,           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_runoff_flux_sldon, cobalt%runoff_flux_sldon,           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_runoff_flux_srdon, cobalt%runoff_flux_srdon,           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_runoff_flux_ndet, cobalt%runoff_flux_ndet,           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_runoff_flux_pdet, cobalt%runoff_flux_pdet,           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_runoff_flux_po4, cobalt%runoff_flux_po4,           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_runoff_flux_ldop, cobalt%runoff_flux_ldop,           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_runoff_flux_sldop, cobalt%runoff_flux_sldop,           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_runoff_flux_srdop, cobalt%runoff_flux_srdop,           &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-!
-! Save 100m integral fluxes
-!
-       used = g_send_data(cobalt%id_jprod_allphytos_100, cobalt%jprod_allphytos_100,         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_jprod_allphytos_200, cobalt%jprod_allphytos_200,         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_jprod_diat_100, cobalt%jprod_diat_100,         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       do n= 1, NUM_PHYTO  !{
-          used = g_send_data(phyto(n)%id_jprod_n_100, phyto(n)%jprod_n_100,         &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_jprod_n_new_100, phyto(n)%jprod_n_new_100,         &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_jzloss_n_100, phyto(n)%jzloss_n_100,         &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_jexuloss_n_100, phyto(n)%jexuloss_n_100,         &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_jvirloss_n_100, phyto(n)%jvirloss_n_100,         &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_jmortloss_n_100, phyto(n)%jmortloss_n_100,         &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_jaggloss_n_100, phyto(n)%jaggloss_n_100,         &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(phyto(n)%id_f_n_100, phyto(n)%f_n_100,         &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       enddo !} n
-       used = g_send_data(phyto(DIAZO)%id_jprod_n_n2_100, phyto(DIAZO)%jprod_n_n2_100,         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       do n= 1, NUM_ZOO  !{
-          used = g_send_data(zoo(n)%id_jprod_n_100, zoo(n)%jprod_n_100,         &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(zoo(n)%id_jingest_n_100, zoo(n)%jingest_n_100,         &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(zoo(n)%id_jremin_n_100, zoo(n)%jremin_n_100,         &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(zoo(n)%id_f_n_100, zoo(n)%f_n_100,         &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       enddo !} n
-
-       do n= 1,2  !{
-          used = g_send_data(zoo(n)%id_jzloss_n_100, zoo(n)%jzloss_n_100,         &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(zoo(n)%id_jprod_don_100, zoo(n)%jprod_don_100,         &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       enddo !} n
-
-       do n= 2,3  !{
-          used = g_send_data(zoo(n)%id_jhploss_n_100, zoo(n)%jhploss_n_100,         &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(zoo(n)%id_jprod_ndet_100, zoo(n)%jprod_ndet_100,         &
-          model_time, rmask = grid_tmask(:,:,1),&
-          is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       enddo !} n
-
-        used = g_send_data(cobalt%id_hp_jingest_n_100, cobalt%hp_jingest_n_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_hp_jremin_n_100, cobalt%hp_jremin_n_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_hp_jprod_ndet_100, cobalt%hp_jprod_ndet_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(bact(1)%id_jprod_n_100, bact(1)%jprod_n_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(bact(1)%id_jzloss_n_100, bact(1)%jzloss_n_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(bact(1)%id_jvirloss_n_100, bact(1)%jvirloss_n_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(bact(1)%id_jremin_n_100, bact(1)%jremin_n_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(bact(1)%id_juptake_ldon_100, bact(1)%juptake_ldon_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(bact(1)%id_f_n_100, bact(1)%f_n_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_jprod_lithdet_100, cobalt%jprod_lithdet_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_jprod_sidet_100, cobalt%jprod_sidet_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_jprod_cadet_calc_100, cobalt%jprod_cadet_calc_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_jprod_cadet_arag_100, cobalt%jprod_cadet_arag_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_jremin_ndet_100, cobalt%jremin_ndet_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_jprod_mesozoo_200, cobalt%jprod_mesozoo_200,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_daylength, cobalt%daylength,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_f_ndet_100, cobalt%f_ndet_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_f_don_100, cobalt%f_don_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_f_silg_100, cobalt%f_silg_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_f_simd_100, cobalt%f_simd_100,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_f_mesozoo_200, cobalt%f_mesozoo_200,         &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_fndet_100,     cobalt%fndet_100,                &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_fpdet_100,     cobalt%fpdet_100,                &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_fsidet_100,     cobalt%fsidet_100,                &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_flithdet_100,     cobalt%flithdet_100,                &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_fcadet_calc_100,     cobalt%fcadet_calc_100,                &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_fcadet_arag_100,     cobalt%fcadet_arag_100,                &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_ffedet_100,     cobalt%ffedet_100,                &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_fntot_100,     cobalt%fntot_100,                &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_fptot_100,     cobalt%fptot_100,                &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_fsitot_100,     cobalt%fsitot_100,                &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        used = g_send_data(cobalt%id_ffetot_100,     cobalt%ffetot_100,                &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-!
-!---------------------------------------------------------------------
-! Save water column vertical integrals
-!---------------------------------------------------------------------
-!
-!       used = g_send_data(cobalt%id_wc_vert_int_c,    cobalt%wc_vert_int_c,         &
-!       model_time, rmask = grid_tmask(:,:,1),&
-!       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-!       used = g_send_data(cobalt%id_wc_vert_int_dic,    cobalt%wc_vert_int_dic,         &
-!       model_time, rmask = grid_tmask(:,:,1),&
-!       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-!       used = g_send_data(cobalt%id_wc_vert_int_doc,    cobalt%wc_vert_int_doc,         &
-!       model_time, rmask = grid_tmask(:,:,1),&
-!       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-!       used = g_send_data(cobalt%id_wc_vert_int_poc,    cobalt%wc_vert_int_poc,         &
-!       model_time, rmask = grid_tmask(:,:,1),&
-!       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-!       used = g_send_data(cobalt%id_wc_vert_int_n,    cobalt%wc_vert_int_n,         &
-!       model_time, rmask = grid_tmask(:,:,1),&
-!       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-!       used = g_send_data(cobalt%id_wc_vert_int_p,    cobalt%wc_vert_int_p,         &
-!       model_time, rmask = grid_tmask(:,:,1),&
-!       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-!       used = g_send_data(cobalt%id_wc_vert_int_fe,    cobalt%wc_vert_int_fe,         &
-!       model_time, rmask = grid_tmask(:,:,1),&
-!       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-!       used = g_send_data(cobalt%id_wc_vert_int_si,    cobalt%wc_vert_int_si,         &
-!       model_time, rmask = grid_tmask(:,:,1),&
-!       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-!       used = g_send_data(cobalt%id_wc_vert_int_o2,    cobalt%wc_vert_int_o2,         &
-!       model_time, rmask = grid_tmask(:,:,1),&
-!       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-!       used = g_send_data(cobalt%id_wc_vert_int_alk,    cobalt%wc_vert_int_alk,         &
-!       model_time, rmask = grid_tmask(:,:,1),&
-!       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_wc_vert_int_npp,    cobalt%wc_vert_int_npp,         &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_wc_vert_int_jdiss_sidet,    cobalt%wc_vert_int_jdiss_sidet,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_wc_vert_int_jdiss_cadet,    cobalt%wc_vert_int_jdiss_cadet,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_wc_vert_int_jo2resp,    cobalt%wc_vert_int_jo2resp,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_wc_vert_int_jprod_cadet,    cobalt%wc_vert_int_jprod_cadet,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_wc_vert_int_jno3denit,    cobalt%wc_vert_int_jno3denit,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_wc_vert_int_jprod_no3nitrif,    cobalt%wc_vert_int_jprod_no3nitrif,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_wc_vert_int_jnamx,    cobalt%wc_vert_int_jnamx,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_wc_vert_int_juptake_nh4,    cobalt%wc_vert_int_juptake_nh4,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_wc_vert_int_jprod_nh4,    cobalt%wc_vert_int_jprod_nh4,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_wc_vert_int_juptake_no3,    cobalt%wc_vert_int_juptake_no3,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_wc_vert_int_nfix,    cobalt%wc_vert_int_nfix,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_wc_vert_int_jfe_iceberg,    cobalt%wc_vert_int_jfe_iceberg,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_wc_vert_int_jno3_iceberg,    cobalt%wc_vert_int_jno3_iceberg,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_wc_vert_int_jpo4_iceberg,    cobalt%wc_vert_int_jpo4_iceberg,  &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-!
-!---------------------------------------------------------------------
-! Save CaCO3 saturation and O2 minimum depths
-!---------------------------------------------------------------------
-!
-       used = g_send_data(cobalt%id_o2min,         cobalt%o2min,                    &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_z_o2min,    cobalt%z_o2min,                     &
-       model_time, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_z_sat_arag,    cobalt%z_sat_arag,               &
-       model_time, mask = cobalt%mask_z_sat_arag, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-       used = g_send_data(cobalt%id_z_sat_calc,    cobalt%z_sat_calc,               &
-       model_time, mask = cobalt%mask_z_sat_calc, rmask = grid_tmask(:,:,1),&
-       is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-!
-!---------------------------------------------------------------------
-! Send additional diagnostics  jgj 2015/10/26
-!---------------------------------------------------------------------
-!
-       used = g_send_data(cobalt%id_jalk, cobalt%jalk*rho_dzt,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_jalkc, cobalt%jalk,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_jalk_plus_btm, cobalt%jalk_plus_btm*rho_dzt,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_jdic, cobalt%jdic*rho_dzt,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_jdicc, cobalt%jdic,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_jno3c, cobalt%jno3,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_jpo4c, cobalt%jpo4,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_jsio4c, cobalt%jsio4,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_jdic_plus_btm, cobalt%jdic_plus_btm*rho_dzt,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_jnh4, cobalt%jnh4*rho_dzt,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_jndet, cobalt%jndet*rho_dzt,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_jnh4_plus_btm, cobalt%jnh4_plus_btm*rho_dzt,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_jo2_plus_btm, cobalt%jo2_plus_btm*rho_dzt,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_jo2, cobalt%jo2*rho_dzt,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_jo2c, cobalt%jo2,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-!==============================================================================================================
-!  2016/07/05 jgj  send temperature as a test
-
-       used = g_send_data(cobalt%id_thetao,  Temp,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-!==============================================================================================================
-! JGJ 2016/08/08 CMIP6 OcnBgchem Oyr and Omon: 3-D Marine Biogeochemical Tracer Fields
-!
-       used = g_send_data(cobalt%id_dissic,  cobalt%p_dic(:,:,:,tau) * cobalt%Rho_0,           &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! PENDING:
-!        used = g_send_data(cobalt%id_dissicnat,                                                    &
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-!        used = g_send_data(cobalt%id_dissicabio,                                                    &
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-!        used = g_send_data(cobalt%id_dissi14cabio,                                                    &
-!         model_time, rmask = grid_tmask,&
-!         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       ! CAS updated to not include background values in accordance with CMIP results
-       cobalt%dissoc(:,:,:) = cobalt%c_2_n * (cobalt%p_ldon(:,:,:,tau) + cobalt%p_sldon(:,:,:,tau) + &
-                                           cobalt%p_srdon(:,:,:,tau) )
-
-       used = g_send_data(cobalt%id_dissoc,  cobalt%dissoc * cobalt%Rho_0,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_phyc,  (cobalt%p_nlg(:,:,:,tau) + cobalt%p_nsm(:,:,:,tau) +  &
-       cobalt%p_ndi(:,:,:,tau)) * cobalt%c_2_n * cobalt%Rho_0, &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_zooc,  (cobalt%p_nlgz(:,:,:,tau) + cobalt%p_nsmz(:,:,:,tau) +  &
-       cobalt%p_nmdz(:,:,:,tau)) * cobalt%c_2_n * cobalt%Rho_0, &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_bacc,  cobalt%p_nbact(:,:,:,tau) * cobalt%c_2_n * cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_detoc,  cobalt%p_ndet(:,:,:,tau) * cobalt%c_2_n * cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_calc,  cobalt%p_cadet_calc(:,:,:,tau) * cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_arag,  cobalt%p_cadet_arag(:,:,:,tau) * cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_phydiat,  (cobalt%nlg_diatoms + cobalt%nmd_diatoms) * &
-              cobalt%c_2_n * cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_phydiaz,  cobalt%p_ndi(:,:,:,tau) * cobalt%c_2_n * cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_phypico,  cobalt%p_nsm(:,:,:,tau) * cobalt%c_2_n * cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_phymisc,  (cobalt%p_nlg(:,:,:,tau)-cobalt%nlg_diatoms + &
-              cobalt%p_nmd(:,:,:,tau)-cobalt%nmd_diatoms) * cobalt%c_2_n * cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_zmicro,  cobalt%p_nsmz(:,:,:,tau) * cobalt%c_2_n * cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_zmeso,  (cobalt%p_nlgz(:,:,:,tau)+cobalt%p_nmdz(:,:,:,tau)) * cobalt%c_2_n * cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-      used = g_send_data(cobalt%id_talk,  cobalt%p_alk(:,:,:,tau) * cobalt%Rho_0,       &
-      model_time, rmask = grid_tmask,&
-      is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! PENDING:
-!        used = g_send_data(cobalt%id_talknat,
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! CHECK3: this is using ntau=1
-       used = g_send_data(cobalt%id_ph,  log10(cobalt%f_htotal+epsln) * (-1.0),       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! PENDING:
-!        used = g_send_data(cobalt%id_phnat,  log10(cobalt%f_htotal+epsln) * -1.0,       &
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! PENDING:
-!        used = g_send_data(cobalt%id_phabio,  log10(cobalt%f_htotal+epsln) * -1.0,       &
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_o2_cmip,  cobalt%p_o2(:,:,:,tau) * cobalt%Rho_0,   &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_o2sat,  cobalt%o2sat, &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_no3_cmip,  cobalt%p_no3(:,:,:,tau) * cobalt%Rho_0,   &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_nh4_cmip,  cobalt%p_nh4(:,:,:,tau) * cobalt%Rho_0,   &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_po4_cmip,  cobalt%p_po4(:,:,:,tau) * cobalt%Rho_0,   &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_dfe,  cobalt%p_fed(:,:,:,tau) * cobalt%Rho_0,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_si,  cobalt%p_sio4(:,:,:,tau) * cobalt%Rho_0,       &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_chl_cmip,  cobalt%f_chl * cobalt%Rho_0 / 1e9,   &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_chldiat,  (phyto(LARGE)%theta * cobalt%nlg_diatoms + &
-              phyto(MEDIUM)%theta * cobalt%nmd_diatoms) * cobalt%c_2_n * cobalt%Rho_0 * 12e-3,   &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_chldiaz,  phyto(DIAZO)%theta * cobalt%p_ndi(:,:,:,tau) * cobalt%c_2_n * cobalt%Rho_0 * 12e-3,   &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_chlpico,  phyto(SMALL)%theta * cobalt%p_nsm(:,:,:,tau) * cobalt%c_2_n * cobalt%Rho_0 * 12e-3,   &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_chlmisc, (phyto(LARGE)%theta * (cobalt%p_nlg(:,:,:,tau)-cobalt%nlg_diatoms) + phyto(MEDIUM)%theta * (cobalt%p_nmd(:,:,:,tau)-cobalt%nmd_diatoms)) *  &
-       cobalt%c_2_n * cobalt%Rho_0 * 12e-3,   &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_poc,  (cobalt%p_ndi(:,:,:,tau) + cobalt%p_nlg(:,:,:,tau) + &
-       cobalt%p_nmd(:,:,:,tau) + cobalt%p_nsm(:,:,:,tau) + cobalt%p_nbact(:,:,:,tau) +  cobalt%p_ndet(:,:,:,tau) + &
-       cobalt%p_nsmz(:,:,:,tau) + cobalt%p_nmdz(:,:,:,tau) + cobalt%p_nlgz(:,:,:,tau)) * cobalt%Rho_0 * cobalt%c_2_n,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_pon,  (cobalt%p_ndi(:,:,:,tau) + cobalt%p_nlg(:,:,:,tau) + &
-       cobalt%p_nmd(:,:,:,tau) + cobalt%p_nsm(:,:,:,tau) + cobalt%p_nbact(:,:,:,tau) +  cobalt%p_ndet(:,:,:,tau) + &
-       cobalt%p_nsmz(:,:,:,tau) + cobalt%p_nmdz(:,:,:,tau) + cobalt%p_nlgz(:,:,:,tau)) * cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! CAS: added bacteria and more general accomodation of static but different p_2_n ratios
-        used = g_send_data(cobalt%id_pop,  (cobalt%p_pdi(:,:,:,tau) + &
-        cobalt%p_plg(:,:,:,tau) + cobalt%p_pmd(:,:,:,tau) +  cobalt%p_psm(:,:,:,tau) + &
-        cobalt%p_pdet(:,:,:,tau) + zoo(1)%q_p_2_n * cobalt%p_nsmz(:,:,:,tau) + zoo(2)%q_p_2_n * cobalt%p_nmdz(:,:,:,tau) + &
-        zoo(3)%q_p_2_n * cobalt%p_nlgz(:,:,:,tau) + bact(1)%q_p_2_n * cobalt%p_nbact(:,:,:,tau)) * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! CAS: old code, delete once satisfied with new code above
-!    if (cobalt%id_pop .gt. 0)            &
-!        used = g_send_data(cobalt%id_pop,  ((phyto(DIAZO)%p_2_n_static * cobalt%p_ndi(:,:,:,tau)) + cobalt%p_nlg(:,:,:,tau) + &
-!        cobalt%p_nsm(:,:,:,tau) + cobalt%p_nbact(:,:,:,tau) +  cobalt%p_pdet(:,:,:,tau) + &
-!        cobalt%p_nsmz(:,:,:,tau) + cobalt%p_nmdz(:,:,:,tau) + cobalt%p_nlgz(:,:,:,tau)) * cobalt%Rho_0,  &
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_bfe,  (cobalt%p_fedi(:,:,:,tau) + cobalt%p_felg(:,:,:,tau) + &
-              cobalt%p_femd(:,:,:,tau) + cobalt%p_fesm(:,:,:,tau) + &
-       cobalt%p_fedet(:,:,:,tau))  * cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_bsi,  (cobalt%p_silg(:,:,:,tau) + cobalt%p_simd(:,:,:,tau) + &
-              cobalt%p_sidet(:,:,:,tau))  * cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_phyn,  (cobalt%p_nlg(:,:,:,tau) + cobalt%p_nmd(:,:,:,tau) +  &
-       cobalt%p_nsm(:,:,:,tau) + cobalt%p_ndi(:,:,:,tau)) * cobalt%Rho_0, &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! CAS: added p_2_n ratios for other phyto groups
-       used = g_send_data(cobalt%id_phyp,  (cobalt%p_pdi(:,:,:,tau) + &
-       cobalt%p_plg(:,:,:,tau) + cobalt%p_pmd(:,:,:,tau) + cobalt%p_psm(:,:,:,tau) )* &
-       cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! CAS: added p_2_n ratios for other phyto groups
-!        used = g_send_data(cobalt%id_phyp,  (phyto(DIAZO)%p_2_n_static * cobalt%p_ndi(:,:,:,tau) + &
-!        phyto(LARGE)%p_2_n_static * cobalt%p_nlg(:,:,:,tau) + phyto(MEDIUM)%p_2_n_static * cobalt%p_nmd(:,:,:,tau) + &
-!        phyto(SMALL)%p_2_n_static * cobalt%p_nsm(:,:,:,tau) )* &
-!        cobalt%Rho_0,  &
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_phyfe,  (cobalt%p_fedi(:,:,:,tau) + cobalt%p_felg(:,:,:,tau) +  &
-       cobalt%p_femd(:,:,:,tau) + cobalt%p_fesm(:,:,:,tau)) * cobalt%Rho_0, &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_physi,  (cobalt%p_silg(:,:,:,tau) + cobalt%p_simd(:,:,:,tau)) * &
-              cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_co3,  cobalt%f_co3_ion * cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! PENDING:
-!        used = g_send_data(cobalt%id_co3nat,  cobalt%f_co3_ion * cobalt%Rho_0,  &
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! PENDING:
-!        used = g_send_data(cobalt%id_co3abio,  cobalt%f_co3_ion * cobalt%Rho_0,  &
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_co3satcalc,  cobalt%co3_sol_calc * cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-       used = g_send_data(cobalt%id_co3satarag,  cobalt%co3_sol_arag * cobalt%Rho_0,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-!==============================================================================================================
-! JGJ 2016/08/08 CMIP6 OcnBgchem Oyr: Marine Biogeochemical 3-D Fields: Rates of Production and Removal
-!
-! CHECK3: using dzt for layer thickness
-! Maybe just use cobalt%Rho_0 instead of rho_dzt / dzt in production terms
-!
-! also in Omon
-       used = g_send_data(cobalt%id_pp,  (phyto(DIAZO)%jprod_n +  phyto(LARGE)%jprod_n +  &
-       phyto(MEDIUM)%jprod_n + phyto(SMALL)%jprod_n) * rho_dzt * cobalt%c_2_n / dzt,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! also in Omon
-       used = g_send_data(cobalt%id_pnitrate,  (phyto(DIAZO)%juptake_no3 +  phyto(LARGE)%juptake_no3 +  &
-       phyto(MEDIUM)%juptake_no3 + phyto(SMALL)%juptake_no3) * rho_dzt * cobalt%c_2_n / dzt,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! Not requested
-!        used = g_send_data(cobalt%id_pphosphate,  (phyto(DIAZO)%juptake_po4 +  phyto(LARGE)%juptake_po4 +  &
-!        phyto(SMALL)%juptake_po4) * rho_dzt * cobalt%c_2_n / dzt,  &
-!        model_time, rmask = grid_tmask,&
-!        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! also in Omon
-       used = g_send_data(cobalt%id_pbfe,  (phyto(DIAZO)%juptake_fe +  phyto(LARGE)%juptake_fe +  &
-       phyto(MEDIUM)%juptake_fe + phyto(SMALL)%juptake_fe) * rho_dzt / dzt,  &
-       model_time, rmask = grid_tmask,&
-       is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! also in Omon
-        used = g_send_data(cobalt%id_pbsi,  (phyto(LARGE)%juptake_sio4 + phyto(MEDIUM)%juptake_sio4) * &
-               rho_dzt / dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-        used = g_send_data(cobalt%id_pcalc,  cobalt%jprod_cadet_calc * rho_dzt / dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-        used = g_send_data(cobalt%id_parag,  cobalt%jprod_cadet_arag * rho_dzt / dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! also in Omon
-        used = g_send_data(cobalt%id_expc, (cobalt%p_ndet(:,:,:,tau)*cobalt%wsink +  &
-         cobalt%p_nsm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + &
-         cobalt%p_nmd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
-         cobalt%p_nlg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + &
-         cobalt%p_ndi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:))* &
-         cobalt%c_2_n*cobalt%Rho_0*grid_tmask(:,:,:), &
-         model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-         used = g_send_data(cobalt%id_expn, &
-         (cobalt%p_ndet(:,:,:,tau)*cobalt%wsink +  &
-         cobalt%p_nsm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + &
-         cobalt%p_nmd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
-         cobalt%p_nlg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + &
-         cobalt%p_ndi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:))* &
-         cobalt%Rho_0*grid_tmask(:,:,:), &
-         model_time, rmask = grid_tmask,&
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-        used = g_send_data(cobalt%id_expp, &
-         (cobalt%p_pdet(:,:,:,tau)*cobalt%wsink +  &
-         cobalt%p_psm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + &
-         cobalt%p_pmd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
-         cobalt%p_plg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + &
-         cobalt%p_pdi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:))* &
-         cobalt%Rho_0*grid_tmask(:,:,:), &
-         model_time, rmask = grid_tmask,&
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-        used = g_send_data(cobalt%id_expfe, &
-         (cobalt%p_fedet(:,:,:,tau)*cobalt%wsink +  &
-         cobalt%p_fesm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + &
-         cobalt%p_femd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
-         cobalt%p_felg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + &
-         cobalt%p_fedi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:))* &
-         cobalt%Rho_0*grid_tmask(:,:,:), &
-         model_time, rmask = grid_tmask,&
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-        used = g_send_data(cobalt%id_expsi, &
-         (cobalt%p_sidet(:,:,:,tau)*cobalt%wsink +  &
-         cobalt%p_simd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
-         cobalt%p_silg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:))* &
-         cobalt%Rho_0*grid_tmask(:,:,:), &
-         model_time, rmask = grid_tmask,&
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-        used = g_send_data(cobalt%id_expcalc,  cobalt%p_cadet_calc(:,:,:,tau) * cobalt%Rho_0 * cobalt%wsink,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-        used = g_send_data(cobalt%id_exparag,  cobalt%p_cadet_arag(:,:,:,tau) * cobalt%Rho_0 * cobalt%wsink,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! CAS: added jprod_nh4_plus_btm to calculate
-        used = g_send_data(cobalt%id_remoc,  cobalt%jprod_nh4_plus_btm*cobalt%c_2_n*cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! CAS: added redissolution from sediment
-        used = g_send_data(cobalt%id_dcalc,  cobalt%jdiss_cadet_calc_plus_btm*cobalt%Rho_0, &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! CAS: added redissolution from sediment
-        used = g_send_data(cobalt%id_darag,  cobalt%jdiss_cadet_arag_plus_btm*cobalt%Rho_0, &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! CAS: fixed unit conversion on production from all groups by adding *rho_dzt,
-        used = g_send_data(cobalt%id_ppdiat,  (phyto(LARGE)%jprod_n * phyto(LARGE)%silim + &
-               phyto(MEDIUM)%jprod_n * phyto(MEDIUM)%silim) * rho_dzt * cobalt%c_2_n / dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-        used = g_send_data(cobalt%id_ppdiaz,  phyto(DIAZO)%jprod_n * rho_dzt * cobalt%c_2_n / dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-        used = g_send_data(cobalt%id_pppico,  phyto(SMALL)%jprod_n * rho_dzt * cobalt%c_2_n / dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-        used = g_send_data(cobalt%id_ppmisc, ((phyto(LARGE)%jprod_n * (1.0 - phyto(LARGE)%silim)) + &
-               (phyto(MEDIUM)%jprod_n * (1.0 - phyto(MEDIUM)%silim))) * rho_dzt * cobalt%c_2_n / dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! CHECK3 _z regridding
-! CAS fixed conversion for all bddt terms
-        used = g_send_data(cobalt%id_bddtdic,  cobalt%jdic_plus_btm * rho_dzt / dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-        used = g_send_data(cobalt%id_bddtdin,  cobalt%jdin_plus_btm * rho_dzt / dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-        used = g_send_data(cobalt%id_bddtdip,  cobalt%jpo4_plus_btm * rho_dzt / dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-        used = g_send_data(cobalt%id_bddtdife,  cobalt%jfed_plus_btm * rho_dzt / dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-        used = g_send_data(cobalt%id_bddtdisi,  cobalt%jsio4_plus_btm * rho_dzt / dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-        used = g_send_data(cobalt%id_bddtalk,  cobalt%jalk_plus_btm * rho_dzt / dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! CAS: fixed conversion
-        used = g_send_data(cobalt%id_fescav,  cobalt%jfe_ads * rho_dzt / dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! CAS: fixed conversion
-        used = g_send_data(cobalt%id_fediss,  cobalt%jremin_fedet * rho_dzt / dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-! also in Omon
-! CAS: fixed conversion
-        used = g_send_data(cobalt%id_graz,  (phyto(DIAZO)%jzloss_n +  phyto(LARGE)%jzloss_n +  &
-        phyto(SMALL)%jzloss_n) * cobalt%c_2_n  * rho_dzt / dzt,  &
-        model_time, rmask = grid_tmask,&
-        is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
-!==============================================================================================================
-! JGJ 2016/08/08 CMIP6 OcnBgchem Omon: Marine Biogeochemical 2-D Surface Fields
-!  Identical to Oyr 3-D Tracer fields but for surface only
-
-        used = g_send_data(cobalt%id_dissicos,  cobalt%p_dic(:,:,1,tau) * cobalt%Rho_0,           &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! PENDING:
-!        used = g_send_data(cobalt%id_dissicnatos,                                                    &
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-!        used = g_send_data(cobalt%id_dissicabioos,                                                    &
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-!        used = g_send_data(cobalt%id_dissi14cabioos,                                                    &
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_dissocos,  cobalt%dissoc(:,:,1) * cobalt%Rho_0,       &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_phycos,  (cobalt%p_nlg(:,:,1,tau) + cobalt%p_nmd(:,:,1,tau) +  &
-        cobalt%p_nsm(:,:,1,tau) + cobalt%p_ndi(:,:,1,tau)) * cobalt%c_2_n * cobalt%Rho_0, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_zoocos,  (cobalt%p_nlgz(:,:,1,tau) + cobalt%p_nsmz(:,:,1,tau) +  &
-        cobalt%p_nmdz(:,:,1,tau)) * cobalt%c_2_n * cobalt%Rho_0, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_baccos,  cobalt%p_nbact(:,:,1,tau) * cobalt%c_2_n * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_detocos,  cobalt%p_ndet(:,:,1,tau) * cobalt%c_2_n * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_calcos,  cobalt%p_cadet_calc(:,:,1,tau) * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_aragos,  cobalt%p_cadet_arag(:,:,1,tau) * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_phydiatos,  (cobalt%nlg_diatoms(:,:,1) + cobalt%nmd_diatoms(:,:,1)) * &
-               cobalt%c_2_n * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_phydiazos,  cobalt%p_ndi(:,:,1,tau) * cobalt%c_2_n * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_phypicoos,  cobalt%p_nsm(:,:,1,tau) * cobalt%c_2_n * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_phymiscos,  ((cobalt%p_nlg(:,:,1,tau)-cobalt%nlg_diatoms(:,:,1)) + &
-               (cobalt%p_nmd(:,:,1,tau)-cobalt%nmd_diatoms(:,:,1))) * cobalt%c_2_n * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_zmicroos,  cobalt%p_nsmz(:,:,1,tau) * cobalt%c_2_n * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_zmesoos,  (cobalt%p_nlgz(:,:,1,tau)+cobalt%p_nmdz(:,:,1,tau)) * cobalt%c_2_n * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_talkos,  cobalt%p_alk(:,:,1,tau) * cobalt%Rho_0,       &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! PENDING:
-!        used = g_send_data(cobalt%id_talknatos,
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CHECK3: this is using ntau=1
-        used = g_send_data(cobalt%id_phos,  log10(cobalt%f_htotal(:,:,1)+epsln) * (-1.0),       &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! PENDING:
-!        used = g_send_data(cobalt%id_phnatos,  log10(cobalt%f_htotal(:,:,1)+epsln) * -1.0,       &
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! PENDING:
-!        used = g_send_data(cobalt%id_phabioos,  log10(cobalt%f_htotal(:,:,1)+epsln) * -1.0,       &
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_o2os,  cobalt%p_o2(:,:,1,tau) * cobalt%Rho_0,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_o2satos,  cobalt%o2sat(:,:,1), &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_no3os,  cobalt%p_no3(:,:,1,tau) * cobalt%Rho_0,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_nh4os,  cobalt%p_nh4(:,:,1,tau) * cobalt%Rho_0,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_po4os,  cobalt%p_po4(:,:,1,tau) * cobalt%Rho_0,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_dfeos,  cobalt%p_fed(:,:,1,tau) * cobalt%Rho_0,       &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_sios,  cobalt%p_sio4(:,:,1,tau) * cobalt%Rho_0,       &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_chlos,  cobalt%f_chl(:,:,1) * cobalt%Rho_0 / 1e9,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_chldiatos,  (phyto(LARGE)%theta(:,:,1) * cobalt%nlg_diatoms(:,:,1) + &
-        phyto(MEDIUM)%theta(:,:,1) * cobalt%nmd_diatoms(:,:,1)) * cobalt%c_2_n * cobalt%Rho_0 * 12e3,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_chldiazos,  phyto(DIAZO)%theta(:,:,1) * cobalt%p_ndi(:,:,1,tau) * cobalt%c_2_n * cobalt%Rho_0 * 12e3,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_chlpicoos,  phyto(SMALL)%theta(:,:,1) * cobalt%p_nsm(:,:,1,tau) * cobalt%c_2_n * cobalt%Rho_0 * 12e3,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_chlmiscos,  (phyto(LARGE)%theta(:,:,1) * (cobalt%p_nlg(:,:,1,tau)-cobalt%nlg_diatoms(:,:,1)) + &
-        phyto(MEDIUM)%theta(:,:,1) * (cobalt%p_nmd(:,:,1,tau)-cobalt%nmd_diatoms(:,:,1))) * &
-        cobalt%c_2_n * cobalt%Rho_0 * 12e3,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_ponos,  (cobalt%p_ndi(:,:,1,tau) + cobalt%p_nlg(:,:,1,tau) + &
-        cobalt%p_nmd(:,:,1,tau) + cobalt%p_nsm(:,:,1,tau) + cobalt%p_nbact(:,:,1,tau) +  cobalt%p_ndet(:,:,1,tau) + &
-        cobalt%p_nsmz(:,:,1,tau) + cobalt%p_nmdz(:,:,1,tau) + cobalt%p_nlgz(:,:,1,tau)) * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_popos,  (cobalt%p_pdi(:,:,1,tau) + &
-        cobalt%p_plg(:,:,1,tau) + cobalt%p_pmd(:,:,1,tau) + cobalt%p_psm(:,:,1,tau) + &
-        bact(1)%q_p_2_n*cobalt%p_nbact(:,:,1,tau) +  cobalt%p_pdet(:,:,1,tau) + &
-        zoo(1)%q_p_2_n*cobalt%p_nsmz(:,:,1,tau) + zoo(2)%q_p_2_n*cobalt%p_nmdz(:,:,1,tau) + &
-        zoo(3)%q_p_2_n*cobalt%p_nlgz(:,:,1,tau)) * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-!        used = g_send_data(cobalt%id_popos,  ((phyto(DIAZO)%p_2_n_static * cobalt%p_ndi(:,:,1,tau)) + &
-!        phyto(LARGE)%p_2_n_static*cobalt%p_nlg(:,:,1,tau) + &
-!        phyto(MEDIUM)%p_2_n_static*cobalt%p_nmd(:,:,1,tau) + &
-!        phyto(SMALL)%p_2_n_static*cobalt%p_nsm(:,:,1,tau) + &
-!        bact(1)%q_p_2_n*cobalt%p_nbact(:,:,1,tau) +  cobalt%p_pdet(:,:,1,tau) + &
-!        zoo(1)%q_p_2_n*cobalt%p_nsmz(:,:,1,tau) + zoo(2)%q_p_2_n*cobalt%p_nmdz(:,:,1,tau) + &
-!        zoo(3)%q_p_2_n*cobalt%p_nlgz(:,:,1,tau)) * cobalt%Rho_0,  &
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_bfeos,  (cobalt%p_fedi(:,:,1,tau) + cobalt%p_felg(:,:,1,tau) + &
-        cobalt%p_femd(:,:,1,tau) + cobalt%p_fesm(:,:,1,tau) + &
-        cobalt%p_fedet(:,:,1,tau))  * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_bsios,  (cobalt%p_silg(:,:,1,tau) + cobalt%p_simd(:,:,1,tau) + &
-        cobalt%p_sidet(:,:,1,tau))  * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_phynos,  (cobalt%p_nlg(:,:,1,tau) + cobalt%p_nmd(:,:,1,tau) +  &
-        cobalt%p_nsm(:,:,1,tau) + cobalt%p_ndi(:,:,1,tau)) * cobalt%Rho_0, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_phypos,  (cobalt%p_pdi(:,:,1,tau) + &
-        cobalt%p_plg(:,:,1,tau) + cobalt%p_pmd(:,:,1,tau) + cobalt%p_psm(:,:,1,tau)) * &
-        cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-!        used = g_send_data(cobalt%id_phypos,  (phyto(DIAZO)%p_2_n_static*cobalt%p_ndi(:,:,1,tau) + &
-!        phyto(LARGE)%p_2_n_static*cobalt%p_nlg(:,:,1,tau) + &
-!        phyto(MEDIUM)%p_2_n_static*cobalt%p_nmd(:,:,1,tau) + &
-!        phyto(SMALL)%p_2_n_static*cobalt%p_nsm(:,:,1,tau))*cobalt%Rho_0,  &
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_phyfeos,  (cobalt%p_fedi(:,:,1,tau) + cobalt%p_felg(:,:,1,tau) +  &
-        cobalt%p_femd(:,:,1,tau) + cobalt%p_fesm(:,:,1,tau)) * cobalt%Rho_0, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_physios, (cobalt%p_silg(:,:,1,tau) + cobalt%p_simd(:,:,1,tau)) * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_co3os,  cobalt%f_co3_ion(:,:,1) * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-         used = g_send_data(cobalt%id_co3natos,  cobalt%f_co3_ion(:,:,1) * cobalt%Rho_0,  &
-         model_time, rmask = grid_tmask(:,:,1),&
-         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-         used = g_send_data(cobalt%id_co3abioos,  cobalt%f_co3_ion(:,:,1) * cobalt%Rho_0,  &
-         model_time, rmask = grid_tmask(:,:,1),&
-         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_co3satcalcos,  cobalt%co3_sol_calc(:,:,1) * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_co3sataragos,  cobalt%co3_sol_arag(:,:,1) * cobalt%Rho_0,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-
-!==============================================================================================================
-! JGJ 2016/08/08 CMIP6 OcnBgchem Omon: 3-D Marine Biogeochemical 3-D Fields
-! Tracers and rates above
-! Limitation terms below
-! 2018/07/18 changed to 2d terms
-!
-        used = g_send_data(cobalt%id_limndiat,  phyto(LARGE)%nlim_bw_100, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CAS, JGJ: not outputting/serving limndiaz because diazotrophs are not N limited
-!        used = g_send_data(cobalt%id_limndiaz,  phyto(DIAZO)%nlim_bw_100, &
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_limnpico,  phyto(SMALL)%nlim_bw_100, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_limnmisc,  phyto(LARGE)%nlim_bw_100, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_limirrdiat,  phyto(LARGE)%irrlim_bw_100,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_limirrdiaz,  phyto(DIAZO)%irrlim_bw_100,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_limirrpico,  phyto(SMALL)%irrlim_bw_100,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_limirrmisc,  phyto(LARGE)%irrlim_bw_100,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_limfediat,  phyto(LARGE)%def_fe_bw_100,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_limfediaz,  phyto(DIAZO)%def_fe_bw_100,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_limfepico,  phyto(SMALL)%def_fe_bw_100,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_limfemisc,  phyto(LARGE)%def_fe_bw_100,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_limpdiat,  phyto(LARGE)%plim_bw_100, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_limpdiaz,  phyto(DIAZO)%plim_bw_100, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_limppico,  phyto(SMALL)%plim_bw_100, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_limpmisc,  phyto(LARGE)%plim_bw_100, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-!==============================================================================================================
-! JGJ 2016/08/08 CMIP6 OcnBgchem Omon: Marine Biogeochemical 2-D Fields
-
-        used = g_send_data(cobalt%id_intpp,  cobalt%jprod_allphytos_100 * cobalt%c_2_n, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_intppnitrate,  (phyto(DIAZO)%jprod_n_new_100 +  phyto(LARGE)%jprod_n_new_100 +  &
-        phyto(SMALL)%jprod_n_new_100) * cobalt%c_2_n,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_intppdiat,  cobalt%jprod_diat_100 * cobalt%c_2_n,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_intppdiaz,  phyto(DIAZO)%jprod_n_100 * cobalt%c_2_n,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_intpppico,  phyto(SMALL)%jprod_n_100 * cobalt%c_2_n,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CAS: can now use jprod_diat_100 to back out misc production
-        used = g_send_data(cobalt%id_intppmisc,  (phyto(LARGE)%jprod_n_100 + phyto(MEDIUM)%jprod_n_100 - &
-        cobalt%jprod_diat_100)  * cobalt%c_2_n,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CAS: I think this is fine
-        used = g_send_data(cobalt%id_intpbn,  cobalt%jprod_allphytos_100, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CAS: I've added juptake_po4_100 in a manner analagous to iron below
-        used = g_send_data(cobalt%id_intpbp, (phyto(DIAZO)%juptake_po4_100 +  phyto(LARGE)%juptake_po4_100 +  &
-        phyto(MEDIUM)%juptake_po4_100 + phyto(SMALL)%juptake_po4_100),  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_intpbfe,  (phyto(DIAZO)%juptake_fe_100 +  phyto(LARGE)%juptake_fe_100 +  &
-        phyto(MEDIUM)%juptake_fe_100 + phyto(SMALL)%juptake_fe_100),  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_intpbsi,  phyto(LARGE)%juptake_sio4_100, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_intpcalcite,  cobalt%jprod_cadet_calc_100, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_intparag,  cobalt%jprod_cadet_arag_100, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CHECK3: should be AT 100m
-        used = g_send_data(cobalt%id_epc100,  cobalt%fndet_100 * cobalt%c_2_n,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CHECK3: should be AT 100m
-        used = g_send_data(cobalt%id_epn100,  cobalt%fndet_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CHECK3: should be AT 100m
-        used = g_send_data(cobalt%id_epp100,  cobalt%fpdet_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CHECK3: should be AT 100m
-        used = g_send_data(cobalt%id_epfe100,  cobalt%ffedet_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CHECK3: should be AT 100m
-        used = g_send_data(cobalt%id_epsi100,  cobalt%fsidet_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CHECK3: should be AT 100m
-        used = g_send_data(cobalt%id_epcalc100,  cobalt%fcadet_calc_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CHECK3: should be AT 100m
-        used = g_send_data(cobalt%id_eparag100,  cobalt%fcadet_arag_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_intdic,  cobalt%wc_vert_int_dic*12e-3,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_intdoc,  cobalt%wc_vert_int_doc*12e-3,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_intpoc,  cobalt%wc_vert_int_poc*12e-3,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_spco2,  cobalt%pco2_csurf * 0.1013,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! PENDING:
-!        used = g_send_data(cobalt%id_spco2nat,  cobalt%pco2_csurf * 0.1013,   &
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! PENDING:
-!        used = g_send_data(cobalt%id_spco2abio,  cobalt%pco2_csurf * 0.1013,   &
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CHECK3:
-        used = g_send_data(cobalt%id_dpco2,  cobalt%deltap_dic * 0.1013,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! PENDING:
-!        used = g_send_data(cobalt%id_dpco2nat,  cobalt%dic_deltap * 0.1013,   &
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! PENDING:
-!        used = g_send_data(cobalt%id_dpco2abio,  cobalt%dic_deltap * 0.1013,   &
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_dpo2,  cobalt%deltap_o2 * 0.1013,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_fgco2,  cobalt%stf_gas_dic * 12e-3,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! PENDING:
-!        used = g_send_data(cobalt%id_fgco2nat,
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-!        used = g_send_data(cobalt%id_fgco2abio,
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-!        used = g_send_data(cobalt%id_fg14co2abio,
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_fgo2,  cobalt%stf_gas_o2,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CAS: Updated on 3/9/2021 to include sediment dissolution based on variable long name, also added
-!      aragonite flux to the sediment (which is instantaneously redissolved)
-        used = g_send_data(cobalt%id_icfriver,  cobalt%runoff_flux_dic + cobalt%fcased_redis + &
-        cobalt%fcadet_arag_btm,model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CAS: Updated on 3/9/2021 to exclude calcite dissolution but include the aragonite flux to
-!      the bottom
-        used = g_send_data(cobalt%id_fric,  cobalt%fcadet_calc_btm + cobalt%fcadet_arag_btm,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CAS: variable includes release from sediment, but there is no organic carbon release from
-!      sediment in COBALT
-        used = g_send_data(cobalt%id_ocfriver, cobalt%c_2_n* &
-        (cobalt%runoff_flux_ldon+cobalt%runoff_flux_sldon+cobalt%runoff_flux_srdon),&
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CAS: Updated on 3/9/2021 to reflect that the total loss of organic carbon at sediments is
-!      equal to the total flux, not just the burial
-        used = g_send_data(cobalt%id_froc,cobalt%c_2_n*cobalt%fndet_btm, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_intpn2,  cobalt%wc_vert_int_nfix,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CAS: Updated on 3/9/2021 to include nh4 deposition and riverine fluxes of organic nitrogen
-        used = g_send_data(cobalt%id_fsn,  cobalt%runoff_flux_no3 + cobalt%dry_no3 + cobalt%wet_no3 + &
-        cobalt%dry_nh4 + cobalt%wet_nh4 + cobalt%runoff_flux_ldon + cobalt%runoff_flux_sldon + &
-        cobalt%runoff_flux_srdon + cobalt%wc_vert_int_nfix,  &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! JYL: Updated on 3/21/2021 to include anammox
-        used = g_send_data(cobalt%id_frn,  cobalt%fno3denit_sed + cobalt%wc_vert_int_jno3denit + &
-        cobalt%wc_vert_int_jnamx + cobalt%fn_burial, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! CAS: Updated on 3/9/2021 to include ffe_iceberg
-        used = g_send_data(cobalt%id_fsfe,  cobalt%runoff_flux_fed + cobalt%dry_fed + cobalt%wet_fed + &
-        cobalt%ffe_sed+cobalt%ffe_geotherm+cobalt%ffe_iceberg, &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_frfe,  cobalt%ffedet_btm,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! revise calculation if providing to CMIP6
-! 2016/08/15 - we will not be providing o2min, zo2min
-!        used = g_send_data(cobalt%id_o2min,  cobalt%o2min,   &
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-!        used = g_send_data(cobalt%id_zo2min,  cobalt%zo2min,   &
-!        model_time, rmask = grid_tmask(:,:,1),&
-!        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-! 2016/08/15 - we will not be providing zsatcalc, zsatarag
-        used = g_send_data(cobalt%id_zsatcalc,  cobalt%z_sat_calc,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_zsatarag,  cobalt%z_sat_arag,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !
+          ! Note: All 3D rates have been changed from layer integrals to moles kg sec-1 to be more conistent with MOM6
+          ! diagnostic approaches.  Layer integrals were used in MOM4/5 to facilitate the integration of fluxes over
+          ! layers in a z/z* coordinate.  Fluxes are rarely saved in native coordinates for MOM6, however, and they
+          ! vary with time, making he layer integrals difficult to interpret and interpolate.  Saving in rates in
+          ! native units avoids this issue.
+          !
+
+          !
+          ! Send phytoplankton diagnostic data
+          !
+          do n= 1, NUM_PHYTO
+            used = g_send_data(phyto(n)%id_P_C_max, phyto(n)%P_C_max, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_alpha, phyto(n)%alpha, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_bresp, phyto(n)%bresp, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_def_fe, phyto(n)%def_fe, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_felim, phyto(n)%felim, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_irrlim, phyto(n)%irrlim, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jzloss_n, phyto(n)%jzloss_n, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jaggloss_n, phyto(n)%jaggloss_n, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jvirloss_n, phyto(n)%jvirloss_n, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jmortloss_n, phyto(n)%jmortloss_n, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jexuloss_n, phyto(n)%jexuloss_n, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_juptake_fe, phyto(n)%juptake_fe, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_juptake_nh4, phyto(n)%juptake_nh4, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_juptake_no3, phyto(n)%juptake_no3, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_juptake_po4, phyto(n)%juptake_po4,   &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jprod_n, phyto(n)%jprod_n, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_liebig_lim,phyto(n)%liebig_lim, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_mu, phyto(n)%mu, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_nh4lim, phyto(n)%nh4lim, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_no3lim, phyto(n)%no3lim, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_po4lim, phyto(n)%po4lim, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_o2lim, phyto(n)%o2lim, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_q_fe_2_n, phyto(n)%q_fe_2_n, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_q_p_2_n, phyto(n)%q_p_2_n, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_silim, phyto(n)%silim, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_q_si_2_n, phyto(n)%q_si_2_n, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_theta, phyto(n)%theta, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_chl, phyto(n)%chl, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_f_mu_mem, phyto(n)%f_mu_mem, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_mu_mix, phyto(n)%mu_mix, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_stress_fac, phyto(n)%stress_fac, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            ! Applied at lower interface
+            used = g_send_data(phyto(n)%id_vmove, phyto(n)%vmove, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          enddo
+
+          do n=2,3
+            used = g_send_data(phyto(n)%id_juptake_sio4, phyto(n)%juptake_sio4, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          enddo 
+
+          used = g_send_data(phyto(DIAZO)%id_juptake_n2, phyto(DIAZO)%juptake_n2,   &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+
+          !
+          ! Send bacterial uptake, production and limitation diagnostic data
+          !
+          used = g_send_data(bact(1)%id_jzloss_n, bact(1)%jzloss_n, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(bact(1)%id_jvirloss_n, bact(1)%jvirloss_n, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(bact(1)%id_juptake_ldon, bact(1)%juptake_ldon, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(bact(1)%id_juptake_ldop, bact(1)%juptake_ldop, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(bact(1)%id_jprod_nh4, bact(1)%jprod_nh4, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(bact(1)%id_jprod_po4, bact(1)%jprod_po4, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(bact(1)%id_jprod_n, bact(1)%jprod_n, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(bact(1)%id_o2lim, bact(1)%o2lim, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(bact(1)%id_ldonlim, bact(1)%ldonlim, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(bact(1)%id_temp_lim, bact(1)%temp_lim, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+
+          !
+          ! Send zooplankton ingestion, production and limitation diagnostic data
+          !
+          do n= 1, NUM_ZOO
+            used = g_send_data(zoo(n)%id_jzloss_n, zoo(n)%jzloss_n, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jhploss_n, zoo(n)%jhploss_n, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jingest_n, zoo(n)%jingest_n, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jingest_p, zoo(n)%jingest_p, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jingest_sio2, zoo(n)%jingest_sio2, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jingest_fe, zoo(n)%jingest_fe, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jprod_ndet, zoo(n)%jprod_ndet, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jprod_pdet, zoo(n)%jprod_pdet, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jprod_ldon, zoo(n)%jprod_ldon, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jprod_ldop, zoo(n)%jprod_ldop, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jprod_sldon, zoo(n)%jprod_sldon, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jprod_sldop, zoo(n)%jprod_sldop, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jprod_srdon, zoo(n)%jprod_srdon, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jprod_srdop, zoo(n)%jprod_srdop, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jprod_fed,  zoo(n)%jprod_fed, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jprod_fedet, zoo(n)%jprod_fedet, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jprod_sidet, zoo(n)%jprod_sidet, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jprod_sio4, zoo(n)%jprod_sio4, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jprod_po4,  zoo(n)%jprod_po4, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jprod_nh4,  zoo(n)%jprod_nh4, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_jprod_n, zoo(n)%jprod_n, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_o2lim, zoo(n)%o2lim, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(zoo(n)%id_temp_lim, zoo(n)%temp_lim, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          enddo
+
+          !
+          ! General COBALT Production diagnostics (not specific to phytoplankton, zooplankton or bacteria)
+          !
+          used = g_send_data(cobalt%id_jprod_cadet_arag, cobalt%jprod_cadet_arag, &
+            model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_cadet_calc, cobalt%jprod_cadet_calc, &
+            model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_ndet, cobalt%jprod_ndet, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_pdet, cobalt%jprod_pdet, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_srdon, cobalt%jprod_srdon, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_sldon, cobalt%jprod_sldon, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_ldon, cobalt%jprod_ldon, &
+            model_time, rmask = grid_tmask,is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_srdop, cobalt%jprod_srdop, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_sldop, cobalt%jprod_sldop, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_ldop, cobalt%jprod_ldop, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_nh4, cobalt%jprod_nh4, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_nh4_plus_btm, cobalt%jprod_nh4_plus_btm, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_po4, cobalt%jprod_po4, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_fed, cobalt%jprod_fed, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_fedet,  cobalt%jprod_fedet, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_sidet, cobalt%jprod_sidet, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_sio4, cobalt%jprod_sio4, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_lithdet, cobalt%jprod_lithdet, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jdiss_cadet_arag, cobalt%jdiss_cadet_arag, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jdiss_cadet_calc, cobalt%jdiss_cadet_calc, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jdiss_sidet, cobalt%jdiss_sidet, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jremin_ndet, cobalt%jremin_ndet, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jremin_pdet, cobalt%jremin_pdet, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jremin_fedet, cobalt%jremin_fedet, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jfed, cobalt%jfed, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jfe_ads, cobalt%jfe_ads, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! Additional iron scavenging diagnostics aligned with adsorption to help understand rates
+          used = g_send_data(cobalt%id_kfe_eq_lig, log10(cobalt%kfe_eq_lig+epsln), &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_feprime, cobalt%feprime, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_ligand, cobalt%ligand, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_fe_sol, cobalt%fe_sol, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jfe_coast, cobalt%jfe_coast, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jfe_iceberg, cobalt%jfe_iceberg, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jno3_iceberg, cobalt%jno3_iceberg, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jpo4_iceberg, cobalt%jpo4_iceberg, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jno3denit_wc,  cobalt%jno3denit_wc, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_juptake_nh4amx, cobalt%juptake_nh4amx, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_juptake_no3amx, cobalt%juptake_no3amx, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jo2resp_wc,  cobalt%jo2resp_wc, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jprod_no3nitrif, cobalt%jprod_no3nitrif,       &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_juptake_nh4nitrif, cobalt%juptake_nh4nitrif,       &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jnamx, cobalt%jnamx, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          !
+          ! Other general COBALT limitation and forcing terms
+          !
+          used = g_send_data(cobalt%id_expkT, cobalt%expkT, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_expkreminT, cobalt%expkreminT, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_hp_o2lim, cobalt%hp_o2lim, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_hp_temp_lim, cobalt%hp_temp_lim,  &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_irr_inst, cobalt%irr_inst, &
+            model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_irr_mix, cobalt%irr_mix, &
+            model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_irr_aclm_inst, cobalt%irr_aclm_inst, &
+            model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_irr_aclm, cobalt%f_irr_aclm, &
+            model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_irr_aclm_z, cobalt%f_irr_aclm_z, &
+            model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_total_filter_feeding,cobalt%total_filter_feeding, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          !
+          ! Benthic fluxes and processes applied during the time step
+          !
+          used = g_send_data(cobalt%id_b_alk, -cobalt%b_alk, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_b_dic, -cobalt%b_dic, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_b_fed, -cobalt%b_fed, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_b_nh4, -cobalt%b_nh4, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_b_no3, -cobalt%b_no3, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_b_o2, -cobalt%b_o2, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_b_po4, -cobalt%b_po4, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_b_sio4, -cobalt%b_sio4, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fcased_burial, cobalt%fcased_burial, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fcased_redis, cobalt%fcased_redis, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fcased_redis_surfresp,cobalt%fcased_redis_surfresp, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_cased_redis_coef, cobalt%cased_redis_coef, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_cased_redis_delz,  cobalt%cased_redis_delz, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_ffe_sed, cobalt%ffe_sed, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_ffe_geotherm,  cobalt%ffe_geotherm, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_ffe_iceberg,  cobalt%ffe_iceberg, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fnso4red_sed,cobalt%fnso4red_sed, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fno3denit_sed, cobalt%fno3denit_sed, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fnoxic_sed, cobalt%fnoxic_sed, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_frac_burial, cobalt%frac_burial, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fn_burial, cobalt%fn_burial, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_fp_burial, cobalt%fp_burial, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_cased_2d, cobalt%cased_2d, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          !
+          ! Radiocarbon fields
+          !
+          if (do_14c) then
+            used = g_send_data(cobalt%id_b_di14c, cobalt%b_di14c, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+            used = g_send_data(cobalt%id_c14_2_n, cobalt%c14_2_n, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(cobalt%id_c14o2_csurf, cobalt%c14o2_csurf, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+            used = g_send_data(cobalt%id_c14o2_alpha, cobalt%c14o2_alpha, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+            used = g_send_data(cobalt%id_fpo14c, cobalt%fpo14c, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(cobalt%id_j14c_decay_dic, cobalt%j14c_decay_dic, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(cobalt%id_j14c_decay_doc, cobalt%j14c_decay_doc, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(cobalt%id_j14c_reminp, cobalt%j14c_reminp, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(cobalt%id_jdi14c, cobalt%jdi14c, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(cobalt%id_jdo14c, cobalt%jdo14c, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          endif
+
+          !
+          ! Surface light and acclimation diagnostics (handle in diag table?)
+          !
+          used = g_send_data(cobalt%id_sfc_irr, cobalt%irr_inst(:,:,1), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_sfc_irr_aclm, cobalt%f_irr_aclm_sfc(:,:,1), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_mld_aclm, cobalt%mld_aclm, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_daylength, cobalt%daylength, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+
+
+          !
+          ! Surface Phytplankton Limitations and Rates (handle in diag tables?)
+          ! 
+          do n= 1, NUM_PHYTO
+            used = g_send_data(phyto(n)%id_sfc_def_fe, phyto(n)%def_fe(:,:,1), &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(phyto(n)%id_sfc_felim, phyto(n)%felim(:,:,1), &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(phyto(n)%id_sfc_irrlim, phyto(n)%irrlim(:,:,1), &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(phyto(n)%id_sfc_theta, phyto(n)%theta(:,:,1), &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(phyto(n)%id_sfc_mu, phyto(n)%mu(:,:,1), &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(phyto(n)%id_sfc_po4lim, phyto(n)%po4lim(:,:,1), &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(phyto(n)%id_sfc_q_fe_2_n, phyto(n)%q_fe_2_n(:,:,1), &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(phyto(n)%id_sfc_q_p_2_n, phyto(n)%q_p_2_n(:,:,1), &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(phyto(n)%id_sfc_nh4lim, phyto(n)%nh4lim(:,:,1), &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(phyto(n)%id_sfc_no3lim, phyto(n)%no3lim(:,:,1), &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          enddo
+
+          !
+          ! Save river, depositon and bulk elemental fluxes
+          !
+          used = g_send_data(cobalt%id_dep_dry_fed, cobalt%dry_fed, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_dep_dry_lith, cobalt%dry_lith, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_dep_dry_nh4, cobalt%dry_nh4, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_dep_dry_no3, cobalt%dry_no3, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_dep_dry_po4, cobalt%dry_po4, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_dep_wet_fed, cobalt%wet_fed, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_dep_wet_lith, cobalt%wet_lith, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_dep_wet_nh4, cobalt%wet_nh4, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_dep_wet_no3, cobalt%wet_no3, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_dep_wet_po4, cobalt%wet_po4, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_runoff_flux_alk, cobalt%runoff_flux_alk, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_runoff_flux_dic, cobalt%runoff_flux_dic, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_runoff_flux_di14c, cobalt%runoff_flux_di14c, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_runoff_flux_fed, cobalt%runoff_flux_fed, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_runoff_flux_lith, cobalt%runoff_flux_lith, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_runoff_flux_no3, cobalt%runoff_flux_no3, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_runoff_flux_ldon, cobalt%runoff_flux_ldon, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_runoff_flux_sldon, cobalt%runoff_flux_sldon, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_runoff_flux_srdon, cobalt%runoff_flux_srdon, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_runoff_flux_ndet, cobalt%runoff_flux_ndet, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_runoff_flux_pdet, cobalt%runoff_flux_pdet, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_runoff_flux_po4, cobalt%runoff_flux_po4, &
+            model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_runoff_flux_ldop, cobalt%runoff_flux_ldop, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_runoff_flux_sldop, cobalt%runoff_flux_sldop, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_runoff_flux_srdop, cobalt%runoff_flux_srdop, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+
+          !
+          ! Save 100m integral fluxes (move calculation here for consistency with post_vertdiff?)
+          !
+          ! Phytoplankton 100m flux integrals
+          used = g_send_data(cobalt%id_jprod_allphytos_100, cobalt%jprod_allphytos_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_jprod_allphytos_200, cobalt%jprod_allphytos_200, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_jprod_diat_100, cobalt%jprod_diat_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          do n= 1, NUM_PHYTO  !{
+            used = g_send_data(phyto(n)%id_jprod_n_100, phyto(n)%jprod_n_100, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(phyto(n)%id_jprod_n_new_100, phyto(n)%jprod_n_new_100, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(phyto(n)%id_jzloss_n_100, phyto(n)%jzloss_n_100, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(phyto(n)%id_jexuloss_n_100, phyto(n)%jexuloss_n_100, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(phyto(n)%id_jvirloss_n_100, phyto(n)%jvirloss_n_100, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(phyto(n)%id_jmortloss_n_100, phyto(n)%jmortloss_n_100, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(phyto(n)%id_jaggloss_n_100, phyto(n)%jaggloss_n_100, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          enddo !} n
+          used = g_send_data(phyto(DIAZO)%id_jprod_n_n2_100, phyto(DIAZO)%jprod_n_n2_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !
+          ! Zooplankton 100m flux integrals - generalized to define production terms for all zooplankton regardless of
+          ! default settings.  This may create zero arrays in some cases, but supports setting changes
+          !
+          do n= 1, NUM_ZOO  !{
+            used = g_send_data(zoo(n)%id_jprod_n_100, zoo(n)%jprod_n_100, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(zoo(n)%id_jingest_n_100, zoo(n)%jingest_n_100, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(zoo(n)%id_jremin_n_100, zoo(n)%jremin_n_100, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(zoo(n)%id_jzloss_n_100, zoo(n)%jzloss_n_100, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(zoo(n)%id_jprod_don_100, zoo(n)%jprod_don_100, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(zoo(n)%id_jhploss_n_100, zoo(n)%jhploss_n_100, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+            used = g_send_data(zoo(n)%id_jprod_ndet_100, zoo(n)%jprod_ndet_100, &
+              model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          enddo !} n
+          used = g_send_data(cobalt%id_jprod_mesozoo_200, cobalt%jprod_mesozoo_200, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          ! Higher predator 100m flux integrals
+          used = g_send_data(cobalt%id_hp_jingest_n_100, cobalt%hp_jingest_n_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_hp_jremin_n_100, cobalt%hp_jremin_n_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_hp_jprod_ndet_100, cobalt%hp_jprod_ndet_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !
+          ! Bacteria 100m flux integrals
+          !
+          used = g_send_data(bact(1)%id_jprod_n_100, bact(1)%jprod_n_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(bact(1)%id_jzloss_n_100, bact(1)%jzloss_n_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(bact(1)%id_jvirloss_n_100, bact(1)%jvirloss_n_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(bact(1)%id_jremin_n_100, bact(1)%jremin_n_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(bact(1)%id_juptake_ldon_100, bact(1)%juptake_ldon_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !
+          ! Detritus production 100m flux integrals
+          !
+          used = g_send_data(cobalt%id_jprod_lithdet_100, cobalt%jprod_lithdet_100, &
+            model_time, rmask = grid_tmask(:,:,1),  is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_jprod_sidet_100, cobalt%jprod_sidet_100, &
+            model_time, rmask = grid_tmask(:,:,1),  is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_jprod_cadet_calc_100, cobalt%jprod_cadet_calc_100, &
+            model_time, rmask = grid_tmask(:,:,1),  is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_jprod_cadet_arag_100, cobalt%jprod_cadet_arag_100, &
+            model_time, rmask = grid_tmask(:,:,1),  is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_jremin_ndet_100, cobalt%jremin_ndet_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !
+          ! Water column flux integrals
+          !
+          used = g_send_data(cobalt%id_wc_vert_int_npp, cobalt%wc_vert_int_npp, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_jdiss_sidet, cobalt%wc_vert_int_jdiss_sidet, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_jdiss_cadet, cobalt%wc_vert_int_jdiss_cadet, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_jo2resp, cobalt%wc_vert_int_jo2resp, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_jprod_cadet, cobalt%wc_vert_int_jprod_cadet, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_jno3denit, cobalt%wc_vert_int_jno3denit, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_jprod_no3nitrif, cobalt%wc_vert_int_jprod_no3nitrif, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_jnamx, cobalt%wc_vert_int_jnamx, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_juptake_nh4, cobalt%wc_vert_int_juptake_nh4, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_jprod_nh4, cobalt%wc_vert_int_jprod_nh4, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_juptake_no3, cobalt%wc_vert_int_juptake_no3, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_nfix, cobalt%wc_vert_int_nfix, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_jfe_iceberg, cobalt%wc_vert_int_jfe_iceberg, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_jno3_iceberg, cobalt%wc_vert_int_jno3_iceberg, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_wc_vert_int_jpo4_iceberg, cobalt%wc_vert_int_jpo4_iceberg, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          !
+          ! Additional 3D flux diagnostics
+          !
+          used = g_send_data(cobalt%id_jalk, cobalt%jalk, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jalk_plus_btm, cobalt%jalk_plus_btm, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jdic, cobalt%jdic, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jno3, cobalt%jno3, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jpo4, cobalt%jpo4, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jsio4, cobalt%jsio4, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jdic_plus_btm, cobalt%jdic_plus_btm, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jnh4, cobalt%jnh4, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jndet, cobalt%jndet, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jnh4_plus_btm, cobalt%jnh4_plus_btm, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jo2_plus_btm, cobalt%jo2_plus_btm, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jo2, cobalt%jo2, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+
+          !
+          ! CMIP marine biogeochemical fluxes and other fields
+          !
+          ! Note: *rho_dzt/dzt in unescessarily complex, now just multiply by cobalt%Rho_0
+          used = g_send_data(cobalt%id_pp,  (phyto(DIAZO)%jprod_n +  phyto(LARGE)%jprod_n + &
+            phyto(MEDIUM)%jprod_n + phyto(SMALL)%jprod_n) * cobalt%Rho_0 * cobalt%c_2_n, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_pnitrate,  (phyto(DIAZO)%juptake_no3 +  phyto(LARGE)%juptake_no3 + &
+            phyto(MEDIUM)%juptake_no3 + phyto(SMALL)%juptake_no3) * cobalt%Rho_0 * cobalt%c_2_n, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_pphosphate,  (phyto(DIAZO)%juptake_po4 +  phyto(LARGE)%juptake_po4 + &
+            phyto(MEDIUM)%juptake_po4 + phyto(SMALL)%juptake_po4) *  cobalt%Rho_0 * cobalt%c_2_n, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_pbfe,  (phyto(DIAZO)%juptake_fe +  phyto(LARGE)%juptake_fe + &
+            phyto(MEDIUM)%juptake_fe + phyto(SMALL)%juptake_fe) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_pbsi, (phyto(LARGE)%juptake_sio4 + phyto(MEDIUM)%juptake_sio4) * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_pcalc, cobalt%jprod_cadet_calc * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_parag,  cobalt%jprod_cadet_arag * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_remoc, cobalt%jprod_nh4_plus_btm*cobalt%c_2_n*cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_dcalc,  cobalt%jdiss_cadet_calc_plus_btm*cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_darag,  cobalt%jdiss_cadet_arag_plus_btm*cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_ppdiat, (phyto(LARGE)%jprod_n * phyto(LARGE)%silim + &
+            phyto(MEDIUM)%jprod_n * phyto(MEDIUM)%silim) * cobalt%Rho_0 * cobalt%c_2_n,  &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_ppdiaz,  phyto(DIAZO)%jprod_n * cobalt%Rho_0 * cobalt%c_2_n,  &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_pppico,  phyto(SMALL)%jprod_n *  cobalt%Rho_0 * cobalt%c_2_n,  &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_ppmisc, ((phyto(LARGE)%jprod_n * (1.0 - phyto(LARGE)%silim)) + &
+            (phyto(MEDIUM)%jprod_n * (1.0 - phyto(MEDIUM)%silim))) * cobalt%Rho_0 * cobalt%c_2_n,  &
+            model_time, rmask = grid_tmask,  is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_bddtdic, cobalt%jdic_plus_btm * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_bddtdin, cobalt%jdin_plus_btm * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_bddtdip, cobalt%jpo4_plus_btm * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_bddtdife, cobalt%jfed_plus_btm * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_bddtdisi, cobalt%jsio4_plus_btm * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_bddtalk, cobalt%jalk_plus_btm * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_fescav, cobalt%jfe_ads * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_fediss, cobalt%jremin_fedet * cobalt%Rho_0, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_graz, (phyto(DIAZO)%jzloss_n + phyto(LARGE)%jzloss_n + &
+            phyto(MEDIUM)%jzloss_n + phyto(SMALL)%jzloss_n) * cobalt%c_2_n  * cobalt%Rho_0,  &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          !
+          ! CMIP 100m biomass-weighted limitation terms 
+          ! (recommend using surface to avoid aliasing the limitation with information from below the nutricline)
+          ! (***needs to update these for 4P formulation***) 
+          !
+          used = g_send_data(cobalt%id_limndiat, phyto(LARGE)%nlim_bw_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          ! Not outputting/serving limndiaz because diazotrophs are not N limited
+          ! used = g_send_data(cobalt%id_limndiaz, phyto(DIAZO)%nlim_bw_100, &
+          !  model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_limnpico, phyto(SMALL)%nlim_bw_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_limnmisc, phyto(LARGE)%nlim_bw_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_limirrdiat, phyto(LARGE)%irrlim_bw_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_limirrdiaz, phyto(DIAZO)%irrlim_bw_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_limirrpico, phyto(SMALL)%irrlim_bw_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_limirrmisc, phyto(LARGE)%irrlim_bw_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_limfediat, phyto(LARGE)%def_fe_bw_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_limfediaz, phyto(DIAZO)%def_fe_bw_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_limfepico, phyto(SMALL)%def_fe_bw_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_limfemisc, phyto(LARGE)%def_fe_bw_100,  &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_limpdiat, phyto(LARGE)%plim_bw_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_limpdiaz, phyto(DIAZO)%plim_bw_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_limppico, phyto(SMALL)%plim_bw_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_limpmisc, phyto(LARGE)%plim_bw_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+
+          ! should this be 100m or full water column?
+          used = g_send_data(cobalt%id_intpp,  cobalt%jprod_allphytos_100 * cobalt%c_2_n, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intppnitrate,  (phyto(DIAZO)%jprod_n_new_100 +  phyto(LARGE)%jprod_n_new_100 + &
+            phyto(MEDIUM)%jprod_n_new_100 + phyto(SMALL)%jprod_n_new_100) * cobalt%c_2_n, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intppdiat,  cobalt%jprod_diat_100 * cobalt%c_2_n,  &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intppdiaz,  phyto(DIAZO)%jprod_n_100 * cobalt%c_2_n, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intpppico,  phyto(SMALL)%jprod_n_100 * cobalt%c_2_n, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intppmisc, (phyto(LARGE)%jprod_n_100 + phyto(MEDIUM)%jprod_n_100 - &
+            cobalt%jprod_diat_100) *cobalt%c_2_n, model_time, rmask = grid_tmask(:,:,1), &
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intpbn,  cobalt%jprod_allphytos_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intpbp, (phyto(DIAZO)%juptake_po4_100 +  phyto(LARGE)%juptake_po4_100 +  &
+            phyto(MEDIUM)%juptake_po4_100 + phyto(SMALL)%juptake_po4_100), model_time, rmask = grid_tmask(:,:,1), &
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intpbfe,  (phyto(DIAZO)%juptake_fe_100 +  phyto(LARGE)%juptake_fe_100 +  &
+            phyto(MEDIUM)%juptake_fe_100 + phyto(SMALL)%juptake_fe_100), model_time, rmask = grid_tmask(:,:,1), &
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intpbsi,  phyto(LARGE)%juptake_sio4_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intpcalcite,  cobalt%jprod_cadet_calc_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intparag,  cobalt%jprod_cadet_arag_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          ! CAS: Updated on 3/9/2021 to include sediment dissolution based on variable long name, also added
+          !      aragonite flux to the sediment (which is instantaneously redissolved)
+          used = g_send_data(cobalt%id_icfriver,  cobalt%runoff_flux_dic + cobalt%fcased_redis + &
+            cobalt%fcadet_arag_btm,model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          ! CAS: Updated on 3/9/2021 to exclude calcite dissolution but include the aragonite flux to
+          !      the bottom
+          used = g_send_data(cobalt%id_fric,  cobalt%fcadet_calc_btm + cobalt%fcadet_arag_btm,  &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          ! CAS: variable includes release from sediment, but there is no organic carbon release from
+          !      sediment in COBALT
+          used = g_send_data(cobalt%id_ocfriver, cobalt%c_2_n* &
+            (cobalt%runoff_flux_ldon+cobalt%runoff_flux_sldon+cobalt%runoff_flux_srdon), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          ! CAS: Updated on 3/9/2021 to reflect that the total loss of organic carbon at sediments is
+          !      equal to the total flux, not just the burial
+          used = g_send_data(cobalt%id_froc,cobalt%c_2_n*cobalt%fndet_btm, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intpn2,  cobalt%wc_vert_int_nfix,  &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          ! CAS: Updated on 3/9/2021 to include nh4 deposition and riverine fluxes of organic nitrogen
+          used = g_send_data(cobalt%id_fsn,  cobalt%runoff_flux_no3 + cobalt%dry_no3 + cobalt%wet_no3 + &
+            cobalt%dry_nh4 + cobalt%wet_nh4 + cobalt%runoff_flux_ldon + cobalt%runoff_flux_sldon + &
+            cobalt%runoff_flux_srdon + cobalt%wc_vert_int_nfix, model_time, rmask = grid_tmask(:,:,1), &
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          ! JYL: Updated on 3/21/2021 to include anammox
+          used = g_send_data(cobalt%id_frn,  cobalt%fno3denit_sed + cobalt%wc_vert_int_jno3denit + &
+            cobalt%wc_vert_int_jnamx + cobalt%fn_burial, model_time, rmask = grid_tmask(:,:,1), &
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          ! CAS: Updated on 3/9/2021 to include ffe_iceberg
+          used = g_send_data(cobalt%id_fsfe,  cobalt%runoff_flux_fed + cobalt%dry_fed + cobalt%wet_fed + &
+            cobalt%ffe_sed+cobalt%ffe_geotherm+cobalt%ffe_iceberg, model_time, rmask = grid_tmask(:,:,1), & 
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_frfe,  cobalt%ffedet_btm, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
 
 ! 2016/08/15 - we will not be providing these fields
 ! CHECK: rate was computed offline for TOPAZ by saving a reference history file, dividing by secs_per_month and differencing monthly averages
@@ -2516,53 +1951,18 @@ module COBALT_send_diag
 !==============================================================================================================
 ! 2016/08/15 JGJ: 100m integrals w/o CMOR conversion
 
-        used = g_send_data(cobalt%id_f_dic_int_100,  cobalt%f_dic_int_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_f_din_int_100,  cobalt%f_din_int_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_f_po4_int_100,  cobalt%f_po4_int_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_f_fed_int_100,  cobalt%f_fed_int_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_f_sio4_int_100,  cobalt%f_sio4_int_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_f_alk_int_100,  cobalt%f_alk_int_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_jdic_100,  cobalt%jdic_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_jdin_100,  cobalt%jdin_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_jpo4_100,  cobalt%jpo4_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_jfed_100,  cobalt%jfed_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_jsio4_100,  cobalt%jsio4_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-        used = g_send_data(cobalt%id_jalk_100,  cobalt%jalk_100,   &
-        model_time, rmask = grid_tmask(:,:,1),&
-        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_jdic_100, cobalt%jdic_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_jdin_100, cobalt%jdin_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_jpo4_100, cobalt%jpo4_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_jfed_100, cobalt%jfed_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_jsio4_100, cobalt%jsio4_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_jalk_100, cobalt%jalk_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
 
 !==============================================================================================================
 

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -26,7 +26,7 @@ module cobalt_types
   logical, public :: do_14c             = .false.            !< If true, then simulate radiocarbon 
   logical, public :: do_nh3_atm_ocean_exchange = .false.     ! If true, then do NH3 air-sea exchange 
   !
-  logical, public :: do_vertfill_pre = .false.             !< Returns tracer arrays with sensible values
+  logical, public :: do_vertfill_pre = .false.
   logical, public :: debug           = .false.             !< not use   
   real, public    :: imbalance_tolerance=1.0e-10           !< the tolerance for non-conservation in C,N,P,Sc,Fe
 
@@ -413,6 +413,7 @@ module cobalt_types
                                                !    as is the case with MOM6  THERMO_SPANS_COUPLING option
           do_fnso4red_sed,  &     ! Simulate O2 deficit and alkalinity flux from implied sedimentary sulfate reduction
           cased_steady,     &     ! steady state approximation for cased
+          recalculate_carbon, &   ! true means C system is resolved for diagnostic
           tracer_debug
      real  ::          &
           min_thickness       ! minimum thickness of a layer that will be checked for source/sink imbalances
@@ -568,7 +569,6 @@ module cobalt_types
           f_sio4,&
           co3_sol_arag,&
           co3_sol_calc,&
-          rho_test,&
           f_chl,&
           f_nh3,&
           f_co3_ion,&
@@ -724,8 +724,8 @@ module cobalt_types
           total_filter_feeding,&
           nmd_diatoms,&
           nlg_diatoms,&
-          q_si_2_n_md_diatoms,&
-          q_si_2_n_lg_diatoms,&
+          nmd_misc,&
+          nlg_misc,&
           zt, &
           c14_2_n,&
           f_di14c,&
@@ -805,8 +805,6 @@ module cobalt_types
           fsitot_100, &
           ffetot_100, &
           btm_temp,     &
-          btm_temp_old, &
-          btm_o2_old,   &
           btm_o2,       &
           btm_no3,      &
           btm_alk,       &
@@ -816,13 +814,9 @@ module cobalt_types
           rho_dzt_kmt_diag, &
           rho_dzt_bot_diag, &
           btm_htotal,   &
-          btm_htotal_old, &
           btm_co3_ion,  &
-          btm_co3_ion_old, &
           btm_co3_sol_arag, &
-          btm_co3_sol_arag_old, &
           btm_co3_sol_calc, &
-          btm_co3_sol_calc_old, &
           btm_omega_calc, &
           btm_omega_arag, &
           cased_2d,     &
@@ -951,7 +945,6 @@ module cobalt_types
      integer               ::          &
           id_co3_sol_arag  = -1,       &
           id_co3_sol_calc  = -1,       &
-          id_rho_test      = -1,       &
           id_dep_dry_fed   = -1,       &
           id_dep_dry_nh4   = -1,       &
           id_dep_dry_no3   = -1,       &
@@ -967,7 +960,6 @@ module cobalt_types
           id_irr_aclm      = -1,       &
           id_irr_aclm_z    = -1,       &
           id_jfed          = -1,       &
-          id_jfedc         = -1,       & 
           id_jprod_ndet    = -1,       &
           id_jprod_pdet    = -1,       &
           id_jprod_sldon   = -1,       &
@@ -1013,15 +1005,13 @@ module cobalt_types
           id_irr_mix       = -1,       &
           id_irr_aclm_inst = -1,       &
           id_jalk          = -1,       &
-          id_jalkc         = -1,       &  
           id_jalk_plus_btm = -1,       &
           id_jdic          = -1,       &
-          id_jdicc         = -1,       &  
-          id_jno3c         = -1,       &  
-          id_jpo4c         = -1,       &  
-          id_jsio4c        = -1,       &  
           id_jdic_plus_btm = -1,       &
           id_jnh4          = -1,       &
+          id_jno3          = -1,       &
+          id_jpo4          = -1,       &
+          id_jsio4         = -1,       &
           id_jndet         = -1,       &
           id_jnh4_plus_btm = -1,       &
           id_jno3denit_wc  = -1,       &
@@ -1095,8 +1085,6 @@ module cobalt_types
           id_sfc_irr_aclm   = -1,       &
           id_sfc_temp      = -1,       &
           id_btm_temp      = -1,       &
-          id_btm_temp_old  = -1,       &
-          id_btm_o2_old    = -1,       &
           id_btm_o2        = -1,       &
           id_btm_no3       = -1,       &
           id_btm_alk       = -1,       &
@@ -1106,13 +1094,9 @@ module cobalt_types
           id_rho_dzt_kmt_diag = -1,    &
           id_rho_dzt_bot_diag = -1,    &
           id_btm_htotal    = -1,       &
-          id_btm_htotal_old    = -1,   &
           id_btm_co3_sol_arag = -1,    &
-          id_btm_co3_sol_arag_old = -1,&
           id_btm_co3_sol_calc = -1,    &
-          id_btm_co3_sol_calc_old = -1,&
           id_btm_co3_ion      = -1,    &
-          id_btm_co3_ion_old  = -1,    &
           id_btm_omega_calc   = -1,    &
           id_btm_omega_arag   = -1,    &
           id_b_dic            = -1,    &
@@ -1177,12 +1161,12 @@ module cobalt_types
           id_total_filter_feeding = -1,&
           id_nlg_diatoms = -1,         &
           id_nmd_diatoms = -1,         &
+          id_nlg_misc = -1,         &
+          id_nmd_misc = -1,         &
           id_jprod_allphytos_100 = -1, &
           id_jprod_allphytos_200 = -1, &
           id_jprod_diat_100 = -1,      &
           id_mld_aclm          = -1,      &
-          id_q_si_2_n_lg_diatoms = -1, &
-          id_q_si_2_n_md_diatoms = -1, &
           id_hp_jingest_n_100 = -1,    &
           id_hp_jremin_n_100 = -1,     &
           id_hp_jprod_ndet_100 = -1,   &

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -122,7 +122,6 @@ module cobalt_types
      real, ALLOCATABLE, dimension(:,:,:)  ::  alpha          !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  bresp          !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  def_fe         !<
-     real, ALLOCATABLE, dimension(:,:,:)  ::  def_p          !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  f_fe           !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  f_n            !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  f_p            !<
@@ -179,7 +178,6 @@ module cobalt_types
      integer ::  id_alpha        = -1
      integer ::  id_bresp        = -1
      integer ::  id_def_fe       = -1
-     integer ::  id_def_p        = -1
      integer ::  id_felim        = -1
      integer ::  id_irrlim       = -1
      integer ::  id_jzloss_fe    = -1
@@ -539,8 +537,8 @@ module cobalt_types
      real    :: a1_o2, a2_o2, a3_o2, a4_o2, a5_o2
 
      logical, dimension(:,:), ALLOCATABLE ::  &
-          mask_z_sat_arag,&
-          mask_z_sat_calc
+          mask_zsatarag,&
+          mask_zsatcalc
 
      real, dimension(:,:,:), ALLOCATABLE ::  &
           f_alk,&				! Other prognostic variables
@@ -821,9 +819,9 @@ module cobalt_types
           btm_omega_arag, &
           cased_2d,     &
           o2min, &
-          z_o2min, &
-          z_sat_arag,&
-          z_sat_calc,&
+          zo2min, &
+          zsatarag,&
+          zsatcalc,&
           daylength,&
 !==============================================================================================================
 ! JGJ 2016/08/08 CMIP6 Ocnbgc
@@ -1022,7 +1020,6 @@ module cobalt_types
           id_jprod_no3nitrif = -1,     &
           id_jo2resp_wc    = -1,       &
           id_co2_csurf     = -1,       &
-          id_pco2_csurf    = -1,       &
           id_co2_alpha     = -1,       &
           id_nh3_csurf     = -1,       &
           id_nh3_alpha     = -1,       &
@@ -1063,7 +1060,6 @@ module cobalt_types
           id_fn_burial  = -1,       &
           id_fp_burial  = -1,       &
           id_nphyto_tot    = -1,       &
-          id_no3_in_source = -1,       &
           id_pco2surf      = -1,       &
           id_pnh3surf      = -1,       &
           id_sfc_alk       = -1,       &
@@ -1194,9 +1190,9 @@ module cobalt_types
           id_ffetot_100 = -1,          &
           id_fsitot_100 = -1,          &
           id_o2min         = -1,       &
-          id_z_o2min       = -1,       &
-          id_z_sat_arag    = -1,       & ! Depth of Aragonite saturation
-          id_z_sat_calc    = -1,       & ! Depth of Calcite saturation
+          id_zo2min       = -1,        &
+          id_zsatarag    = -1,         & ! Depth of Aragonite saturation
+          id_zsatcalc    = -1,         & ! Depth of Calcite saturation
           id_b_di14c       = -1,       & ! Bottom flux of DI14C
           id_c14_2_n       = -1,       & ! DI14C to PO4 uptake ratio
           id_c14o2_csurf   = -1,       & ! Surface water 14CO2*
@@ -1215,7 +1211,6 @@ module cobalt_types
           id_f_sio4_int_100 = -1, &
           id_jo2_plus_btm   = -1, &
           id_jo2            = -1, & 
-          id_jo2c           = -1, & 
           id_jalk_100       = -1, &
           id_jdic_100       = -1, &
           id_jdin_100       = -1, &
@@ -1410,9 +1405,6 @@ module cobalt_types
           id_frn                = -1, &
           id_fsfe               = -1, &
           id_frfe               = -1, &
-          id_zo2min             = -1, &
-          id_zsatcalc           = -1, &
-          id_zsatarag           = -1, &
           id_fddtdic            = -1, &
           id_fddtdin            = -1, &
           id_fddtdip            = -1, &

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -393,7 +393,7 @@ contains
     call get_param(param_file, "generic_COBALT", "htotal_scale_hi", cobalt%htotal_scale_hi, &
                    "scaling factor for initializing carbon chemistry solver", units=" ", default=100.0)
     ! Flag to recalculate the carbon system parameters after vertdiff to ensure consistency with prognostic tracers
-    call get_param(param_file, "generic_COBALT", "recalculate_carbon", cobalt%cased_steady, "recalculate_carbon", &
+    call get_param(param_file, "generic_COBALT", "recalculate_carbon", cobalt%recalculate_carbon, "recalculate_carbon", &
                    default=.true.)
 
     call get_param(param_file, "generic_COBALT", "RHO_0", cobalt%Rho_0, "reference density", &

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -392,6 +392,9 @@ contains
                    "scaling factor for initializing carbon chemistry solver", units=" ", default=0.01)
     call get_param(param_file, "generic_COBALT", "htotal_scale_hi", cobalt%htotal_scale_hi, &
                    "scaling factor for initializing carbon chemistry solver", units=" ", default=100.0)
+    ! Flag to recalculate the carbon system parameters after vertdiff to ensure consistency with prognostic tracers
+    call get_param(param_file, "generic_COBALT", "recalculate_carbon", cobalt%cased_steady, "recalculate_carbon", &
+                   default=.true.)
 
     call get_param(param_file, "generic_COBALT", "RHO_0", cobalt%Rho_0, "reference density", &
                    units="kg m-3", default=1035.0)
@@ -2543,12 +2546,12 @@ contains
   !  </IN>
   !
   ! </SUBROUTINE>
-  subroutine generic_COBALT_update_from_bottom(tracer_list, dt, tau, model_time,Temp, rho_dzt, dzt, ilb, jlb)
+  subroutine generic_COBALT_update_from_bottom(tracer_list, dt, tau, model_time,Temp, Salt, rho_dzt, dzt, ilb, jlb)
     type(g_tracer_type), pointer :: tracer_list
     real,               intent(in) :: dt
     integer,            intent(in) :: tau
     type(time_type),    intent(in) :: model_time
-    real, dimension(ilb:,jlb:,:),   intent(in) :: Temp,rho_dzt,dzt
+    real, dimension(ilb:,jlb:,:),   intent(in) :: Temp, Salt, rho_dzt,dzt
     integer,                        intent(in) :: ilb,jlb
     integer :: isc,iec, jsc,jec,isd,ied,jsd,jed,nk,ntau
     integer :: i, j, k
@@ -2820,8 +2823,8 @@ contains
     is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)    
 
     ! send_diag for integeral outputs
-    call cobalt_send_diagnostics(tracer_list,model_time,grid_tmask,Temp,rho_dzt,dzt, &
-         isc,iec,jsc,jec,nk,tau,phyto,zoo,bact,cobalt,post_vertdiff=.true.)
+    call cobalt_send_diagnostics(tracer_list,model_time,grid_tmask,Temp,Salt,rho_dzt,dzt, &
+         isc,iec,jsc,jec,isd,ied,jsd,jed,nk,grid_kmt,tau,phyto,zoo,bact,cobalt,post_vertdiff=.true.)
 
   end subroutine generic_COBALT_update_from_bottom
 
@@ -3549,7 +3552,8 @@ contains
             endif
           enddo
 
-          ! Calculate the chlorophyll.  Coversions give mg Chl (1000 kg)-1 ~ mg Chl m-3 
+          ! Calculate the chlorophyll.  Coversions give mg Chl (1000 kg)-1 ~ mg Chl m-3
+          ! Note: Better to make this c_2_n*12*cobalt%Rho_0*1000*theta*f_n?  ~3.5% difference
           phyto(n)%chl(i,j,k) = cobalt%c_2_n*12.0e6*phyto(n)%theta(i,j,k)*phyto(n)%f_n(i,j,k)
           cobalt%f_chl(i,j,k) = cobalt%f_chl(i,j,k)+phyto(n)%chl(i,j,k)
 
@@ -3675,10 +3679,8 @@ contains
     do k = 1, nk  ; do j = jsc, jec ; do i = isc, iec   !{
        cobalt%nlg_diatoms(i,j,k)=phyto(LARGE)%f_n(i,j,k)*phyto(LARGE)%silim(i,j,k)
        cobalt%nmd_diatoms(i,j,k)=phyto(MEDIUM)%f_n(i,j,k)*phyto(MEDIUM)%silim(i,j,k)
-       cobalt%q_si_2_n_lg_diatoms(i,j,k)= cobalt%f_silg(i,j,k)/ &
-             (cobalt%nlg_diatoms(i,j,k) + epsln)
-       cobalt%q_si_2_n_md_diatoms(i,j,k)= cobalt%f_simd(i,j,k)/ &
-             (cobalt%nmd_diatoms(i,j,k) + epsln)
+       cobalt%nlg_misc(i,j,k)=phyto(LARGE)%f_n(i,j,k) - phyto(LARGE)%f_n(i,j,k)*phyto(LARGE)%silim(i,j,k)
+       cobalt%nmd_misc(i,j,k)=phyto(MEDIUM)%f_n(i,j,k) - phyto(MEDIUM)%f_n(i,j,k)*phyto(MEDIUM)%silim(i,j,k)
        phyto(LARGE)%juptake_sio4(i,j,k) = &
              max(phyto(LARGE)%juptake_no3(i,j,k)+phyto(LARGE)%juptake_nh4(i,j,k),0.0)*phyto(LARGE)%silim(i,j,k)* &
              phyto(LARGE)%silim(i,j,k)*phyto(LARGE)%si_2_n_max
@@ -5069,6 +5071,8 @@ contains
 
        endif !}
     enddo; enddo  !} i, j
+    deallocate(rho_dzt_bot)
+    deallocate(k_bot)
 
     do k = 2, nk ; do j = jsc, jec ; do i = isc, iec   !{
        cobalt%f_cased(i,j,k) = 0.0
@@ -5977,6 +5981,8 @@ contains
     ! Then find all the layers within the specified bottom boundary layer thickness.  The first layer is always included.
     ! Additional layers are included if they fall, in part or whole, within the specified bottom thickness.  This
     ! could be done more finely, but awaiting an explicit bottom boundary layer scheme.
+    allocate(rho_dzt_bot(isc:iec,jsc:jec))
+    allocate(k_bot(isc:iec,jsc:jec))
     do j = jsc, jec ; do i = isc, iec  !{
       k = grid_kmt(i,j)         ! start at the bottom
       rho_dzt_bot(i,j) = 0.0    ! local variable to track the mass of the cells assigned to the bottom (kg m-2) 
@@ -6016,6 +6022,8 @@ contains
         enddo
       endif
     enddo; enddo
+    deallocate(rho_dzt_bot)
+    deallocate(k_bot)
 
 !****************************************************************************************************
 
@@ -6027,12 +6035,6 @@ contains
     !
     do j = jsc, jec ; do i = isc, iec !{
        rho_dzt_100(i,j) = rho_dzt(i,j,1)
-       cobalt%f_alk_int_100(i,j) = cobalt%p_alk(i,j,1,tau) * rho_dzt(i,j,1)
-       cobalt%f_dic_int_100(i,j) = cobalt%p_dic(i,j,1,tau) * rho_dzt(i,j,1)
-       cobalt%f_din_int_100(i,j) = (cobalt%p_no3(i,j,1,tau) + cobalt%p_nh4(i,j,1,tau)) * rho_dzt(i,j,1)
-       cobalt%f_fed_int_100(i,j) = cobalt%p_fed(i,j,1,tau) * rho_dzt(i,j,1)
-       cobalt%f_po4_int_100(i,j) = cobalt%p_po4(i,j,1,tau) * rho_dzt(i,j,1)
-       cobalt%f_sio4_int_100(i,j) = cobalt%p_sio4(i,j,1,tau) * rho_dzt(i,j,1)
        cobalt%jalk_100(i,j) = cobalt%jalk(i,j,1) * rho_dzt(i,j,1)
        cobalt%jdic_100(i,j) = cobalt%jdic(i,j,1) * rho_dzt(i,j,1)
        cobalt%jdin_100(i,j) = (cobalt%jno3(i,j,1) + cobalt%jnh4(i,j,1)) * rho_dzt(i,j,1)
@@ -6045,7 +6047,6 @@ contains
           phyto(n)%jprod_n_new_100(i,j) = phyto(n)%juptake_no3(i,j,1) * rho_dzt(i,j,1)
           phyto(n)%jzloss_n_100(i,j) = phyto(n)%jzloss_n(i,j,1) * rho_dzt(i,j,1)
           phyto(n)%jexuloss_n_100(i,j) = phyto(n)%jexuloss_n(i,j,1) * rho_dzt(i,j,1)
-          phyto(n)%f_n_100(i,j) = phyto(n)%f_n(i,j,1) * rho_dzt(i,j,1)
           phyto(n)%juptake_fe_100(i,j) = phyto(n)%juptake_fe(i,j,1) * rho_dzt(i,j,1)
           phyto(n)%juptake_po4_100(i,j) = phyto(n)%juptake_po4(i,j,1) * rho_dzt(i,j,1)
           phyto(n)%jvirloss_n_100(i,j) = phyto(n)%jvirloss_n(i,j,1) * rho_dzt(i,j,1)
@@ -6055,12 +6056,16 @@ contains
        phyto(DIAZO)%jprod_n_n2_100(i,j) = phyto(DIAZO)%juptake_n2(i,j,1) * rho_dzt(i,j,1)
        cobalt%jprod_diat_100(i,j) = (phyto(LARGE)%jprod_n(i,j,1)*phyto(LARGE)%silim(i,j,1) + &
                              phyto(MEDIUM)%jprod_n(i,j,1)*phyto(MEDIUM)%silim(i,j,1)) *rho_dzt(i,j,1)
+       ! May need to add these to update the biomass-weighted limitation terms for COBALTv3
+       !cobalt%nmd_diat_100(i,j) =
+       !cobalt%nlg_diat_100(i,j) = 
+       !cobalt%nmd_misc_100(i,j) =
+       !cobalt%nlg_misc_100(i,j) = 
        phyto(LARGE)%juptake_sio4_100(i,j) = phyto(LARGE)%juptake_sio4(i,j,1) * rho_dzt(i,j,1)
        do n = 1, NUM_ZOO  !{
           zoo(n)%jprod_n_100(i,j) = zoo(n)%jprod_n(i,j,1) * rho_dzt(i,j,1)
           zoo(n)%jingest_n_100(i,j) = zoo(n)%jingest_n(i,j,1) * rho_dzt(i,j,1)
           zoo(n)%jremin_n_100(i,j) = zoo(n)%jprod_nh4(i,j,1) * rho_dzt(i,j,1)
-          zoo(n)%f_n_100(i,j) = zoo(n)%f_n(i,j,1) * rho_dzt(i,j,1)
        enddo   !} n
 
        do n = 1,2  !{
@@ -6083,45 +6088,12 @@ contains
        bact(1)%jvirloss_n_100(i,j) = bact(1)%jvirloss_n(i,j,1) * rho_dzt(i,j,1)
        bact(1)%jremin_n_100(i,j) = bact(1)%jprod_nh4(i,j,1) * rho_dzt(i,j,1)
        bact(1)%juptake_ldon_100(i,j) = bact(1)%juptake_ldon(i,j,1) * rho_dzt(i,j,1)
-       bact(1)%f_n_100(i,j) = bact(1)%f_n(i,j,1) * rho_dzt(i,j,1)
 
        cobalt%jprod_lithdet_100(i,j) = cobalt%jprod_lithdet(i,j,1) * rho_dzt(i,j,1)
        cobalt%jprod_sidet_100(i,j) = cobalt%jprod_sidet(i,j,1) * rho_dzt(i,j,1)
        cobalt%jprod_cadet_calc_100(i,j) = cobalt%jprod_cadet_calc(i,j,1) * rho_dzt(i,j,1)
        cobalt%jprod_cadet_arag_100(i,j) = cobalt%jprod_cadet_arag(i,j,1) * rho_dzt(i,j,1)
        cobalt%jremin_ndet_100(i,j) = cobalt%jremin_ndet(i,j,1) * rho_dzt(i,j,1)
-
-       cobalt%f_ndet_100(i,j) = cobalt%f_ndet(i,j,1)*rho_dzt(i,j,1)
-       cobalt%f_don_100(i,j) = (cobalt%f_ldon(i,j,1)+cobalt%f_sldon(i,j,1)+cobalt%f_srdon(i,j,1))* &
-           rho_dzt(i,j,1)
-       cobalt%f_silg_100(i,j) = cobalt%f_silg(i,j,1)*rho_dzt(i,j,1)
-       cobalt%f_simd_100(i,j) = cobalt%f_simd(i,j,1)*rho_dzt(i,j,1)
-
-       cobalt%fndet_100(i,j) = cobalt%f_ndet(i,j,1) * cobalt%Rho_0 * cobalt%wsink
-       cobalt%fpdet_100(i,j) = cobalt%f_pdet(i,j,1) * cobalt%Rho_0 * cobalt%wsink
-       cobalt%ffedet_100(i,j) = cobalt%f_fedet(i,j,1) * cobalt%Rho_0 * cobalt%wsink
-       cobalt%flithdet_100(i,j) = cobalt%f_lithdet(i,j,1) * cobalt%Rho_0 * cobalt%wsink
-       cobalt%fsidet_100(i,j) = cobalt%f_sidet(i,j,1) * cobalt%Rho_0 * cobalt%wsink
-       cobalt%fcadet_arag_100(i,j) = cobalt%f_cadet_arag(i,j,1) * cobalt%Rho_0 * cobalt%wsink
-       cobalt%fcadet_calc_100(i,j) = cobalt%f_cadet_calc(i,j,1) * cobalt%Rho_0 * cobalt%wsink
-       cobalt%fntot_100(i,j) = (cobalt%f_ndet(i,j,1)*cobalt%wsink + &
-         phyto(SMALL)%f_n(i,j,1)*phyto(SMALL)%vmove(i,j,1) + &
-         phyto(MEDIUM)%f_n(i,j,1)*phyto(MEDIUM)%vmove(i,j,1) + &
-         phyto(LARGE)%f_n(i,j,1)*phyto(LARGE)%vmove(i,j,1) + &
-         phyto(DIAZO)%f_n(i,j,1)*phyto(DIAZO)%vmove(i,j,1))*cobalt%Rho_0
-       cobalt%fptot_100(i,j) = (cobalt%f_pdet(i,j,1)*cobalt%wsink + &
-         phyto(SMALL)%f_p(i,j,1)*phyto(SMALL)%vmove(i,j,1) + &
-         phyto(MEDIUM)%f_p(i,j,1)*phyto(MEDIUM)%vmove(i,j,1) + &
-         phyto(LARGE)%f_p(i,j,1)*phyto(LARGE)%vmove(i,j,1) + &
-         phyto(DIAZO)%f_p(i,j,1)*phyto(DIAZO)%vmove(i,j,1))*cobalt%Rho_0
-       cobalt%ffetot_100(i,j) = (cobalt%f_fedet(i,j,1)*cobalt%wsink + &
-         phyto(SMALL)%f_fe(i,j,1)*phyto(SMALL)%vmove(i,j,1) + &
-         phyto(MEDIUM)%f_fe(i,j,1)*phyto(MEDIUM)%vmove(i,j,1) + &
-         phyto(LARGE)%f_fe(i,j,1)*phyto(LARGE)%vmove(i,j,1) + &
-         phyto(DIAZO)%f_fe(i,j,1)*phyto(DIAZO)%vmove(i,j,1))*cobalt%Rho_0
-       cobalt%fsitot_100(i,j) = (cobalt%f_sidet(i,j,1)*cobalt%wsink + &
-         cobalt%f_simd(i,j,1)*phyto(MEDIUM)%vmove(i,j,1) + &
-         cobalt%f_silg(i,j,1)*phyto(LARGE)%vmove(i,j,1))*cobalt%Rho_0
     enddo; enddo !} i,j
 
     do j = jsc, jec ; do i = isc, iec ; !{
@@ -6130,13 +6102,6 @@ contains
           if (rho_dzt_100(i,j) .lt. cobalt%Rho_0 * 100.0) then
              k_100 = k
              rho_dzt_100(i,j) = rho_dzt_100(i,j) + rho_dzt(i,j,k)
-             cobalt%f_alk_int_100(i,j) = cobalt%f_alk_int_100(i,j) + cobalt%p_alk(i,j,k,tau) * rho_dzt(i,j,k)
-             cobalt%f_dic_int_100(i,j) = cobalt%f_dic_int_100(i,j) + cobalt%p_dic(i,j,k,tau) * rho_dzt(i,j,k)
-             cobalt%f_din_int_100(i,j) = cobalt%f_din_int_100(i,j) + (cobalt%p_no3(i,j,k,tau) +        &
-                cobalt%p_nh4(i,j,k,tau)) * rho_dzt(i,j,k)
-             cobalt%f_fed_int_100(i,j) = cobalt%f_fed_int_100(i,j) + cobalt%p_fed(i,j,k,tau) * rho_dzt(i,j,k)
-             cobalt%f_po4_int_100(i,j) = cobalt%f_po4_int_100(i,j) + cobalt%p_po4(i,j,k,tau) * rho_dzt(i,j,k)
-             cobalt%f_sio4_int_100(i,j) = cobalt%f_sio4_int_100(i,j) + cobalt%p_sio4(i,j,k,tau) *  rho_dzt(i,j,k)
              cobalt%jalk_100(i,j) = cobalt%jalk_100(i,j) + cobalt%jalk(i,j,k) * rho_dzt(i,j,k)
              cobalt%jdic_100(i,j) = cobalt%jdic_100(i,j) + cobalt%jdic(i,j,k) * rho_dzt(i,j,k)
              cobalt%jdin_100(i,j) = cobalt%jdin_100(i,j) + (cobalt%jno3(i,j,k) + cobalt%jnh4(i,j,k)) * rho_dzt(i,j,k)
@@ -6160,7 +6125,6 @@ contains
                    rho_dzt(i,j,k)
                 phyto(n)%jaggloss_n_100(i,j) = phyto(n)%jaggloss_n_100(i,j) + phyto(n)%jaggloss_n(i,j,k)* &
                    rho_dzt(i,j,k)
-                phyto(n)%f_n_100(i,j) = phyto(n)%f_n_100(i,j) + phyto(n)%f_n(i,j,k)*rho_dzt(i,j,k)
                 phyto(n)%juptake_fe_100(i,j) = phyto(n)%juptake_fe_100(i,j) + phyto(n)%juptake_fe(i,j,k)*rho_dzt(i,j,k)
                 phyto(n)%juptake_po4_100(i,j) = phyto(n)%juptake_po4_100(i,j) + phyto(n)%juptake_po4(i,j,k)*rho_dzt(i,j,k)
              enddo !} n
@@ -6181,7 +6145,6 @@ contains
                    rho_dzt(i,j,k)
                 zoo(n)%jremin_n_100(i,j) = zoo(n)%jremin_n_100(i,j) + zoo(n)%jprod_nh4(i,j,k)* &
                    rho_dzt(i,j,k)
-                zoo(n)%f_n_100(i,j) = zoo(n)%f_n_100(i,j) + zoo(n)%f_n(i,j,k)*rho_dzt(i,j,k)
              enddo !} n
 
              do n = 1,2 !{
@@ -6210,57 +6173,17 @@ contains
              bact(1)%jvirloss_n_100(i,j) = bact(1)%jvirloss_n_100(i,j) + bact(1)%jvirloss_n(i,j,k) * rho_dzt(i,j,k)
              bact(1)%jremin_n_100(i,j) = bact(1)%jremin_n_100(i,j) + bact(1)%jprod_nh4(i,j,k) * rho_dzt(i,j,k)
              bact(1)%juptake_ldon_100(i,j) = bact(1)%juptake_ldon_100(i,j) + bact(1)%juptake_ldon(i,j,k) * rho_dzt(i,j,k)
-             bact(1)%f_n_100(i,j) = bact(1)%f_n_100(i,j) + bact(1)%f_n(i,j,k)*rho_dzt(i,j,k)
 
              cobalt%jprod_lithdet_100(i,j) = cobalt%jprod_lithdet_100(i,j) + cobalt%jprod_lithdet(i,j,k) * rho_dzt(i,j,k)
              cobalt%jprod_sidet_100(i,j) = cobalt%jprod_sidet_100(i,j) + cobalt%jprod_sidet(i,j,k) * rho_dzt(i,j,k)
              cobalt%jprod_cadet_calc_100(i,j) = cobalt%jprod_cadet_calc_100(i,j) + cobalt%jprod_cadet_calc(i,j,k) * rho_dzt(i,j,k)
              cobalt%jprod_cadet_arag_100(i,j) = cobalt%jprod_cadet_arag_100(i,j) + cobalt%jprod_cadet_arag(i,j,k) * rho_dzt(i,j,k)
              cobalt%jremin_ndet_100(i,j) = cobalt%jremin_ndet_100(i,j) + cobalt%jremin_ndet(i,j,k) * rho_dzt(i,j,k)
-             cobalt%f_ndet_100(i,j) = cobalt%f_ndet_100(i,j) + cobalt%f_ndet(i,j,k)*rho_dzt(i,j,k)
-             cobalt%f_don_100(i,j) = cobalt%f_don_100(i,j) + (cobalt%f_ldon(i,j,k) + cobalt%f_sldon(i,j,k) + &
-                cobalt%f_srdon(i,j,k))*rho_dzt(i,j,k)
-             cobalt%f_silg_100(i,j) = cobalt%f_silg_100(i,j) + cobalt%f_silg(i,j,k)*rho_dzt(i,j,k)
-
-             cobalt%fndet_100(i,j) = cobalt%f_ndet(i,j,k) * cobalt%Rho_0 * cobalt%wsink
-             cobalt%fpdet_100(i,j) = cobalt%f_pdet(i,j,k) * cobalt%Rho_0 * cobalt%wsink
-             cobalt%ffedet_100(i,j) = cobalt%f_fedet(i,j,k) * cobalt%Rho_0 * cobalt%wsink
-             cobalt%flithdet_100(i,j) = cobalt%f_lithdet(i,j,k) * cobalt%Rho_0 * cobalt%wsink
-             cobalt%fsidet_100(i,j) = cobalt%f_sidet(i,j,k) * cobalt%Rho_0 * cobalt%wsink
-             cobalt%fcadet_arag_100(i,j) = cobalt%f_cadet_arag(i,j,k) * cobalt%Rho_0 * cobalt%wsink
-             cobalt%fcadet_calc_100(i,j) = cobalt%f_cadet_calc(i,j,k) * cobalt%Rho_0 * cobalt%wsink
-
-             cobalt%fntot_100(i,j) = (cobalt%f_ndet(i,j,k)*cobalt%wsink + &
-               phyto(SMALL)%f_n(i,j,k)*phyto(SMALL)%vmove(i,j,k) + &
-               phyto(MEDIUM)%f_n(i,j,k)*phyto(MEDIUM)%vmove(i,j,k) + &
-               phyto(LARGE)%f_n(i,j,k)*phyto(LARGE)%vmove(i,j,k) + &
-               phyto(DIAZO)%f_n(i,j,k)*phyto(DIAZO)%vmove(i,j,k))*cobalt%Rho_0
-             cobalt%fptot_100(i,j) = (cobalt%f_pdet(i,j,k)*cobalt%wsink + &
-               phyto(SMALL)%f_p(i,j,k)*phyto(SMALL)%vmove(i,j,k) + &
-               phyto(MEDIUM)%f_p(i,j,k)*phyto(MEDIUM)%vmove(i,j,k) + &
-               phyto(LARGE)%f_p(i,j,k)*phyto(LARGE)%vmove(i,j,k) + &
-               phyto(DIAZO)%f_p(i,j,k)*phyto(DIAZO)%vmove(i,j,k))*cobalt%Rho_0
-             cobalt%ffetot_100(i,j) = (cobalt%f_fedet(i,j,k)*cobalt%wsink + &
-               phyto(SMALL)%f_fe(i,j,k)*phyto(SMALL)%vmove(i,j,k) + &
-               phyto(MEDIUM)%f_fe(i,j,k)*phyto(MEDIUM)%vmove(i,j,k) + &
-               phyto(LARGE)%f_fe(i,j,k)*phyto(LARGE)%vmove(i,j,k) + &
-               phyto(DIAZO)%f_fe(i,j,k)*phyto(DIAZO)%vmove(i,j,k))*cobalt%Rho_0
-             cobalt%fsitot_100(i,j) = (cobalt%f_sidet(i,j,k)*cobalt%wsink + &
-               cobalt%f_simd(i,j,k)*phyto(MEDIUM)%vmove(i,j,k) + &
-               cobalt%f_silg(i,j,k)*phyto(LARGE)%vmove(i,j,k))*cobalt%Rho_0
-
           endif
        enddo  !} k
 
        if (k_100 .gt. 1 .and. k_100 .lt. grid_kmt(i,j)) then
           drho_dzt = cobalt%Rho_0 * 100.0 - rho_dzt_100(i,j)
-          cobalt%f_alk_int_100(i,j) = cobalt%f_alk_int_100(i,j) + cobalt%p_alk(i,j,k_100,tau) * drho_dzt
-          cobalt%f_dic_int_100(i,j) = cobalt%f_dic_int_100(i,j) + cobalt%p_dic(i,j,k_100,tau) * drho_dzt
-          cobalt%f_din_int_100(i,j) = cobalt%f_din_int_100(i,j) + (cobalt%p_no3(i,j,k_100,tau) +       &
-             cobalt%p_nh4(i,j,k_100,tau)) * drho_dzt
-          cobalt%f_fed_int_100(i,j) = cobalt%f_fed_int_100(i,j) + cobalt%p_fed(i,j,k_100,tau) * drho_dzt
-          cobalt%f_po4_int_100(i,j) = cobalt%f_po4_int_100(i,j) + cobalt%p_po4(i,j,k_100,tau) * drho_dzt
-          cobalt%f_sio4_int_100(i,j) = cobalt%f_sio4_int_100(i,j) + cobalt%p_sio4(i,j,k_100,tau) * drho_dzt
           cobalt%jalk_100(i,j) = cobalt%jalk_100(i,j) + cobalt%jalk(i,j,k_100) * drho_dzt
           cobalt%jdic_100(i,j) = cobalt%jdic_100(i,j) + cobalt%jdic(i,j,k_100) * drho_dzt
           cobalt%jdin_100(i,j) = cobalt%jdin_100(i,j) + (cobalt%jno3(i,j,k_100) +  cobalt%jnh4(i,j,k_100)) * drho_dzt
@@ -6283,7 +6206,6 @@ contains
                  drho_dzt
               phyto(n)%jaggloss_n_100(i,j) = phyto(n)%jaggloss_n_100(i,j) + phyto(n)%jaggloss_n(i,j,k_100)* &
                  drho_dzt
-              phyto(n)%f_n_100(i,j) = phyto(n)%f_n_100(i,j) + phyto(n)%f_n(i,j,k_100)*drho_dzt
               phyto(n)%juptake_fe_100(i,j) = phyto(n)%juptake_fe_100(i,j) + phyto(n)%juptake_fe(i,j,k_100)*drho_dzt
               phyto(n)%juptake_po4_100(i,j) = phyto(n)%juptake_po4_100(i,j) + phyto(n)%juptake_po4(i,j,k_100)*drho_dzt
            enddo !} n
@@ -6304,7 +6226,6 @@ contains
                  drho_dzt
                zoo(n)%jremin_n_100(i,j) = zoo(n)%jremin_n_100(i,j) + zoo(n)%jprod_nh4(i,j,k_100)* &
                  drho_dzt
-               zoo(n)%f_n_100(i,j) = zoo(n)%f_n_100(i,j) + zoo(n)%f_n(i,j,k_100)*drho_dzt
            enddo !} n
 
            do n = 1,2 !{
@@ -6350,39 +6271,6 @@ contains
                 drho_dzt
            cobalt%jremin_ndet_100(i,j) = cobalt%jremin_ndet_100(i,j) + cobalt%jremin_ndet(i,j,k_100)* &
                 drho_dzt
-
-           cobalt%f_ndet_100(i,j) = cobalt%f_ndet_100(i,j) + cobalt%f_ndet(i,j,k_100)*drho_dzt
-           cobalt%f_don_100(i,j) = cobalt%f_don_100(i,j) + (cobalt%f_ldon(i,j,k_100) + cobalt%f_sldon(i,j,k_100) + &
-              cobalt%f_srdon(i,j,k_100))*drho_dzt
-           cobalt%f_silg_100(i,j) = cobalt%f_silg_100(i,j) + cobalt%f_silg(i,j,k_100)*drho_dzt
-           cobalt%f_simd_100(i,j) = cobalt%f_simd_100(i,j) + cobalt%f_simd(i,j,k_100)*drho_dzt
-
-           cobalt%fndet_100(i,j) = cobalt%f_ndet(i,j,k_100) * cobalt%Rho_0 * cobalt%wsink
-           cobalt%fpdet_100(i,j) = cobalt%f_pdet(i,j,k_100) * cobalt%Rho_0 * cobalt%wsink
-           cobalt%ffedet_100(i,j) = cobalt%f_fedet(i,j,k_100) * cobalt%Rho_0 * cobalt%wsink
-           cobalt%flithdet_100(i,j) = cobalt%f_lithdet(i,j,k_100) * cobalt%Rho_0 * cobalt%wsink
-           cobalt%fsidet_100(i,j) = cobalt%f_sidet(i,j,k_100) * cobalt%Rho_0 * cobalt%wsink
-           cobalt%fcadet_arag_100(i,j) = cobalt%f_cadet_arag(i,j,k_100) * cobalt%Rho_0 * cobalt%wsink
-           cobalt%fcadet_calc_100(i,j) = cobalt%f_cadet_calc(i,j,k_100) * cobalt%Rho_0 * cobalt%wsink
-
-           cobalt%fntot_100(i,j) = (cobalt%f_ndet(i,j,k_100)*cobalt%wsink + &
-               phyto(SMALL)%f_n(i,j,k_100)*phyto(SMALL)%vmove(i,j,k_100) + &
-               phyto(MEDIUM)%f_n(i,j,k_100)*phyto(MEDIUM)%vmove(i,j,k_100) + &
-               phyto(LARGE)%f_n(i,j,k_100)*phyto(LARGE)%vmove(i,j,k_100) + &
-               phyto(DIAZO)%f_n(i,j,k_100)*phyto(DIAZO)%vmove(i,j,k_100))*cobalt%Rho_0
-           cobalt%fptot_100(i,j) = (cobalt%f_pdet(i,j,k_100)*cobalt%wsink + &
-               phyto(SMALL)%f_p(i,j,k_100)*phyto(SMALL)%vmove(i,j,k_100) + &
-               phyto(MEDIUM)%f_p(i,j,k_100)*phyto(MEDIUM)%vmove(i,j,k_100) + &
-               phyto(LARGE)%f_p(i,j,k_100)*phyto(LARGE)%vmove(i,j,k_100) + &
-               phyto(DIAZO)%f_p(i,j,k_100)*phyto(DIAZO)%vmove(i,j,k_100))*cobalt%Rho_0
-           cobalt%ffetot_100(i,j) = (cobalt%f_fedet(i,j,k_100)*cobalt%wsink + &
-               phyto(SMALL)%f_fe(i,j,k_100)*phyto(SMALL)%vmove(i,j,k_100) + &
-               phyto(MEDIUM)%f_fe(i,j,k_100)*phyto(MEDIUM)%vmove(i,j,k_100) + &
-               phyto(LARGE)%f_fe(i,j,k_100)*phyto(LARGE)%vmove(i,j,k_100) + &
-               phyto(DIAZO)%f_fe(i,j,k_100)*phyto(DIAZO)%vmove(i,j,k_100))*cobalt%Rho_0
-           cobalt%fsitot_100(i,j) = (cobalt%f_sidet(i,j,k_100)*cobalt%wsink + &
-               cobalt%f_simd(i,j,k_100)*phyto(MEDIUM)%vmove(i,j,k_100) + &
-               cobalt%f_silg(i,j,k_100)*phyto(LARGE)%vmove(i,j,k_100))*cobalt%Rho_0
        endif
 
        cobalt%jprod_allphytos_100(i,j) = phyto(SMALL)%jprod_n_100(i,j) + phyto(MEDIUM)%jprod_n_100(i,j) + &
@@ -6401,7 +6289,7 @@ contains
                 phyto(n)%f_n(i,j,1)*rho_dzt(i,j,1)/(phyto(n)%f_n_100(i,j)+epsln)
           phyto(n)%plim_bw_100(i,j) = phyto(n)%po4lim(i,j,1)* &
                 phyto(n)%f_n(i,j,1)*rho_dzt(i,j,1)/(phyto(n)%f_n_100(i,j)+epsln)
-          phyto(n)%def_fe_bw_100(i,j) = phyto(n)%def_fe(i,j,1)* &
+          phyto(n)%def_fe_bw_100(i,j) = max(phyto(n)%felim(i,j,1),phyto(n)%def_fe(i,j,1))* &
                 phyto(n)%f_n(i,j,1)*rho_dzt(i,j,1)/(phyto(n)%f_n_100(i,j)+epsln)
           phyto(n)%irrlim_bw_100(i,j) = phyto(n)%irrlim(i,j,1)* &
                 phyto(n)%f_n(i,j,1)*rho_dzt(i,j,1)/(phyto(n)%f_n_100(i,j)+epsln)
@@ -6420,7 +6308,8 @@ contains
                    phyto(n)%f_n(i,j,k)*rho_dzt(i,j,k)/(phyto(n)%f_n_100(i,j)+epsln)
                 phyto(n)%plim_bw_100(i,j) = phyto(n)%plim_bw_100(i,j) + phyto(n)%po4lim(i,j,k)* &
                    phyto(n)%f_n(i,j,k)*rho_dzt(i,j,k)/(phyto(n)%f_n_100(i,j)+epsln)
-                phyto(n)%def_fe_bw_100(i,j) = phyto(n)%def_fe_bw_100(i,j) + phyto(n)%def_fe(i,j,k)* &
+                phyto(n)%def_fe_bw_100(i,j) = phyto(n)%def_fe_bw_100(i,j) + &
+                   max(phyto(n)%felim(i,j,k),phyto(n)%def_fe(i,j,k))* &
                    phyto(n)%f_n(i,j,k)*rho_dzt(i,j,k)/(phyto(n)%f_n_100(i,j)+epsln)
                 phyto(n)%irrlim_bw_100(i,j) = phyto(n)%irrlim_bw_100(i,j) + phyto(n)%irrlim(i,j,k)* &
                    phyto(n)%f_n(i,j,k)*rho_dzt(i,j,k)/(phyto(n)%f_n_100(i,j)+epsln)
@@ -6436,7 +6325,8 @@ contains
                 phyto(n)%f_n(i,j,k_100)*drho_dzt/(phyto(n)%f_n_100(i,j)+epsln)
              phyto(n)%plim_bw_100(i,j) = phyto(n)%plim_bw_100(i,j) + phyto(n)%po4lim(i,j,k_100)* &
                 phyto(n)%f_n(i,j,k_100)*drho_dzt/(phyto(n)%f_n_100(i,j)+epsln)
-             phyto(n)%def_fe_bw_100(i,j) = phyto(n)%def_fe_bw_100(i,j) + phyto(n)%def_fe(i,j,k_100)* &
+             phyto(n)%def_fe_bw_100(i,j) = phyto(n)%def_fe_bw_100(i,j) + &
+                max(phyto(n)%felim(i,j,k_100),phyto(n)%def_fe(i,j,k_100))* &
                 phyto(n)%f_n(i,j,k_100)*drho_dzt/(phyto(n)%f_n_100(i,j)+epsln)
              phyto(n)%irrlim_bw_100(i,j) = phyto(n)%irrlim_bw_100(i,j) + phyto(n)%irrlim(i,j,k_100)* &
                 phyto(n)%f_n(i,j,k_100)*drho_dzt/(phyto(n)%f_n_100(i,j)+epsln)
@@ -6447,85 +6337,9 @@ contains
 
     do j = jsc, jec ; do i = isc, iec ; !{
       if (grid_kmt(i,j) .gt. 0) then !{
-    !     cobalt%btm_temp_old(i,j) = Temp(i,j,grid_kmt(i,j))
-    !     cobalt%btm_o2_old(i,j) = cobalt%f_o2(i,j,grid_kmt(i,j))
-    !     cobalt%btm_htotal_old(i,j) = cobalt%f_htotal(i,j,grid_kmt(i,j))
-    !     cobalt%btm_co3_sol_arag_old(i,j) = cobalt%co3_sol_arag(i,j,grid_kmt(i,j))
-    !     cobalt%btm_co3_sol_calc_old(i,j) = cobalt%co3_sol_calc(i,j,grid_kmt(i,j))
-    !     cobalt%btm_co3_ion_old(i,j) = cobalt%f_co3_ion(i,j,grid_kmt(i,j))
          cobalt%cased_2d(i,j) = cobalt%f_cased(i,j,1)
       endif
     enddo; enddo  !} i, j
-
-    ! Calculate the bottom layer over a thickness defined by cobalt%bottom_thickness
-    ! rather than the bottom-most layer as in MOM4/5.  This avoids numerical issues
-    ! generated in "vanishing" layers that overlie the benthos in most regions.
-    do j = jsc, jec ; do i = isc, iec  !{
-       rho_dzt_bot(i,j) = 0.0
-       cobalt%btm_temp(i,j) = 0.0
-       cobalt%btm_o2(i,j) = 0.0
-       cobalt%btm_dic(i,j) = 0.0
-       cobalt%btm_alk(i,j) = 0.0
-       cobalt%btm_htotal(i,j) = 0.0
-       cobalt%btm_co3_sol_arag(i,j) = 0.0
-       cobalt%btm_co3_sol_calc(i,j) = 0.0
-       cobalt%btm_co3_ion(i,j) = 0.0
-       cobalt%btm_omega_calc(i,j) = 0.0
-       cobalt%btm_omega_arag(i,j) = 0.0
-       k_bot(i,j) = 0
-       k = grid_kmt(i,j)
-       if (k .gt. 0) then !{
-         cobalt%grid_kmt_diag(i,j) = float(k)
-         cobalt%rho_dzt_kmt_diag(i,j) = rho_dzt(i,j,k)
-         do k = grid_kmt(i,j),1,-1   !{
-           if (rho_dzt_bot(i,j).lt.cobalt%Rho_0*cobalt%bottom_thickness) then
-             k_bot(i,j) = k
-             rho_dzt_bot(i,j) = rho_dzt_bot(i,j) + rho_dzt(i,j,k)
-             cobalt%k_bot_diag(i,j) = grid_kmt(i,j)-float(k)+1.0
-             cobalt%btm_o2(i,j) = cobalt%btm_o2(i,j) + &
-               cobalt%f_o2(i,j,k)*rho_dzt(i,j,k)
-             cobalt%btm_alk(i,j) = cobalt%btm_alk(i,j) + &
-               cobalt%f_alk(i,j,k)*rho_dzt(i,j,k)
-             cobalt%btm_dic(i,j) = cobalt%btm_dic(i,j) + &
-               cobalt%f_dic(i,j,k)*rho_dzt(i,j,k)
-             cobalt%btm_temp(i,j) = cobalt%btm_temp(i,j) + &
-               Temp(i,j,k)*rho_dzt(i,j,k)
-             cobalt%btm_htotal(i,j) = cobalt%btm_htotal(i,j) + &
-               cobalt%f_htotal(i,j,k)*rho_dzt(i,j,k)
-             cobalt%btm_co3_sol_arag(i,j) = cobalt%btm_co3_sol_arag(i,j) + &
-               cobalt%co3_sol_arag(i,j,k)*rho_dzt(i,j,k)
-             cobalt%btm_co3_sol_calc(i,j) = cobalt%btm_co3_sol_calc(i,j) + &
-               cobalt%co3_sol_calc(i,j,k)*rho_dzt(i,j,k)
-             cobalt%btm_co3_ion(i,j) = cobalt%btm_co3_ion(i,j) + &
-               cobalt%f_co3_ion(i,j,k)*rho_dzt(i,j,k)
-           endif
-         enddo
-         ! diagnostic to assess how far up into the water column info is being drawn from
-         cobalt%rho_dzt_bot_diag(i,j) = rho_dzt_bot(i,j)
-         ! calculate overshoot and subtract off
-         drho_dzt = rho_dzt_bot(i,j) - cobalt%Rho_0*cobalt%bottom_thickness
-         cobalt%btm_temp(i,j)=cobalt%btm_temp(i,j)-Temp(i,j,k_bot(i,j))*drho_dzt
-         cobalt%btm_o2(i,j)=cobalt%btm_o2(i,j)-cobalt%f_o2(i,j,k_bot(i,j))*drho_dzt
-         cobalt%btm_alk(i,j)=cobalt%btm_alk(i,j)-cobalt%f_alk(i,j,k_bot(i,j))*drho_dzt
-         cobalt%btm_dic(i,j)=cobalt%btm_dic(i,j)-cobalt%f_dic(i,j,k_bot(i,j))*drho_dzt
-         cobalt%btm_htotal(i,j)=cobalt%btm_htotal(i,j)-cobalt%f_htotal(i,j,k_bot(i,j))*drho_dzt
-         cobalt%btm_co3_sol_arag(i,j)=cobalt%btm_co3_sol_arag(i,j)-cobalt%co3_sol_arag(i,j,k_bot(i,j))*drho_dzt
-         cobalt%btm_co3_sol_calc(i,j)=cobalt%btm_co3_sol_calc(i,j)-cobalt%co3_sol_calc(i,j,k_bot(i,j))*drho_dzt
-         cobalt%btm_co3_ion(i,j)=cobalt%btm_co3_ion(i,j)-cobalt%f_co3_ion(i,j,k_bot(i,j))*drho_dzt
-         ! convert back to moles kg-1
-         cobalt%btm_temp(i,j)=cobalt%btm_temp(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-         cobalt%btm_o2(i,j)=cobalt%btm_o2(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-         cobalt%btm_alk(i,j)=cobalt%btm_alk(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-         cobalt%btm_dic(i,j)=cobalt%btm_dic(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-         cobalt%btm_htotal(i,j)=cobalt%btm_htotal(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-         cobalt%btm_co3_sol_arag(i,j)=cobalt%btm_co3_sol_arag(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-         cobalt%btm_co3_sol_calc(i,j)=cobalt%btm_co3_sol_calc(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-         cobalt%btm_co3_ion(i,j)=cobalt%btm_co3_ion(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-         ! calculate bottom saturation states
-         cobalt%btm_omega_calc(i,j) = cobalt%btm_co3_ion(i,j)/cobalt%btm_co3_sol_calc(i,j)
-         cobalt%btm_omega_arag(i,j) = cobalt%btm_co3_ion(i,j)/cobalt%btm_co3_sol_arag(i,j)
-       endif
-    enddo; enddo
 
     !
     !---------------------------------------------------------------------
@@ -6537,7 +6351,6 @@ contains
     do j = jsc, jec ; do i = isc, iec !{
        rho_dzt_200(i,j) = rho_dzt(i,j,1)
        cobalt%jprod_mesozoo_200(i,j) = (zoo(2)%jprod_n(i,j,1) + zoo(3)%jprod_n(i,j,1))*rho_dzt(i,j,1)
-       cobalt%f_mesozoo_200(i,j) = (zoo(2)%f_n(i,j,1)+zoo(3)%f_n(i,j,1))*rho_dzt(i,j,1)
        cobalt%jprod_allphytos_200(i,j) = (phyto(1)%jprod_n(i,j,1) + phyto(2)%jprod_n(i,j,1) + &
              phyto(3)%jprod_n(i,j,1) + phyto(4)%jprod_n(i,j,1))*rho_dzt(i,j,1);
     enddo; enddo !} i,j
@@ -6550,8 +6363,6 @@ contains
              rho_dzt_200(i,j) = rho_dzt_200(i,j) + rho_dzt(i,j,k)
              cobalt%jprod_mesozoo_200(i,j) = cobalt%jprod_mesozoo_200(i,j) + &
                 (zoo(2)%jprod_n(i,j,k) + zoo(3)%jprod_n(i,j,k))*rho_dzt(i,j,k)
-             cobalt%f_mesozoo_200(i,j) = cobalt%f_mesozoo_200(i,j) + &
-                (zoo(2)%f_n(i,j,k)+zoo(3)%f_n(i,j,k))*rho_dzt(i,j,k)
              cobalt%jprod_allphytos_200(i,j) = cobalt%jprod_allphytos_200(i,j) + &
                  (phyto(1)%jprod_n(i,j,k) + phyto(2)%jprod_n(i,j,k) + &
                  phyto(3)%jprod_n(i,j,k) + phyto(4)%jprod_n(i,j,k))*rho_dzt(i,j,k);
@@ -6562,13 +6373,12 @@ contains
           drho_dzt = cobalt%Rho_0 * 200.0 - rho_dzt_200(i,j)
           cobalt%jprod_mesozoo_200(i,j) = cobalt%jprod_mesozoo_200(i,j) + &
               (zoo(2)%jprod_n(i,j,k_200) + zoo(3)%jprod_n(i,j,k_200))*drho_dzt
-          cobalt%f_mesozoo_200(i,j) = cobalt%f_mesozoo_200(i,j) + &
-              (zoo(2)%f_n(i,j,k_200)+zoo(3)%f_n(i,j,k_200))*drho_dzt
           cobalt%jprod_allphytos_200(i,j) = cobalt%jprod_allphytos_200(i,j) + &
                (phyto(1)%jprod_n(i,j,k_200) + phyto(2)%jprod_n(i,j,k_200) + &
                phyto(3)%jprod_n(i,j,k_200) + phyto(4)%jprod_n(i,j,k_200))*drho_dzt
        endif
     enddo ; enddo  !} i,j
+    deallocate(rho_dzt_200)
 
     call g_tracer_get_values(tracer_list,'alk','runoff_tracer_flux',cobalt%runoff_flux_alk,isd,jsd)
     call g_tracer_get_values(tracer_list,'dic','runoff_tracer_flux',cobalt%runoff_flux_dic,isd,jsd)
@@ -6624,8 +6434,8 @@ contains
 !
 ! Send phytoplankton diagnostic data
 
-    call cobalt_send_diagnostics(tracer_list,model_time,grid_tmask,Temp,rho_dzt,dzt, &
-            isc,iec,jsc,jec,nk,tau,phyto,zoo,bact,cobalt) 
+    call cobalt_send_diagnostics(tracer_list,model_time,grid_tmask,Temp,Salt,rho_dzt,dzt, &
+         isc,iec,jsc,jec,isd,ied,jsd,jed,nk,grid_kmt,tau,phyto,zoo,bact,cobalt)
 
 !==============================================================================================================
 
@@ -7183,7 +6993,6 @@ contains
     allocate(cobalt%f_sio4(isd:ied, jsd:jed, 1:nk))       ; cobalt%f_sio4=0.0
     allocate(cobalt%co3_sol_arag(isd:ied, jsd:jed, 1:nk)) ; cobalt%co3_sol_arag=0.0
     allocate(cobalt%co3_sol_calc(isd:ied, jsd:jed, 1:nk)) ; cobalt%co3_sol_calc=0.0
-    allocate(cobalt%rho_test(isd:ied, jsd:jed, 1:nk)) ; cobalt%rho_test=0.0
     allocate(cobalt%f_chl(isd:ied, jsd:jed, 1:nk))        ; cobalt%f_chl=0.0
     if (do_nh3_diag) allocate(cobalt%f_nh3(isd:ied, jsd:jed, 1:nk))        ; cobalt%f_nh3=0.0
     allocate(cobalt%f_co3_ion(isd:ied, jsd:jed, 1:nk))    ; cobalt%f_co3_ion=0.0
@@ -7332,8 +7141,8 @@ contains
     allocate(cobalt%total_filter_feeding(isd:ied,jsd:jed,1:nk)); cobalt%total_filter_feeding=0.0
     allocate(cobalt%nlg_diatoms(isd:ied, jsd:jed, 1:nk)); cobalt%nlg_diatoms=0.0
     allocate(cobalt%nmd_diatoms(isd:ied, jsd:jed, 1:nk)); cobalt%nmd_diatoms=0.0
-    allocate(cobalt%q_si_2_n_lg_diatoms(isd:ied, jsd:jed, 1:nk)); cobalt%q_si_2_n_lg_diatoms=0.0
-    allocate(cobalt%q_si_2_n_md_diatoms(isd:ied, jsd:jed, 1:nk)); cobalt%q_si_2_n_md_diatoms=0.0
+    allocate(cobalt%nlg_misc(isd:ied, jsd:jed, 1:nk)); cobalt%nlg_misc=0.0
+    allocate(cobalt%nmd_misc(isd:ied, jsd:jed, 1:nk)); cobalt%nmd_misc=0.0
     allocate(cobalt%zt(isd:ied, jsd:jed, 1:nk))           ; cobalt%zt=0.0
     allocate(cobalt%b_alk(isd:ied, jsd:jed))              ; cobalt%b_alk=0.0
     allocate(cobalt%b_dic(isd:ied, jsd:jed))              ; cobalt%b_dic=0.0
@@ -7523,13 +7332,6 @@ contains
    allocate(cobalt%k_bot_diag(isd:ied,jsd:jed))            ; cobalt%k_bot_diag = 0.0
    allocate(cobalt%rho_dzt_bot_diag(isd:ied,jsd:jed))      ; cobalt%rho_dzt_bot_diag = 0.0
    allocate(cobalt%rho_dzt_kmt_diag(isd:ied,jsd:jed))      ; cobalt%rho_dzt_kmt_diag = 0.0
-
-   allocate(cobalt%btm_temp_old(isd:ied,jsd:jed))          ; cobalt%btm_temp_old = 0.0
-   allocate(cobalt%btm_o2_old(isd:ied,jsd:jed))            ; cobalt%btm_o2_old = 0.0
-   allocate(cobalt%btm_htotal_old(isd:ied,jsd:jed))        ; cobalt%btm_htotal_old = 0.0
-   allocate(cobalt%btm_co3_ion_old(isd:ied,jsd:jed))       ; cobalt%btm_co3_ion_old = 0.0
-   allocate(cobalt%btm_co3_sol_arag_old(isd:ied,jsd:jed))  ; cobalt%btm_co3_sol_arag_old = 0.0
-   allocate(cobalt%btm_co3_sol_calc_old(isd:ied,jsd:jed))  ; cobalt%btm_co3_sol_calc_old = 0.0
 
    allocate(cobalt%o2min(isd:ied, jsd:jed))                ; cobalt%o2min=0.0
    allocate(cobalt%z_o2min(isd:ied, jsd:jed))              ; cobalt%z_o2min=0.0
@@ -7736,7 +7538,6 @@ contains
     deallocate(cobalt%f_sio4)
     deallocate(cobalt%co3_sol_arag)
     deallocate(cobalt%co3_sol_calc)
-    deallocate(cobalt%rho_test)
     deallocate(cobalt%f_chl)
     if (allocated(cobalt%f_nh3)) deallocate(cobalt%f_nh3)
     deallocate(cobalt%f_co3_ion)
@@ -7888,8 +7689,8 @@ contains
     deallocate(cobalt%total_filter_feeding)
     deallocate(cobalt%nlg_diatoms)
     deallocate(cobalt%nmd_diatoms)
-    deallocate(cobalt%q_si_2_n_lg_diatoms)
-    deallocate(cobalt%q_si_2_n_md_diatoms)
+    deallocate(cobalt%nlg_misc)
+    deallocate(cobalt%nmd_misc)
     deallocate(cobalt%zt)
 !==============================================================================================================
 ! JGJ 2016/08/08 CMIP6 OcnBgchem
@@ -7986,12 +7787,6 @@ contains
     deallocate(cobalt%rho_dzt_bot_diag)
     deallocate(cobalt%rho_dzt_kmt_diag)
     deallocate(cobalt%cased_2d)
-    deallocate(cobalt%btm_temp_old)
-    deallocate(cobalt%btm_o2_old)
-    deallocate(cobalt%btm_htotal_old)
-    deallocate(cobalt%btm_co3_ion_old)
-    deallocate(cobalt%btm_co3_sol_arag_old)
-    deallocate(cobalt%btm_co3_sol_calc_old)
     deallocate(cobalt%o2min)
     deallocate(cobalt%z_o2min)
     deallocate(cobalt%z_sat_arag)

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -5196,11 +5196,6 @@ contains
                     cobalt%p_simd(i,j,k,tau) + cobalt%p_sidet(i,j,k,tau))*grid_tmask(i,j,k)
     enddo; enddo ; enddo  !} i,j,k
 
-    if (cobalt%id_no3_in_source .gt. 0)                &
-         used = g_send_data(cobalt%id_no3_in_source,         cobalt%f_no3,          &
-         model_time, rmask = grid_tmask,&
-         is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-
     call mpp_clock_end(id_clock_source_sink_loop1)
     !
     !-----------------------------------------------------------------------
@@ -5768,13 +5763,13 @@ contains
     do j = jsc, jec ; do i = isc, iec  !{
       if (grid_kmt(i,j) .gt. 0) then !{
         cobalt%o2min(i,j)=cobalt%p_o2(i,j,1,tau)
-        cobalt%z_o2min(i,j)=cobalt%zt(i,j,1)
-        cobalt%z_sat_arag(i,j)=missing_value1
-        cobalt%z_sat_calc(i,j)=missing_value1
-        cobalt%mask_z_sat_arag(i,j) = .FALSE.
-        cobalt%mask_z_sat_calc(i,j) = .FALSE.
-        if (cobalt%omega_arag(i,j,1) .le. 1.0) cobalt%z_sat_arag(i,j)=0.0
-        if (cobalt%omega_calc(i,j,1) .le. 1.0) cobalt%z_sat_calc(i,j)=0.0
+        cobalt%zo2min(i,j)=cobalt%zt(i,j,1)
+        cobalt%zsatarag(i,j)=missing_value1
+        cobalt%zsatcalc(i,j)=missing_value1
+        cobalt%mask_zsatarag(i,j) = .FALSE.
+        cobalt%mask_zsatcalc(i,j) = .FALSE.
+        if (cobalt%omega_arag(i,j,1) .le. 1.0) cobalt%zsatarag(i,j)=0.0
+        if (cobalt%omega_calc(i,j,1) .le. 1.0) cobalt%zsatcalc(i,j)=0.0
       endif !}
     enddo ; enddo  !} i,j,k
     do j = jsc, jec ; do i = isc, iec  !{
@@ -5783,7 +5778,7 @@ contains
          if (k .le. grid_kmt(i,j) .and. first) then !{
            if (cobalt%p_o2(i,j,k,tau) .lt. cobalt%p_o2(i,j,k-1,tau)) then
              cobalt%o2min(i,j)=cobalt%p_o2(i,j,k,tau)
-             cobalt%z_o2min(i,j)=cobalt%zt(i,j,k)
+             cobalt%zo2min(i,j)=cobalt%zt(i,j,k)
            else
              first = .false.
            endif !}
@@ -5793,13 +5788,13 @@ contains
 
     do k = 2, nk ; do j = jsc, jec ; do i = isc, iec  !{
       if (k .le. grid_kmt(i,j)) then !{
-        if (cobalt%omega_arag(i,j,k) .le. 1.0 .and. cobalt%z_sat_arag(i,j) .lt. 0.0) then
-          cobalt%z_sat_arag(i,j)=cobalt%zt(i,j,k)
-          cobalt%mask_z_sat_arag(i,j) = .TRUE.
+        if (cobalt%omega_arag(i,j,k) .le. 1.0 .and. cobalt%zsatarag(i,j) .lt. 0.0) then
+          cobalt%zsatarag(i,j)=cobalt%zt(i,j,k)
+          cobalt%mask_zsatarag(i,j) = .TRUE.
         endif
-        if (cobalt%omega_calc(i,j,k) .le. 1.0 .and. cobalt%z_sat_calc(i,j) .lt. 0.0) then
-          cobalt%z_sat_calc(i,j)=cobalt%zt(i,j,k)
-          cobalt%mask_z_sat_calc(i,j) = .TRUE.
+        if (cobalt%omega_calc(i,j,k) .le. 1.0 .and. cobalt%zsatcalc(i,j) .lt. 0.0) then
+          cobalt%zsatcalc(i,j)=cobalt%zt(i,j,k)
+          cobalt%mask_zsatcalc(i,j) = .TRUE.
         endif
       endif !}
     enddo; enddo ; enddo  !} i,j,k
@@ -6852,7 +6847,6 @@ contains
        allocate(phyto(n)%alpha(isd:ied,jsd:jed,nk))        ; phyto(n)%alpha          = 0.0
        allocate(phyto(n)%bresp(isd:ied,jsd:jed,nk))        ; phyto(n)%bresp          = 0.0
        allocate(phyto(n)%def_fe(isd:ied,jsd:jed,nk))       ; phyto(n)%def_fe         = 0.0
-       allocate(phyto(n)%def_p(isd:ied,jsd:jed,nk))        ; phyto(n)%def_p          = 0.0
        allocate(phyto(n)%f_fe(isd:ied,jsd:jed,nk))         ; phyto(n)%f_fe           = 0.0
        allocate(phyto(n)%f_n(isd:ied,jsd:jed,nk))          ; phyto(n)%f_n            = 0.0
        allocate(phyto(n)%f_p(isd:ied,jsd:jed,nk))          ; phyto(n)%f_p            = 0.0
@@ -7334,11 +7328,11 @@ contains
    allocate(cobalt%rho_dzt_kmt_diag(isd:ied,jsd:jed))      ; cobalt%rho_dzt_kmt_diag = 0.0
 
    allocate(cobalt%o2min(isd:ied, jsd:jed))                ; cobalt%o2min=0.0
-   allocate(cobalt%z_o2min(isd:ied, jsd:jed))              ; cobalt%z_o2min=0.0
-   allocate(cobalt%z_sat_arag(isd:ied, jsd:jed))           ; cobalt%z_sat_arag=0.0
-   allocate(cobalt%z_sat_calc(isd:ied, jsd:jed))           ; cobalt%z_sat_calc=0.0
-   allocate(cobalt%mask_z_sat_arag(isd:ied, jsd:jed))      ; cobalt%mask_z_sat_arag = .FALSE.
-   allocate(cobalt%mask_z_sat_calc(isd:ied, jsd:jed))      ; cobalt%mask_z_sat_calc = .FALSE.
+   allocate(cobalt%zo2min(isd:ied, jsd:jed))               ; cobalt%zo2min=0.0
+   allocate(cobalt%zsatarag(isd:ied, jsd:jed))             ; cobalt%zsatarag=0.0
+   allocate(cobalt%zsatcalc(isd:ied, jsd:jed))             ; cobalt%zsatcalc=0.0
+   allocate(cobalt%mask_zsatarag(isd:ied, jsd:jed))        ; cobalt%mask_zsatarag = .FALSE.
+   allocate(cobalt%mask_zsatcalc(isd:ied, jsd:jed))        ; cobalt%mask_zsatcalc = .FALSE.
    if (do_14c) then                                        !<<RADIOCARBON
       allocate(cobalt%c14_2_n(isd:ied, jsd:jed, 1:nk));        cobalt%c14_2_n=0.0
       allocate(cobalt%f_di14c(isd:ied, jsd:jed, 1:nk));        cobalt%f_di14c=0.0
@@ -7401,7 +7395,6 @@ contains
        deallocate(phyto(n)%alpha)
        deallocate(phyto(n)%bresp)
        deallocate(phyto(n)%def_fe)
-       deallocate(phyto(n)%def_p)
        deallocate(phyto(n)%f_fe)
        deallocate(phyto(n)%f_n)
        deallocate(phyto(n)%f_p)
@@ -7788,11 +7781,11 @@ contains
     deallocate(cobalt%rho_dzt_kmt_diag)
     deallocate(cobalt%cased_2d)
     deallocate(cobalt%o2min)
-    deallocate(cobalt%z_o2min)
-    deallocate(cobalt%z_sat_arag)
-    deallocate(cobalt%z_sat_calc)
-    deallocate(cobalt%mask_z_sat_arag)
-    deallocate(cobalt%mask_z_sat_calc)
+    deallocate(cobalt%zo2min)
+    deallocate(cobalt%zsatarag)
+    deallocate(cobalt%zsatcalc)
+    deallocate(cobalt%mask_zsatarag)
+    deallocate(cobalt%mask_zsatcalc)
 !==============================================================================================================
 ! JGJ 2016/08/08 CMIP6 OcnBgchem
     deallocate(cobalt%f_alk_int_100)

--- a/generic_tracers/generic_tracer.F90
+++ b/generic_tracers/generic_tracer.F90
@@ -537,11 +537,11 @@ contains
   !  </IN>
   ! </SUBROUTINE>
 
-  subroutine generic_tracer_update_from_bottom(dt, tau, model_time, Temp, rho_dzt, dzt, ilb, jlb)
+  subroutine generic_tracer_update_from_bottom(dt, tau, model_time, Temp, Salt, rho_dzt, dzt, ilb, jlb)
     real,    intent(in) :: dt
     integer, intent(in) ::tau
     type(time_type),                intent(in) :: model_time
-    real, dimension(ilb:,jlb:,:),   intent(in) :: Temp,rho_dzt,dzt
+    real, dimension(ilb:,jlb:,:),   intent(in) :: Temp,Salt,rho_dzt,dzt
     integer, intent(in) :: ilb, jlb
 
     character(len=fm_string_len), parameter :: sub_name = 'generic_tracer_update_from_bottom'
@@ -565,7 +565,7 @@ contains
 !    if(do_generic_miniBLING)  call generic_miniBLING_update_from_bottom(tracer_list,dt, tau)
 
     if(do_generic_COBALT)  call generic_COBALT_update_from_bottom(tracer_list,dt, tau, model_time, &
-                                 Temp, rho_dzt, dzt, ilb, jlb)
+                                 Temp, Salt, rho_dzt, dzt, ilb, jlb)
 
     return
 


### PR DESCRIPTION
This PR is the first step in clean-up of the diagnostic codes for COBALTv3 to support CMIP6 and CEFI.  The major task was to re-organize the “g_send_data” calls so that the diagnostics associated with the prognostic tracers, diagnostic tracers, and sinking were saved after vertdiff.  

This is essentially an expansion of the structure established in @yichengt900's PR #117, which moved the water column tracer integrals after the tridiagonal vertdiff solver with the flag “is_postvertdiff”.  The fluxes used to calculate the biological sources/sink tendencies and the associated limitations are still saved at the end of ocean_cobalt_update_from_source.

The movement of these diagnostics ensures time-step scale consistency of all tracer values and fluxes within MOM6-COBALT (i.e., the fluxes reflect those applied during the time step, prognostic tracers and diagnostics derived from them reflect values at the end of the time step). 

For carbon system variables derived from mocsy, alignment with prognostic tracer values at the end of the timestep strictly requires recalculation of the carbon chemistry after the vertdiff call.  This pull request introduces a “recalculate_carbon” logical to the cobalt type with a default value of .true. .  If .false., the recalculation is skipped and the carbon system values kept at the beginning of update_from_source are kept.

The addition of carbon and 100m integrals to cobalt_send_diagnostics required an expansion of the arguments and routines available to the cobalt_send_diagnostics routine.  This in turn required small changes to generic_tracer.F90 and MOM_generic_tracer.F90.

In addition to refining the timing of the diagnostic sends, this PR also cleans up a number of other elements of the diagnostic code:

- The formatting of the calls has been cleaned up and made uniform.
- 3D fluxes that were saved as layer integrals (units of moles m-2 sec-1 by multiplying by rho_dzt) were changed to moles kg sec-1.  The layer integral approach was a legacy of MOM4/5.  It allowed you to easily sum layers to calculate integrated fluxes in a Z* framework.  The interpretation of layer integrals is more challenging in hybrid coordinates and they really don’t make sense when re-mapped.  This simplified the flux diagnostics (and allowed us to get rid of a few).
- replaced cases where cmip diagnostics were multiplied by rho_dzt/dzt with multiplication by cobalt%Rho_0 to simplify.
- Defined nmd_misc and nlg_misc for CMIP calculations.
- Updated the following diagnostics for COBALTv3: graz, intppnitrate
- Fixed a bug in the units of the CMIP surface chlorophyll diagnostics (1e6)
- Clarified units of mesozoo_200 (general strengthening of metadata will be handled in a subsequent PR)


Additional questions for the group:

- Many lines of code of the diagnostic code are spent extracting the top grid cell for surface properties.  Could these be eliminated and the diagnostics made more consistent by defining a surface layer in the diagnostic table?
- Where in the thermodynamic time step are the actual prognostic tracer values saved?
- Should we make the 100m integrals have a user-specified integration depth (i.e., _100m = _intz where z is specified in metadata)?
- What is the best way to test/verify such a broad PR?
