### PR TITLE
Implement neritic CaCO3 burial and particle-associated dissolution

### DIFF
--- a/generic_tracers/cobalt_reg_diag.F90
+++ b/generic_tracers/cobalt_reg_diag.F90
@@ -1931,47 +1931,47 @@ module COBALT_reg_diag
     !      To accomodate axesTi with the least amount of code modification we can set and check for an input array of size 1.
 
     vardesc_temp = vardesc("fcadet_arag","CaCO3 sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_fcadet_arag = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
+    cobalt%id_fcadet_arag = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("fcadet_calc","CaCO3 sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_fcadet_calc = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
+    cobalt%id_fcadet_calc = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("ffedet","fedet sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_ffedet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
+    cobalt%id_ffedet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("flithdet","lithdet sinking flux",'h','1','s','g m-2 s-1','f')
-    cobalt%id_flithdet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
+    cobalt%id_flithdet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("fndet","ndet sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_fndet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
+    cobalt%id_fndet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("fpdet","pdet sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_fpdet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
+    cobalt%id_fpdet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("fsidet","sidet sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_fsidet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
+    cobalt%id_fsidet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("ffetot","total Fe sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_ffetot = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
+    cobalt%id_ffetot = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("fntot","total N sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_fntot = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
+    cobalt%id_fntot = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("fptot","total P sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_fptot = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
+    cobalt%id_fptot = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("fsitot","total Si sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_fsitot = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
+    cobalt%id_fsitot = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     !

--- a/generic_tracers/cobalt_reg_diag.F90
+++ b/generic_tracers/cobalt_reg_diag.F90
@@ -1508,9 +1508,9 @@ module COBALT_reg_diag
     cobalt%id_jprod_cadet_calc = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-     ! << Fei Da, 202504: Add neritic CaCO3 burial
-    vardesc_temp = vardesc("jprod_cadet_neritic","Neritic CaCO3 production/burial",'h','L','s','mol kg-1 s-1','f')
-    cobalt%id_jprod_cadet_neritic = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+     ! << Add neritic CaCO3 burial effect on dissolved inorganic carbon (DIC)
+    vardesc_temp = vardesc("jdic_caco3_nerbur","Impact of neritic CaCO3 burial on DIC",'h','L','s','mol kg-1 s-1','f')
+    cobalt%id_jdic_caco3_nerbur = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
     ! >>
 
@@ -2790,9 +2790,9 @@ module COBALT_reg_diag
     cobalt%id_jprod_cadet_arag_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    ! << Fei Da, 202504: Add neritic CaCO3 burial
-    vardesc_temp = vardesc("jprod_cadet_neritic_150","Neritic CaCO3 production/burial integral in upper 150m",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_jprod_cadet_neritic_150 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+    ! << Add neritic CaCO3 burial
+    vardesc_temp = vardesc("jdic_caco3_nerbur_150","Neritic CaCO3 burial integral in upper 150m",'h','1','s','mol m-2 s-1','f')
+    cobalt%id_jdic_caco3_nerbur_150 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
     ! >>
 

--- a/generic_tracers/cobalt_reg_diag.F90
+++ b/generic_tracers/cobalt_reg_diag.F90
@@ -1508,6 +1508,12 @@ module COBALT_reg_diag
     cobalt%id_jprod_cadet_calc = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
+     ! << Fei Da, 202504: Add neritic CaCO3 burial
+    vardesc_temp = vardesc("jprod_cadet_neritic","Neritic CaCO3 production/burial",'h','L','s','mol kg-1 s-1','f')
+    cobalt%id_jprod_cadet_neritic = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+    ! >>
+
     vardesc_temp = vardesc("jprod_lithdet","Lithogenic detritus production",'h','L','s','g kg-1 s-1','f')
     cobalt%id_jprod_lithdet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -1925,47 +1931,47 @@ module COBALT_reg_diag
     !      To accomodate axesTi with the least amount of code modification we can set and check for an input array of size 1.
 
     vardesc_temp = vardesc("fcadet_arag","CaCO3 sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_fcadet_arag = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
+    cobalt%id_fcadet_arag = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("fcadet_calc","CaCO3 sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_fcadet_calc = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
+    cobalt%id_fcadet_calc = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("ffedet","fedet sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_ffedet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
+    cobalt%id_ffedet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("flithdet","lithdet sinking flux",'h','1','s','g m-2 s-1','f')
-    cobalt%id_flithdet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
+    cobalt%id_flithdet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("fndet","ndet sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_fndet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
+    cobalt%id_fndet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("fpdet","pdet sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_fpdet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
+    cobalt%id_fpdet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("fsidet","sidet sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_fsidet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
+    cobalt%id_fsidet = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("ffetot","total Fe sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_ffetot = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
+    cobalt%id_ffetot = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("fntot","total N sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_fntot = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
+    cobalt%id_fntot = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("fptot","total P sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_fptot = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
+    cobalt%id_fptot = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("fsitot","total Si sinking flux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_fsitot = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
+    cobalt%id_fsitot = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     !
@@ -2783,6 +2789,12 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("jprod_cadet_arag_100","Aragonite detritus production integral in upper 100m",'h','1','s','mol m-2 s-1','f')
     cobalt%id_jprod_cadet_arag_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    ! << Fei Da, 202504: Add neritic CaCO3 burial
+    vardesc_temp = vardesc("jprod_cadet_neritic_150","Neritic CaCO3 production/burial integral in upper 150m",'h','1','s','mol m-2 s-1','f')
+    cobalt%id_jprod_cadet_neritic_150 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+    ! >>
 
     vardesc_temp = vardesc("jremin_ndet_100","Remineralization of nitrogen detritus integral in upper 100m",'h','1','s','mol m-2 s-1','f')
     cobalt%id_jremin_ndet_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -1371,6 +1371,10 @@ module COBALT_send_diag
             model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jprod_cadet_calc, cobalt%jprod_cadet_calc, &
             model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! << Fei Da, 202504: Add neritic CaCO3 burial
+          used = g_send_data(cobalt%id_jprod_cadet_neritic, cobalt%jprod_cadet_neritic, &
+            model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! >>
           used = g_send_data(cobalt%id_jprod_ndet, cobalt%jprod_ndet, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jprod_pdet, cobalt%jprod_pdet, &
@@ -1727,7 +1731,12 @@ module COBALT_send_diag
           used = g_send_data(cobalt%id_jprod_cadet_arag_100, cobalt%jprod_cadet_arag_100, &
             model_time, rmask = grid_tmask(:,:,1),  is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_jremin_ndet_100, cobalt%jremin_ndet_100, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec) 
+          !
+          ! << Fei Da, 202504: neritic CaCO3 burial 150m flux integrals
+          used = g_send_data(cobalt%id_jprod_cadet_neritic_150, cobalt%jprod_cadet_neritic_150, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          ! >>
           !
           ! Water column flux integrals
           !

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -1371,8 +1371,8 @@ module COBALT_send_diag
             model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jprod_cadet_calc, cobalt%jprod_cadet_calc, &
             model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-          ! << Fei Da, 202504: Add neritic CaCO3 burial
-          used = g_send_data(cobalt%id_jprod_cadet_neritic, cobalt%jprod_cadet_neritic, &
+          ! << Add neritic CaCO3 burial
+          used = g_send_data(cobalt%id_jdic_caco3_nerbur, cobalt%jdic_caco3_nerbur, &
             model_time, rmask = grid_tmask(:,:,:), is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           ! >>
           used = g_send_data(cobalt%id_jprod_ndet, cobalt%jprod_ndet, &
@@ -1733,8 +1733,8 @@ module COBALT_send_diag
           used = g_send_data(cobalt%id_jremin_ndet_100, cobalt%jremin_ndet_100, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec) 
           !
-          ! << Fei Da, 202504: neritic CaCO3 burial 150m flux integrals
-          used = g_send_data(cobalt%id_jprod_cadet_neritic_150, cobalt%jprod_cadet_neritic_150, &
+          ! << Neritic CaCO3 burial 150m flux integrals
+          used = g_send_data(cobalt%id_jdic_caco3_nerbur_150, cobalt%jdic_caco3_nerbur_150, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           ! >>
           !

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -38,10 +38,6 @@ module cobalt_types
                                             !! 1-default COBALT
                                             !! 2-update with no temperature dependence
                                             !! 3-update with temperature dependence
-  ! << Fei Da, 202504: add namelist options for neritic CaCO3 burial and enhanced CaCO3 dissolution
-  logical, public :: do_ner_ca_bur = .false.    !< If true, then turn on neritic CaCO3 burial
-  logical, public :: do_resp_ca_diss = .false.  !< If true, then turn on enhanced respiration-driven CaCO3 dissolution
-  ! >>    
   ! parameters      
   integer, parameter, public :: NUM_PHYTO = 4 !< total number of phytoplankton groups
   integer, parameter, public :: NUM_ZOO = 3   !< total number of zooplankton groups
@@ -415,7 +411,11 @@ module cobalt_types
           do_fnso4red_sed,  &     ! Simulate O2 deficit and alkalinity flux from implied sedimentary sulfate reduction
           cased_steady,     &     ! steady state approximation for cased
           recalculate_carbon, &   ! true means C system is resolved for diagnostic
-          tracer_debug
+          tracer_debug, &
+          ! << Fei Da, 202504: options for neritic CaCO3 burial and enhanced CaCO3 dissolution
+          do_ner_ca_bur, &        ! Apply neritic CaCO3 burial from O'Mara & Dunne (2019)
+          do_resp_ca_diss         ! Apply enhanced CaCO3 dissolution
+          ! >>
      real  ::          &
           min_thickness       ! minimum thickness of a layer that will be checked for source/sink imbalances
 

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -412,7 +412,7 @@ module cobalt_types
           cased_steady,     &     ! steady state approximation for cased
           recalculate_carbon, &   ! true means C system is resolved for diagnostic
           tracer_debug, &
-          ! << Fei Da, 202504: options for neritic CaCO3 burial and enhanced CaCO3 dissolution
+          ! << Options for neritic CaCO3 burial and enhanced CaCO3 dissolution
           do_ner_ca_bur, &        ! Apply neritic CaCO3 burial from O'Mara & Dunne (2019)
           do_resp_ca_diss         ! Apply enhanced CaCO3 dissolution
           ! >>
@@ -424,7 +424,7 @@ module cobalt_types
           c_2_n,            &
           ca_2_n_arag,      &
           ca_2_n_calc,      &
-          ! << Fei Da, 202504: enhanced CaCO3 dissolution due to local undersaturation around sinking particles
+          ! << Enhanced CaCO3 dissolution due to local undersaturation around sinking particles
           resp_ca_2_n_arag, &
           resp_ca_2_n_calc, &
           ! >>
@@ -667,8 +667,8 @@ module cobalt_types
           jprod_lithdet,&
           jprod_cadet_arag,&
           jprod_cadet_calc,&
-! << Fei Da, 202504: Add neritic CaCO3 burial >>
-          jprod_cadet_neritic,&
+! << Add neritic CaCO3 burial >>
+          jdic_caco3_nerbur,&
           jprod_nh4,&
           jprod_nh4_plus_btm,&
           jprod_po4,&
@@ -793,8 +793,8 @@ module cobalt_types
           jprod_sidet_100,&
           jprod_cadet_calc_100,&
           jprod_cadet_arag_100,&
-! << Fei Da, 202504: Add neritic CaCO3 burial >>
-          jprod_cadet_neritic_150,&
+! << Add neritic CaCO3 burial >>
+          jdic_caco3_nerbur_150,&
           jprod_mesozoo_200, &
           jremin_ndet_100, &
           f_ndet_100, &
@@ -984,8 +984,8 @@ module cobalt_types
           id_jprod_lithdet = -1,       &
           id_jprod_cadet_arag = -1,    &
           id_jprod_cadet_calc = -1,    &
-! << Fei Da, 202504: Add neritic CaCO3 burial >>
-          id_jprod_cadet_neritic = -1, &
+! << Add neritic CaCO3 burial >>
+          id_jdic_caco3_nerbur = -1, &
           id_jprod_po4     = -1,       &
           id_jprod_nh4     = -1,       &
           id_jprod_nh4_plus_btm = -1,  &
@@ -1183,8 +1183,8 @@ module cobalt_types
           id_jprod_sidet_100 = -1,     &
           id_jprod_cadet_calc_100 = -1, &
           id_jprod_cadet_arag_100 = -1, &
-! << Fei Da, 202504: Add neritic CaCO3 burial >>
-          id_jprod_cadet_neritic_150 = -1, &
+! << Add neritic CaCO3 burial >>
+          id_jdic_caco3_nerbur_150 = -1, &
           id_jprod_mesozoo_200 = -1,   &
           id_daylength         = -1,   &
           id_jremin_ndet_100 = -1,     &

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -38,7 +38,10 @@ module cobalt_types
                                             !! 1-default COBALT
                                             !! 2-update with no temperature dependence
                                             !! 3-update with temperature dependence
-
+  ! << Fei Da, 202504: add namelist options for neritic CaCO3 burial and enhanced CaCO3 dissolution
+  logical, public :: do_ner_ca_bur = .false.    !< If true, then turn on neritic CaCO3 burial
+  logical, public :: do_resp_ca_diss = .false.  !< If true, then turn on enhanced respiration-driven CaCO3 dissolution
+  ! >>    
   ! parameters      
   integer, parameter, public :: NUM_PHYTO = 4 !< total number of phytoplankton groups
   integer, parameter, public :: NUM_ZOO = 3   !< total number of zooplankton groups
@@ -421,6 +424,10 @@ module cobalt_types
           c_2_n,            &
           ca_2_n_arag,      &
           ca_2_n_calc,      &
+          ! << Fei Da, 202504: enhanced CaCO3 dissolution due to local undersaturation around sinking particles
+          resp_ca_2_n_arag, &
+          resp_ca_2_n_calc, &
+          ! >>
           caco3_sat_max,    &
           doc_background,   &
           fe_2_n_upt_fac,   &
@@ -660,6 +667,8 @@ module cobalt_types
           jprod_lithdet,&
           jprod_cadet_arag,&
           jprod_cadet_calc,&
+! << Fei Da, 202504: Add neritic CaCO3 burial >>
+          jprod_cadet_neritic,&
           jprod_nh4,&
           jprod_nh4_plus_btm,&
           jprod_po4,&
@@ -784,6 +793,8 @@ module cobalt_types
           jprod_sidet_100,&
           jprod_cadet_calc_100,&
           jprod_cadet_arag_100,&
+! << Fei Da, 202504: Add neritic CaCO3 burial >>
+          jprod_cadet_neritic_150,&
           jprod_mesozoo_200, &
           jremin_ndet_100, &
           f_ndet_100, &
@@ -973,6 +984,8 @@ module cobalt_types
           id_jprod_lithdet = -1,       &
           id_jprod_cadet_arag = -1,    &
           id_jprod_cadet_calc = -1,    &
+! << Fei Da, 202504: Add neritic CaCO3 burial >>
+          id_jprod_cadet_neritic = -1, &
           id_jprod_po4     = -1,       &
           id_jprod_nh4     = -1,       &
           id_jprod_nh4_plus_btm = -1,  &
@@ -1170,6 +1183,8 @@ module cobalt_types
           id_jprod_sidet_100 = -1,     &
           id_jprod_cadet_calc_100 = -1, &
           id_jprod_cadet_arag_100 = -1, &
+! << Fei Da, 202504: Add neritic CaCO3 burial >>
+          id_jprod_cadet_neritic_150 = -1, &
           id_jprod_mesozoo_200 = -1,   &
           id_daylength         = -1,   &
           id_jremin_ndet_100 = -1,     &

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -4625,18 +4625,15 @@ contains
            rho_dzt_150(i,j) = rho_dzt(i,j,1)
            ! Sum the thickness of vertical layers from the surface down to 150m depth
            do k = 2, grid_kmt(i,j)  !{
-              if (rho_dzt_150(i,j) .lt. cobalt%Rho_0 * 150.0) then
-                 k_150 = k
-                 rho_dzt_150(i,j) = rho_dzt_150(i,j) + rho_dzt(i,j,k)
-              endif
+              if (rho_dzt_150(i,j) .ge. cobalt%Rho_0 * 150.0) exit
+              k_150 = k
+              rho_dzt_150(i,j) = rho_dzt_150(i,j) + rho_dzt(i,j,k)
            enddo  !} k
            ! Calculate the fractional thickness (depth ratio) of each layer, and distribute neritic burial into the 3-D field accordingly
            if (rho_dzt_150(i,j) /= 0.0) then
               thickness_ratio_150(i,j,1:k_150) = rho_dzt(i,j,1:k_150) / rho_dzt_150(i,j)
               cobalt%jdic_caco3_nerbur(i,j,1:k_150) = neritic_cased_burial(i,j) * thickness_ratio_150(i,j,1:k_150) / rho_dzt(i,j,1:k_150)
-              if (k_150 .lt. nk) then
-                 cobalt%jdic_caco3_nerbur(i,j,k_150+1:nk) = 0.0
-              endif
+              if (k_150 .lt. nk) cobalt%jdic_caco3_nerbur(i,j,k_150+1:nk) = 0.0
            else
               cobalt%jdic_caco3_nerbur(i,j,1:nk) = 0.0
            endif
@@ -5272,7 +5269,7 @@ contains
                     cobalt%jnamx(i,j,k) + cobalt%jno3_iceberg(i,j,k))*dt*grid_tmask(i,j,k)
          ! << Apply neritic CaCO3 burial contribution to net carbon source/sink term
          ! This term is zero when neritic burial is turned off (default: jdic_caco3_nerbur = 0.0)
-         net_srcc(i,j,k) = (-1) * cobalt%jdic_caco3_nerbur(i,j,k) *dt*grid_tmask(i,j,k)
+         net_srcc(i,j,k) = -cobalt%jdic_caco3_nerbur(i,j,k) *dt*grid_tmask(i,j,k)
          ! >>         
          pre_totc(i,j,k) = (cobalt%p_dic(i,j,k,tau) + &
                     cobalt%p_cadet_arag(i,j,k,tau) + cobalt%p_cadet_calc(i,j,k,tau) + &
@@ -6486,19 +6483,16 @@ contains
     ! Calculate the vertically integrated neritic CaCO3 burial within the top 150m
     if (cobalt%do_ner_ca_bur) then
        do j = jsc, jec ; do i = isc, iec !{
+          k_150 = 1
           rho_dzt_150(i,j) = rho_dzt(i,j,1)
           cobalt%jdic_caco3_nerbur_150(i,j) = cobalt%jdic_caco3_nerbur(i,j,1) * rho_dzt(i,j,1)
-       enddo; enddo !} i,j
 
-       do j = jsc, jec ; do i = isc, iec ; !{
-          k_150 = 1
           do k = 2, grid_kmt(i,j)  !{
-             if (rho_dzt_150(i,j) .lt. cobalt%Rho_0 * 150.0) then
-                k_150 = k
-                rho_dzt_150(i,j) = rho_dzt_150(i,j) + rho_dzt(i,j,k)
-                cobalt%jdic_caco3_nerbur_150(i,j) = cobalt%jdic_caco3_nerbur_150(i,j) + &
-                                                      cobalt%jdic_caco3_nerbur(i,j,k) * rho_dzt(i,j,k)
-             endif
+             if (rho_dzt_150(i,j) .ge. cobalt%Rho_0 * 150.0) exit
+             k_150 = k
+             rho_dzt_150(i,j) = rho_dzt_150(i,j) + rho_dzt(i,j,k)
+             cobalt%jdic_caco3_nerbur_150(i,j) = cobalt%jdic_caco3_nerbur_150(i,j) + &
+                                                 cobalt%jdic_caco3_nerbur(i,j,k) * rho_dzt(i,j,k)
           enddo  !} k
        enddo ; enddo  !} i,j 
     else

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1448,6 +1448,15 @@ contains
     call get_param(param_file, "generic_COBALT", "caco3_sat_max", cobalt%caco3_sat_max, &
                   "cap for positive scaling of caco3 detritus prod with saturation state", units="none", default= 10.0)
 
+    ! << Fei Da, 202504: respiration-driven CaCO3 dissolution ratios from param file
+    call get_param(param_file, "generic_COBALT", "resp_ca_2_n_arag", cobalt%resp_ca_2_n_arag, &
+                   "ratio of aragonite dissolution to organic matter remineralization (respiration-driven)", &
+                   units="mol dissolved arag mol org. C-1", default = 0.0, scale = c2n)
+    call get_param(param_file, "generic_COBALT", "resp_ca_2_n_calc", cobalt%resp_ca_2_n_calc, &
+                   "ratio of calcite dissolution to organic matter remineralization (respiration-driven)", &
+                   units="mol dissolved calc mol org. C-1", default = 0.0, scale = c2n)
+    ! >>          
+
     ! Organic matter remineralization: Oxygen and temperature dependence follows Laufkotter et al. (2017).
     call get_param(param_file, "generic_COBALT", "k_o2", cobalt%k_o2, "O2 half-saturation for remineralization", &
                    units="mol O2 kg-1", default= 8.0e-6)
@@ -2925,6 +2934,11 @@ contains
     integer, dimension(:,:), Allocatable :: k_bot, kblt
     real, dimension(:), Allocatable   :: tmp_irr_band
     real, dimension(:,:), Allocatable :: rho_dzt_100,rho_dzt_200,rho_dzt_bot,sfc_irrad
+    ! << Fei Da, 202504: variables used for neritic CaCO3 burial
+    integer :: k_150
+    real, dimension(:,:), Allocatable :: rho_dzt_150
+    real, dimension(:,:,:), Allocatable :: depth_ratio_150
+    ! >> 
     real,dimension(1:NUM_ZOO,1:NUM_PREY) :: ipa_matrix,pa_matrix,ingest_matrix
     real,dimension(1:NUM_PREY) :: hp_ipa_vec,hp_pa_vec,hp_ingest_vec
     real,dimension(1:NUM_PREY) :: prey_vec,prey_p2n_vec,prey_fe2n_vec,prey_si2n_vec
@@ -2945,6 +2959,11 @@ contains
 
     logical ::  phos_nh3_override
     logical ::  pha_all_same = .true.
+
+    ! << Fei Da, 202504: variables used for neritic CaCO3 burial
+    logical ::  neritic_override = .true.
+    real, dimension(:,:),   Allocatable :: neritic_cased_burial
+    ! >>
 
     real, dimension(:,:,:), Allocatable :: ztop, zmid, zbot
     real, dimension(:,:,:), Allocatable :: pre_totn, net_srcn, post_totn
@@ -4563,6 +4582,48 @@ contains
                        min(cobalt%caco3_sat_max, max(0.0, cobalt%omega_calc(i,j,k) - 1.0)) + epsln
     enddo; enddo ; enddo !} i,j,k
 
+    ! << Neritic CaCO3 burial
+    ! Fei Da 202504: Enable neritic CaCO3 burial in shallow regions (depth <= 150m)
+    ! Read 'neritic_cased_burial' from netCDF file (O'Mara & Dunne, 2019) to apply spatial pattern
+    if (do_ner_ca_bur) then
+        allocate(neritic_cased_burial(isd:ied,jsd:jed))
+        ! 'neritic_cased_burial' is the 2-D burial field saved in netCDF
+        call data_override('OCN', 'neritic_cased_burial', neritic_cased_burial(isc:iec,jsc:jec), model_time,override=neritic_override)
+        ! Set up vertical redistribution based on local depth structure
+        ! Calculate number of layers covering the top 150m and depth ratios across these layers        
+        allocate(rho_dzt_150(isc:iec,jsc:jec))
+        allocate(depth_ratio_150(isc:iec,jsc:jec,1:nk)); depth_ratio_150 = 0.0
+
+        do j = jsc, jec ; do i = isc, iec ; !{
+           k_150 = 1
+           rho_dzt_150(i,j) = rho_dzt(i,j,1)
+           ! Sum the thickness of vertical layers from the surface down to 150m depth
+           do k = 2, grid_kmt(i,j)  !{
+              if (rho_dzt_150(i,j) .lt. cobalt%Rho_0 * 150.0) then
+                 k_150 = k
+                 rho_dzt_150(i,j) = rho_dzt_150(i,j) + rho_dzt(i,j,k)
+              endif
+           enddo  !} k
+           ! Calculate the fractional thickness (depth ratio) of each layer, and distribute neritic burial into the 3-D field accordingly
+           if (rho_dzt_150(i,j) /= 0.0) then
+              depth_ratio_150(i,j,1:k_150) = rho_dzt(i,j,1:k_150) / rho_dzt_150(i,j)
+              cobalt%jprod_cadet_neritic(i,j,1:k_150) = neritic_cased_burial(i,j) * depth_ratio_150(i,j,1:k_150) / rho_dzt(i,j,1:k_150)
+              if (k_150 .lt. nk) then
+                 cobalt%jprod_cadet_neritic(i,j,k_150+1:nk) = 0.0
+              endif
+           else
+              cobalt%jprod_cadet_neritic(i,j,1:nk) = 0.0
+           endif
+        enddo ; enddo  !} i,j 
+    else
+        ! No neritic burial: set jprod_cadet_neritic to zero to maintain consistency in carbon and alkalinity budgets
+        cobalt%jprod_cadet_neritic = 0.0
+    endif
+    ! deallocate local variables used for neritic burial calculation
+    if (allocated(neritic_cased_burial)) deallocate(neritic_cased_burial)
+    if (allocated(depth_ratio_150)) deallocate(depth_ratio_150)
+    ! Neritic CaCO3 burial >>
+
     !
     ! 4.2: Lithogenic detritus production
     !
@@ -4675,6 +4736,20 @@ contains
          (cobalt%f_ndet(i,j,k) + epsln) * cobalt%remin_eff_fedet*cobalt%f_fedet(i,j,k)
        cobalt%jprod_fed(i,j,k) = cobalt%jprod_fed(i,j,k) + cobalt%jremin_fedet(i,j,k)
     enddo; enddo; enddo  !} i,j,k
+
+    ! << Enhanced CaCO3 dissolution driven by localized undersaturation around sinking particles
+    ! Fei Da, 202504: Add CaCO3 dissolution enhancement associated with organic matter (OM) decomposition
+    ! 
+    ! This routine applies a fixed ratio between POC remineralization and additional CaCO3 dissolution
+    if (do_resp_ca_diss) then
+        do k=1,nk ; do j=jsc,jec ; do i=isc,iec  !{
+           cobalt%jdiss_cadet_arag(i,j,k) = cobalt%jdiss_cadet_arag(i,j,k) + &
+                                            cobalt%resp_ca_2_n_arag * cobalt%jremin_ndet(i,j,k) * cobalt%c_2_n
+           cobalt%jdiss_cadet_calc(i,j,k) = cobalt%jdiss_cadet_calc(i,j,k) + &
+                                            cobalt%resp_ca_2_n_calc * cobalt%jremin_ndet(i,j,k) * cobalt%c_2_n
+        enddo; enddo; enddo  !} i,j,k
+    endif     
+    ! >> 
 
     ! 
     ! 4.5: Iron scavenging onto detritus
@@ -5169,7 +5244,10 @@ contains
                     cobalt%p_nlgz(i,j,k,tau))*grid_tmask(i,j,k)
          net_srcn(i,j,k) = (phyto(DIAZO)%juptake_n2(i,j,k) - cobalt%jno3denit_wc(i,j,k) - &
                     cobalt%jnamx(i,j,k) + cobalt%jno3_iceberg(i,j,k))*dt*grid_tmask(i,j,k)
-         net_srcc(i,j,k) = 0.0
+         ! << Fei Da, 202504: Apply neritic CaCO3 burial contribution to net carbon source/sink term
+         ! This term is zero when neritic burial is turned off (default: jprod_cadet_neritic = 0.0)
+         net_srcc(i,j,k) = (-1) * cobalt%jprod_cadet_neritic(i,j,k) *dt*grid_tmask(i,j,k)
+         ! >>         
          pre_totc(i,j,k) = (cobalt%p_dic(i,j,k,tau) + &
                     cobalt%p_cadet_arag(i,j,k,tau) + cobalt%p_cadet_calc(i,j,k,tau) + &
                     cobalt%c_2_n*(cobalt%p_ndi(i,j,k,tau) + cobalt%p_nlg(i,j,k,tau) + &
@@ -5549,11 +5627,13 @@ contains
        !      to isolate the change in alkalinity due to aerobic organic
        !      matter remineralization
        !
+       ! << Fei Da, 202504: Apply neritic CaCO3 burial contribution
+       ! This term is zero when neritic burial is turned off (default: jprod_cadet_neritic = 0.0) >>       
        cobalt%jalk(i,j,k) = 2.0 * (cobalt%jdiss_cadet_arag(i,j,k) +        &
           cobalt%jdiss_cadet_calc(i,j,k) - cobalt%jprod_cadet_arag(i,j,k) - &
-          cobalt%jprod_cadet_calc(i,j,k)) + phyto(DIAZO)%juptake_no3(i,j,k) + &
-          phyto(LARGE)%juptake_no3(i,j,k) + phyto(MEDIUM)%juptake_no3(i,j,k) + &
-          phyto(SMALL)%juptake_no3(i,j,k) + &
+          cobalt%jprod_cadet_calc(i,j,k) - cobalt%jprod_cadet_neritic(i,j,k)) + &
+          phyto(DIAZO)%juptake_no3(i,j,k)  + phyto(LARGE)%juptake_no3(i,j,k) + &
+          phyto(MEDIUM)%juptake_no3(i,j,k) + phyto(SMALL)%juptake_no3(i,j,k) + &
           (cobalt%jo2resp_wc(i,j,k)-cobalt%juptake_nh4nitrif(i,j,k)*cobalt%o2_2_nitrif)/cobalt%o2_2_nh4 + &
           cobalt%alk_2_n_denit*cobalt%jno3denit_wc(i,j,k) - &
           cobalt%alk_2_nh4_amx*cobalt%juptake_nh4amx(i,j,k) - &
@@ -5573,7 +5653,8 @@ contains
           phyto(MEDIUM)%juptake_nh4(i,j,k) - phyto(SMALL)%juptake_nh4(i,j,k) - &
           phyto(DIAZO)%juptake_n2(i,j,k)) + &
           cobalt%jdiss_cadet_arag(i,j,k) + cobalt%jdiss_cadet_calc(i,j,k) - &
-          cobalt%jprod_cadet_arag(i,j,k) - cobalt%jprod_cadet_calc(i,j,k))
+          cobalt%jprod_cadet_arag(i,j,k) - cobalt%jprod_cadet_calc(i,j,k) - &
+          cobalt%jprod_cadet_neritic(i,j,k))
 
        cobalt%p_dic(i,j,k,tau) = cobalt%p_dic(i,j,k,tau) + cobalt%jdic(i,j,k) * dt * grid_tmask(i,j,k)
     enddo; enddo ; enddo !} i,j,k
@@ -6375,6 +6456,32 @@ contains
     enddo ; enddo  !} i,j
     deallocate(rho_dzt_200)
 
+    ! << Fei Da, 202504: Add diagnostic for neritic CaCO3 burial
+    ! Calculate the vertically integrated neritic CaCO3 burial within the top 150m
+    if (do_ner_ca_bur) then
+       do j = jsc, jec ; do i = isc, iec !{
+          rho_dzt_150(i,j) = rho_dzt(i,j,1)
+          cobalt%jprod_cadet_neritic_150(i,j) = cobalt%jprod_cadet_neritic(i,j,1) * rho_dzt(i,j,1)
+       enddo; enddo !} i,j
+
+       do j = jsc, jec ; do i = isc, iec ; !{
+          k_150 = 1
+          do k = 2, grid_kmt(i,j)  !{
+             if (rho_dzt_150(i,j) .lt. cobalt%Rho_0 * 150.0) then
+                k_150 = k
+                rho_dzt_150(i,j) = rho_dzt_150(i,j) + rho_dzt(i,j,k)
+                cobalt%jprod_cadet_neritic_150(i,j) = cobalt%jprod_cadet_neritic_150(i,j) + &
+                                                      cobalt%jprod_cadet_neritic(i,j,k) * rho_dzt(i,j,k)
+             endif
+          enddo  !} k
+       enddo ; enddo  !} i,j 
+    else
+       ! No neritic burial: set integral to zero
+       cobalt%jprod_cadet_neritic_150 = 0.0
+    endif
+    if (allocated(rho_dzt_150)) deallocate(rho_dzt_150)
+    ! Add diagnostic for neritic CaCO3 burial >>
+
     call g_tracer_get_values(tracer_list,'alk','runoff_tracer_flux',cobalt%runoff_flux_alk,isd,jsd)
     call g_tracer_get_values(tracer_list,'dic','runoff_tracer_flux',cobalt%runoff_flux_dic,isd,jsd)
     if (do_14c) then  !{
@@ -7081,6 +7188,10 @@ contains
     allocate(cobalt%jprod_lithdet(isd:ied, jsd:jed, 1:nk)); cobalt%jprod_lithdet=0.0
     allocate(cobalt%jprod_cadet_arag(isd:ied, jsd:jed, 1:nk)); cobalt%jprod_cadet_arag=0.0
     allocate(cobalt%jprod_cadet_calc(isd:ied, jsd:jed, 1:nk)); cobalt%jprod_cadet_calc=0.0
+    ! << Fei Da, 202504: Always allocate 3-D neritic CaCO3 burial production field
+    ! Needed for DIC and alkalinity budgets even if burial is disabled (set to zero if do_ner_ca_bur = .false.)
+    allocate(cobalt%jprod_cadet_neritic(isd:ied, jsd:jed, 1:nk)); cobalt%jprod_cadet_neritic=0.0
+    ! >>  
     allocate(cobalt%jprod_nh4(isd:ied, jsd:jed, 1:nk))    ; cobalt%jprod_nh4=0.0
     allocate(cobalt%jprod_nh4_plus_btm(isd:ied, jsd:jed, 1:nk))    ; cobalt%jprod_nh4_plus_btm=0.0
     allocate(cobalt%jprod_po4(isd:ied, jsd:jed, 1:nk))    ; cobalt%jprod_po4=0.0
@@ -7288,6 +7399,9 @@ contains
    allocate(cobalt%jprod_sidet_100(isd:ied,jsd:jed))        ; cobalt%jprod_sidet_100 = 0.0
    allocate(cobalt%jprod_cadet_calc_100(isd:ied,jsd:jed))   ; cobalt%jprod_cadet_calc_100 = 0.0
    allocate(cobalt%jprod_cadet_arag_100(isd:ied,jsd:jed))   ; cobalt%jprod_cadet_arag_100 = 0.0
+   ! << Fei Da, 202504: Allocate 2-D diagnostic for integrated neritic CaCO3 burial (0–150m)
+   allocate(cobalt%jprod_cadet_neritic_150(isd:ied,jsd:jed)); cobalt%jprod_cadet_neritic_150 = 0.0
+   ! >>
    allocate(cobalt%jremin_ndet_100(isd:ied,jsd:jed))        ; cobalt%jremin_ndet_100 = 0.0
    allocate(cobalt%jprod_mesozoo_200(isd:ied,jsd:jed))      ; cobalt%jprod_mesozoo_200 = 0.0
    allocate(cobalt%daylength(isd:ied,jsd:jed))              ; cobalt%daylength = 0.0
@@ -7624,6 +7738,9 @@ contains
     deallocate(cobalt%jprod_lithdet)
     deallocate(cobalt%jprod_cadet_arag)
     deallocate(cobalt%jprod_cadet_calc)
+    ! << Fei Da, 202504: deallocate variables for neritic CaCO3 burial 
+    deallocate(cobalt%jprod_cadet_neritic)
+    ! >>     
     deallocate(cobalt%jprod_nh4)
     deallocate(cobalt%jprod_nh4_plus_btm)
     deallocate(cobalt%jprod_po4)
@@ -7745,6 +7862,9 @@ contains
     deallocate(cobalt%jprod_sidet_100)
     deallocate(cobalt%jprod_cadet_arag_100)
     deallocate(cobalt%jprod_cadet_calc_100)
+    ! << Fei Da, 202504: deallocate variables for neritic CaCO3 burial
+    deallocate(cobalt%jprod_cadet_neritic_150)
+    ! >>
     deallocate(cobalt%jprod_mesozoo_200)
     deallocate(cobalt%daylength)
     deallocate(cobalt%jremin_ndet_100)

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -4767,9 +4767,9 @@ contains
     if (cobalt%do_resp_ca_diss) then
         do k=1,nk ; do j=jsc,jec ; do i=isc,iec  !{
            cobalt%jdiss_cadet_arag(i,j,k) = cobalt%jdiss_cadet_arag(i,j,k) + &
-                                            cobalt%resp_ca_2_n_arag * cobalt%jremin_ndet(i,j,k) * cobalt%c_2_n
+                                            cobalt%resp_ca_2_n_arag * cobalt%jremin_ndet(i,j,k)
            cobalt%jdiss_cadet_calc(i,j,k) = cobalt%jdiss_cadet_calc(i,j,k) + &
-                                            cobalt%resp_ca_2_n_calc * cobalt%jremin_ndet(i,j,k) * cobalt%c_2_n
+                                            cobalt%resp_ca_2_n_calc * cobalt%jremin_ndet(i,j,k)
         enddo; enddo; enddo  !} i,j,k
     endif     
     ! >> 

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1448,24 +1448,32 @@ contains
     call get_param(param_file, "generic_COBALT", "caco3_sat_max", cobalt%caco3_sat_max, &
                   "cap for positive scaling of caco3 detritus prod with saturation state", units="none", default= 10.0)
 
-    ! << Fei Da, 202504: flag to include neritic CaCO3 burial and enhanced CaCO3 dissolution
+    ! << flags to include neritic CaCO3 burial and enhanced CaCO3 dissolution >>
     ! If the logical flag "do_ner_ca_bur" is set to true, neritic CaCO3 burial in shallow water (≤150 m) is activated.
     ! Burial rates are based on O'Mara & Dunne (2019) and affect alkalinity and DIC at a 2:1 ratio.
-    ! The burial flux is vertically distributed evenly over the top 150 m of the water column.
+    ! The burial flux is vertically distributed evenly over the top 150m of the water column.
+    ! This is not exactly 150 m, but extends down to the model layer that includes the 150m depth.
+    ! The impact of neritic burial is distributed over 150m to account for the limited ability of global models 
+    ! to resolve coastal bathymetry. In high-resolution regional models, a better approach is to apply the burial 
+    ! effect directly to the bottom boundary condition via b_alk and b_dic.
     ! The spatial pattern is prescribed, while the magnitude is temporally constant.
     ! If the logical flag "do_resp_ca_diss" is set to true, respiration-driven CaCO3 dissolution 
     ! due to localized undersaturation around sinking particles is activated.
     ! This is parameterized as a fixed ratio of organic matter remineralization, targeting enhanced 
     ! CaCO3 dissolution in the upper ocean (e.g., ≤300 m; Kwon et al., 2024).
     ! The ratio is chosen to yield a global CaCO3 flux of ~0.75 Pg-C yr-1 at 300 m, consistent with 
-    ! Sulpis et al. (2021), who estimated 0.9 ± 0.15 Pg-C yr-1.    
+    ! Sulpis et al. (2021), who estimated 0.9 ± 0.15 Pg-C yr-1.   
+    !
+    ! O'Mara and Dunne, 2019; https://www.nature.com/articles/s41598-019-41064-w
+    ! Kwon et al., 2024; https://www.science.org/doi/10.1126/sciadv.adl0779
+    ! Sulpis et al., 2021; https://www.nature.com/articles/s41561-021-00743-y  
     call get_param(param_file, "generic_COBALT", "do_ner_ca_bur", cobalt%do_ner_ca_bur, &
             "logical flag to include neritic CaCO3 burial", default=.false.) 
     call get_param(param_file, "generic_COBALT", "do_resp_ca_diss", cobalt%do_resp_ca_diss, &
             "logical flag to include CaCO3 dissolution due to undersaturation around sinking particles", default=.false.)
     ! >>
 
-    ! << Fei Da, 202504: respiration-driven CaCO3 dissolution ratios from param file
+    ! << Respiration-driven CaCO3 dissolution ratios from param file
     call get_param(param_file, "generic_COBALT", "resp_ca_2_n_arag", cobalt%resp_ca_2_n_arag, &
                    "ratio of aragonite dissolution to organic matter remineralization (respiration-driven)", &
                    units="mol dissolved arag mol org. C-1", default = 0.0, scale = c2n)
@@ -2951,10 +2959,10 @@ contains
     integer, dimension(:,:), Allocatable :: k_bot, kblt
     real, dimension(:), Allocatable   :: tmp_irr_band
     real, dimension(:,:), Allocatable :: rho_dzt_100,rho_dzt_200,rho_dzt_bot,sfc_irrad
-    ! << Fei Da, 202504: variables used for neritic CaCO3 burial
+    ! << local variables used for neritic CaCO3 burial
     integer :: k_150
     real, dimension(:,:), Allocatable :: rho_dzt_150
-    real, dimension(:,:,:), Allocatable :: depth_ratio_150
+    real, dimension(:,:,:), Allocatable :: thickness_ratio_150
     ! >> 
     real,dimension(1:NUM_ZOO,1:NUM_PREY) :: ipa_matrix,pa_matrix,ingest_matrix
     real,dimension(1:NUM_PREY) :: hp_ipa_vec,hp_pa_vec,hp_ingest_vec
@@ -2977,7 +2985,7 @@ contains
     logical ::  phos_nh3_override
     logical ::  pha_all_same = .true.
 
-    ! << Fei Da, 202504: variables used for neritic CaCO3 burial
+    ! << local variables used for neritic CaCO3 burial
     logical ::  neritic_override = .true.
     real, dimension(:,:),   Allocatable :: neritic_cased_burial
     ! >>
@@ -4599,17 +4607,18 @@ contains
                        min(cobalt%caco3_sat_max, max(0.0, cobalt%omega_calc(i,j,k) - 1.0)) + epsln
     enddo; enddo ; enddo !} i,j,k
 
-    ! << Neritic CaCO3 burial
-    ! Fei Da 202504: Enable neritic CaCO3 burial in shallow regions (depth <= 150m)
+    ! << Neritic CaCO3 burial >>
+    ! << Enable neritic CaCO3 burial in shallow regions (depth <= 150m)
     ! Read 'neritic_cased_burial' from netCDF file (O'Mara & Dunne, 2019) to apply spatial pattern
     if (cobalt%do_ner_ca_bur) then
         allocate(neritic_cased_burial(isd:ied,jsd:jed))
         ! 'neritic_cased_burial' is the 2-D burial field saved in netCDF
+        ! data_override is intended to replace internal model fields with externally specified data
         call data_override('OCN', 'neritic_cased_burial', neritic_cased_burial(isc:iec,jsc:jec), model_time,override=neritic_override)
         ! Set up vertical redistribution based on local depth structure
         ! Calculate number of layers covering the top 150m and depth ratios across these layers        
         allocate(rho_dzt_150(isc:iec,jsc:jec))
-        allocate(depth_ratio_150(isc:iec,jsc:jec,1:nk)); depth_ratio_150 = 0.0
+        allocate(thickness_ratio_150(isc:iec,jsc:jec,1:nk)); thickness_ratio_150 = 0.0
 
         do j = jsc, jec ; do i = isc, iec ; !{
            k_150 = 1
@@ -4623,22 +4632,22 @@ contains
            enddo  !} k
            ! Calculate the fractional thickness (depth ratio) of each layer, and distribute neritic burial into the 3-D field accordingly
            if (rho_dzt_150(i,j) /= 0.0) then
-              depth_ratio_150(i,j,1:k_150) = rho_dzt(i,j,1:k_150) / rho_dzt_150(i,j)
-              cobalt%jprod_cadet_neritic(i,j,1:k_150) = neritic_cased_burial(i,j) * depth_ratio_150(i,j,1:k_150) / rho_dzt(i,j,1:k_150)
+              thickness_ratio_150(i,j,1:k_150) = rho_dzt(i,j,1:k_150) / rho_dzt_150(i,j)
+              cobalt%jdic_caco3_nerbur(i,j,1:k_150) = neritic_cased_burial(i,j) * thickness_ratio_150(i,j,1:k_150) / rho_dzt(i,j,1:k_150)
               if (k_150 .lt. nk) then
-                 cobalt%jprod_cadet_neritic(i,j,k_150+1:nk) = 0.0
+                 cobalt%jdic_caco3_nerbur(i,j,k_150+1:nk) = 0.0
               endif
            else
-              cobalt%jprod_cadet_neritic(i,j,1:nk) = 0.0
+              cobalt%jdic_caco3_nerbur(i,j,1:nk) = 0.0
            endif
         enddo ; enddo  !} i,j 
     else
-        ! No neritic burial: set jprod_cadet_neritic to zero to maintain consistency in carbon and alkalinity budgets
-        cobalt%jprod_cadet_neritic = 0.0
+        ! No neritic burial: set jdic_caco3_nerbur to zero to maintain consistency in carbon and alkalinity budgets
+        cobalt%jdic_caco3_nerbur = 0.0
     endif
     ! deallocate local variables used for neritic burial calculation
     if (allocated(neritic_cased_burial)) deallocate(neritic_cased_burial)
-    if (allocated(depth_ratio_150)) deallocate(depth_ratio_150)
+    if (allocated(thickness_ratio_150)) deallocate(thickness_ratio_150)
     ! Neritic CaCO3 burial >>
 
     !
@@ -4754,8 +4763,8 @@ contains
        cobalt%jprod_fed(i,j,k) = cobalt%jprod_fed(i,j,k) + cobalt%jremin_fedet(i,j,k)
     enddo; enddo; enddo  !} i,j,k
 
-    ! << Enhanced CaCO3 dissolution driven by localized undersaturation around sinking particles
-    ! Fei Da, 202504: Add CaCO3 dissolution enhancement associated with organic matter (OM) decomposition
+    ! << Enhanced CaCO3 dissolution driven by localized undersaturation around sinking particles >>
+    ! Add CaCO3 dissolution enhancement associated with organic matter (OM) decomposition
     ! 
     ! This routine applies a fixed ratio between POC remineralization and additional CaCO3 dissolution
     if (cobalt%do_resp_ca_diss) then
@@ -5261,9 +5270,9 @@ contains
                     cobalt%p_nlgz(i,j,k,tau))*grid_tmask(i,j,k)
          net_srcn(i,j,k) = (phyto(DIAZO)%juptake_n2(i,j,k) - cobalt%jno3denit_wc(i,j,k) - &
                     cobalt%jnamx(i,j,k) + cobalt%jno3_iceberg(i,j,k))*dt*grid_tmask(i,j,k)
-         ! << Fei Da, 202504: Apply neritic CaCO3 burial contribution to net carbon source/sink term
-         ! This term is zero when neritic burial is turned off (default: jprod_cadet_neritic = 0.0)
-         net_srcc(i,j,k) = (-1) * cobalt%jprod_cadet_neritic(i,j,k) *dt*grid_tmask(i,j,k)
+         ! << Apply neritic CaCO3 burial contribution to net carbon source/sink term
+         ! This term is zero when neritic burial is turned off (default: jdic_caco3_nerbur = 0.0)
+         net_srcc(i,j,k) = (-1) * cobalt%jdic_caco3_nerbur(i,j,k) *dt*grid_tmask(i,j,k)
          ! >>         
          pre_totc(i,j,k) = (cobalt%p_dic(i,j,k,tau) + &
                     cobalt%p_cadet_arag(i,j,k,tau) + cobalt%p_cadet_calc(i,j,k,tau) + &
@@ -5644,11 +5653,11 @@ contains
        !      to isolate the change in alkalinity due to aerobic organic
        !      matter remineralization
        !
-       ! << Fei Da, 202504: Apply neritic CaCO3 burial contribution
-       ! This term is zero when neritic burial is turned off (default: jprod_cadet_neritic = 0.0) >>       
+       ! << Apply neritic CaCO3 burial contribution
+       ! This term is zero when neritic burial is turned off (default: jdic_caco3_nerbur = 0.0) >>       
        cobalt%jalk(i,j,k) = 2.0 * (cobalt%jdiss_cadet_arag(i,j,k) +        &
           cobalt%jdiss_cadet_calc(i,j,k) - cobalt%jprod_cadet_arag(i,j,k) - &
-          cobalt%jprod_cadet_calc(i,j,k) - cobalt%jprod_cadet_neritic(i,j,k)) + &
+          cobalt%jprod_cadet_calc(i,j,k) - cobalt%jdic_caco3_nerbur(i,j,k)) + &
           phyto(DIAZO)%juptake_no3(i,j,k) + phyto(LARGE)%juptake_no3(i,j,k) + &
           phyto(MEDIUM)%juptake_no3(i,j,k) + phyto(SMALL)%juptake_no3(i,j,k) + &
           (cobalt%jo2resp_wc(i,j,k)-cobalt%juptake_nh4nitrif(i,j,k)*cobalt%o2_2_nitrif)/cobalt%o2_2_nh4 + &
@@ -5671,7 +5680,7 @@ contains
           phyto(DIAZO)%juptake_n2(i,j,k)) + &
           cobalt%jdiss_cadet_arag(i,j,k) + cobalt%jdiss_cadet_calc(i,j,k) - &
           cobalt%jprod_cadet_arag(i,j,k) - cobalt%jprod_cadet_calc(i,j,k) - &
-          cobalt%jprod_cadet_neritic(i,j,k))
+          cobalt%jdic_caco3_nerbur(i,j,k))
 
        cobalt%p_dic(i,j,k,tau) = cobalt%p_dic(i,j,k,tau) + cobalt%jdic(i,j,k) * dt * grid_tmask(i,j,k)
     enddo; enddo ; enddo !} i,j,k
@@ -6473,12 +6482,12 @@ contains
     enddo ; enddo  !} i,j
     deallocate(rho_dzt_200)
 
-    ! << Fei Da, 202504: Add diagnostic for neritic CaCO3 burial
+    ! << Add diagnostic for neritic CaCO3 burial
     ! Calculate the vertically integrated neritic CaCO3 burial within the top 150m
     if (cobalt%do_ner_ca_bur) then
        do j = jsc, jec ; do i = isc, iec !{
           rho_dzt_150(i,j) = rho_dzt(i,j,1)
-          cobalt%jprod_cadet_neritic_150(i,j) = cobalt%jprod_cadet_neritic(i,j,1) * rho_dzt(i,j,1)
+          cobalt%jdic_caco3_nerbur_150(i,j) = cobalt%jdic_caco3_nerbur(i,j,1) * rho_dzt(i,j,1)
        enddo; enddo !} i,j
 
        do j = jsc, jec ; do i = isc, iec ; !{
@@ -6487,14 +6496,14 @@ contains
              if (rho_dzt_150(i,j) .lt. cobalt%Rho_0 * 150.0) then
                 k_150 = k
                 rho_dzt_150(i,j) = rho_dzt_150(i,j) + rho_dzt(i,j,k)
-                cobalt%jprod_cadet_neritic_150(i,j) = cobalt%jprod_cadet_neritic_150(i,j) + &
-                                                      cobalt%jprod_cadet_neritic(i,j,k) * rho_dzt(i,j,k)
+                cobalt%jdic_caco3_nerbur_150(i,j) = cobalt%jdic_caco3_nerbur_150(i,j) + &
+                                                      cobalt%jdic_caco3_nerbur(i,j,k) * rho_dzt(i,j,k)
              endif
           enddo  !} k
        enddo ; enddo  !} i,j 
     else
        ! No neritic burial: set integral to zero
-       cobalt%jprod_cadet_neritic_150 = 0.0
+       cobalt%jdic_caco3_nerbur_150 = 0.0
     endif
     if (allocated(rho_dzt_150)) deallocate(rho_dzt_150)
     ! Add diagnostic for neritic CaCO3 burial >>
@@ -7205,9 +7214,9 @@ contains
     allocate(cobalt%jprod_lithdet(isd:ied, jsd:jed, 1:nk)); cobalt%jprod_lithdet=0.0
     allocate(cobalt%jprod_cadet_arag(isd:ied, jsd:jed, 1:nk)); cobalt%jprod_cadet_arag=0.0
     allocate(cobalt%jprod_cadet_calc(isd:ied, jsd:jed, 1:nk)); cobalt%jprod_cadet_calc=0.0
-    ! << Fei Da, 202504: Always allocate 3-D neritic CaCO3 burial production field
+    ! << Always allocate 3-D neritic CaCO3 burial production field
     ! Needed for DIC and alkalinity budgets even if burial is disabled (set to zero if do_ner_ca_bur = .false.)
-    allocate(cobalt%jprod_cadet_neritic(isd:ied, jsd:jed, 1:nk)); cobalt%jprod_cadet_neritic=0.0
+    allocate(cobalt%jdic_caco3_nerbur(isd:ied, jsd:jed, 1:nk)); cobalt%jdic_caco3_nerbur=0.0
     ! >>  
     allocate(cobalt%jprod_nh4(isd:ied, jsd:jed, 1:nk))    ; cobalt%jprod_nh4=0.0
     allocate(cobalt%jprod_nh4_plus_btm(isd:ied, jsd:jed, 1:nk))    ; cobalt%jprod_nh4_plus_btm=0.0
@@ -7416,8 +7425,8 @@ contains
    allocate(cobalt%jprod_sidet_100(isd:ied,jsd:jed))        ; cobalt%jprod_sidet_100 = 0.0
    allocate(cobalt%jprod_cadet_calc_100(isd:ied,jsd:jed))   ; cobalt%jprod_cadet_calc_100 = 0.0
    allocate(cobalt%jprod_cadet_arag_100(isd:ied,jsd:jed))   ; cobalt%jprod_cadet_arag_100 = 0.0
-   ! << Fei Da, 202504: Allocate 2-D diagnostic for integrated neritic CaCO3 burial (0–150m)
-   allocate(cobalt%jprod_cadet_neritic_150(isd:ied,jsd:jed)); cobalt%jprod_cadet_neritic_150 = 0.0
+   ! << Allocate 2-D diagnostic for integrated neritic CaCO3 burial (0–150m)
+   allocate(cobalt%jdic_caco3_nerbur_150(isd:ied,jsd:jed)); cobalt%jdic_caco3_nerbur_150 = 0.0
    ! >>
    allocate(cobalt%jremin_ndet_100(isd:ied,jsd:jed))        ; cobalt%jremin_ndet_100 = 0.0
    allocate(cobalt%jprod_mesozoo_200(isd:ied,jsd:jed))      ; cobalt%jprod_mesozoo_200 = 0.0
@@ -7755,8 +7764,8 @@ contains
     deallocate(cobalt%jprod_lithdet)
     deallocate(cobalt%jprod_cadet_arag)
     deallocate(cobalt%jprod_cadet_calc)
-    ! << Fei Da, 202504: deallocate variables for neritic CaCO3 burial 
-    deallocate(cobalt%jprod_cadet_neritic)
+    ! << Deallocate variables for neritic CaCO3 burial 
+    deallocate(cobalt%jdic_caco3_nerbur)
     ! >>     
     deallocate(cobalt%jprod_nh4)
     deallocate(cobalt%jprod_nh4_plus_btm)
@@ -7879,8 +7888,8 @@ contains
     deallocate(cobalt%jprod_sidet_100)
     deallocate(cobalt%jprod_cadet_arag_100)
     deallocate(cobalt%jprod_cadet_calc_100)
-    ! << Fei Da, 202504: deallocate variables for neritic CaCO3 burial
-    deallocate(cobalt%jprod_cadet_neritic_150)
+    ! << Deallocate variables for neritic CaCO3 burial
+    deallocate(cobalt%jdic_caco3_nerbur_150)
     ! >>
     deallocate(cobalt%jprod_mesozoo_200)
     deallocate(cobalt%daylength)

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1448,6 +1448,23 @@ contains
     call get_param(param_file, "generic_COBALT", "caco3_sat_max", cobalt%caco3_sat_max, &
                   "cap for positive scaling of caco3 detritus prod with saturation state", units="none", default= 10.0)
 
+    ! << Fei Da, 202504: flag to include neritic CaCO3 burial and enhanced CaCO3 dissolution
+    ! If the logical flag "do_ner_ca_bur" is set to true, neritic CaCO3 burial in shallow water (≤150 m) is activated.
+    ! Burial rates are based on O'Mara & Dunne (2019) and affect alkalinity and DIC at a 2:1 ratio.
+    ! The burial flux is vertically distributed evenly over the top 150 m of the water column.
+    ! The spatial pattern is prescribed, while the magnitude is temporally constant.
+    ! If the logical flag "do_resp_ca_diss" is set to true, respiration-driven CaCO3 dissolution 
+    ! due to localized undersaturation around sinking particles is activated.
+    ! This is parameterized as a fixed ratio of organic matter remineralization, targeting enhanced 
+    ! CaCO3 dissolution in the upper ocean (e.g., ≤300 m; Kwon et al., 2024).
+    ! The ratio is chosen to yield a global CaCO3 flux of ~0.75 Pg-C yr-1 at 300 m, consistent with 
+    ! Sulpis et al. (2021), who estimated 0.9 ± 0.15 Pg-C yr-1.    
+    call get_param(param_file, "generic_COBALT", "do_ner_ca_bur", cobalt%do_ner_ca_bur, &
+            "logical flag to include neritic CaCO3 burial", default=.false.) 
+    call get_param(param_file, "generic_COBALT", "do_resp_ca_diss", cobalt%do_resp_ca_diss, &
+            "logical flag to include CaCO3 dissolution due to undersaturation around sinking particles", default=.false.)
+    ! >>
+
     ! << Fei Da, 202504: respiration-driven CaCO3 dissolution ratios from param file
     call get_param(param_file, "generic_COBALT", "resp_ca_2_n_arag", cobalt%resp_ca_2_n_arag, &
                    "ratio of aragonite dissolution to organic matter remineralization (respiration-driven)", &
@@ -4585,7 +4602,7 @@ contains
     ! << Neritic CaCO3 burial
     ! Fei Da 202504: Enable neritic CaCO3 burial in shallow regions (depth <= 150m)
     ! Read 'neritic_cased_burial' from netCDF file (O'Mara & Dunne, 2019) to apply spatial pattern
-    if (do_ner_ca_bur) then
+    if (cobalt%do_ner_ca_bur) then
         allocate(neritic_cased_burial(isd:ied,jsd:jed))
         ! 'neritic_cased_burial' is the 2-D burial field saved in netCDF
         call data_override('OCN', 'neritic_cased_burial', neritic_cased_burial(isc:iec,jsc:jec), model_time,override=neritic_override)
@@ -4741,7 +4758,7 @@ contains
     ! Fei Da, 202504: Add CaCO3 dissolution enhancement associated with organic matter (OM) decomposition
     ! 
     ! This routine applies a fixed ratio between POC remineralization and additional CaCO3 dissolution
-    if (do_resp_ca_diss) then
+    if (cobalt%do_resp_ca_diss) then
         do k=1,nk ; do j=jsc,jec ; do i=isc,iec  !{
            cobalt%jdiss_cadet_arag(i,j,k) = cobalt%jdiss_cadet_arag(i,j,k) + &
                                             cobalt%resp_ca_2_n_arag * cobalt%jremin_ndet(i,j,k) * cobalt%c_2_n
@@ -5632,7 +5649,7 @@ contains
        cobalt%jalk(i,j,k) = 2.0 * (cobalt%jdiss_cadet_arag(i,j,k) +        &
           cobalt%jdiss_cadet_calc(i,j,k) - cobalt%jprod_cadet_arag(i,j,k) - &
           cobalt%jprod_cadet_calc(i,j,k) - cobalt%jprod_cadet_neritic(i,j,k)) + &
-          phyto(DIAZO)%juptake_no3(i,j,k)  + phyto(LARGE)%juptake_no3(i,j,k) + &
+          phyto(DIAZO)%juptake_no3(i,j,k) + phyto(LARGE)%juptake_no3(i,j,k) + &
           phyto(MEDIUM)%juptake_no3(i,j,k) + phyto(SMALL)%juptake_no3(i,j,k) + &
           (cobalt%jo2resp_wc(i,j,k)-cobalt%juptake_nh4nitrif(i,j,k)*cobalt%o2_2_nitrif)/cobalt%o2_2_nh4 + &
           cobalt%alk_2_n_denit*cobalt%jno3denit_wc(i,j,k) - &
@@ -6458,7 +6475,7 @@ contains
 
     ! << Fei Da, 202504: Add diagnostic for neritic CaCO3 burial
     ! Calculate the vertically integrated neritic CaCO3 burial within the top 150m
-    if (do_ner_ca_bur) then
+    if (cobalt%do_ner_ca_bur) then
        do j = jsc, jec ; do i = isc, iec !{
           rho_dzt_150(i,j) = rho_dzt(i,j,1)
           cobalt%jprod_cadet_neritic_150(i,j) = cobalt%jprod_cadet_neritic(i,j,1) * rho_dzt(i,j,1)


### PR DESCRIPTION
Summary:
This update implements neritic CaCO₃ burial and particle-associated dissolution processes in COBALTv3.
Conditional flags (do_ner_ca_bur and do_resp_ca_diss) have been added to enable or disable these processes as needed. Code formatting and implementation are aligned with existing COBALT conventions.
Key changes:
Added neritic CaCO₃ burial based on shallow water (≤150m) burial fields.
Implemented respiration-driven CaCO₃ dissolution tied to local undersaturation around sinking particles.
Included diagnostics for 3-D burial fields and 150m vertically integrated burial.
Ensured carbon and alkalinity budget closure whether burial/dissolution is enabled or disabled.