### PR TITLE
Make the nitrification "b" exponent a namelist variable

### DIFF
--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -447,7 +447,7 @@ module cobalt_types
           gamma_ndet,       &
           gamma_nitrif,     &
           k_nh3_nitrif,     &
-		  nitrif_b,         &
+          nitrif_b,         &
           gamma_sidet,      &
           gamma_srdon,      &
           gamma_srdop,      &

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -447,6 +447,7 @@ module cobalt_types
           gamma_ndet,       &
           gamma_nitrif,     &
           k_nh3_nitrif,     &
+		  nitrif_b,         &
           gamma_sidet,      &
           gamma_srdon,      &
           gamma_srdop,      &

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1648,7 +1648,7 @@ contains
     call get_param(param_file, "generic_COBALT", "o2_min_nit", cobalt%o2_min_nit, &
                    "Minimum oxygen level for nitrification", units="mol O2 kg-1", default=0.01e-6)
     call get_param(param_file, "generic_COBALT", "nitrif_b", cobalt%nitrif_b, &
-                   "Ammonium exponent for nitrification", units="unitless", default=2)
+                   "Ammonium exponent for nitrification", units="unitless", default=2.0)
     ! Anammox parameterization developed for ESM4.5.  This relatively new process is turned off in the default CEFI
     ! configuration by setting the rate constant to 0.  To activate, set this constant to 0.07 day-1.  Translated to
     ! sec-1 by the model

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1634,9 +1634,9 @@ contains
     ! Nitrification as in Paulot et al., 2020 (https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2019MS002026)
     ! Note: Values and functional form to be updated for ESM4.5 following the data compilation of Tang et al.,
     ! (https://essd.copernicus.org/articles/15/5039/2023/essd-15-5039-2023.html)
-	!
-	! Units for gamma_nitrif is dependent on the value of nitrif_b.
-	! E.g., when nitrif_b = 1, then the units for gamma_nitrif become sec-1 only.
+    !
+    ! Units for gamma_nitrif is dependent on the value of nitrif_b.
+    ! E.g., when nitrif_b = 1, then the units for gamma_nitrif become sec-1 only.
     call get_param(param_file, "generic_COBALT", "gamma_nitrif", cobalt%gamma_nitrif, "nitrification rate constant", &
                    units="(moles kg)-1 sec-1", default= 3.5e6/(30.0*sperd))
     call get_param(param_file, "generic_COBALT", "knh3_nitrif", cobalt%k_nh3_nitrif, "nitrification half-saturation", &
@@ -3743,7 +3743,7 @@ contains
              cobalt%juptake_nh4nitrif(i,j,k) = cobalt%gamma_nitrif * &
                   cobalt%f_nh3(i,j,k)/(cobalt%f_nh3(i,j,k)+cobalt%k_nh3_nitrif) *  &
                   (1.-cobalt%f_irr_aclm(i,j,k)/(cobalt%irr_inhibit+cobalt%f_irr_aclm(i,j,k))) * &
-                  cobalt%f_o2(i,j,k)/(cobalt%k_o2_nit+cobalt%f_o2(i,j,k)) * cobalt%f_nh4(i,j,k)**nitrif_b
+                  cobalt%f_o2(i,j,k)/(cobalt%k_o2_nit+cobalt%f_o2(i,j,k)) * cobalt%f_nh4(i,j,k)**cobalt%nitrif_b
 
              if (scheme_nitrif .eq. 3) then
                 cobalt%juptake_nh4nitrif(i,j,k) = cobalt%juptake_nh4nitrif(i,j,k)*cobalt%expkT(i,j,k)

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1636,9 +1636,9 @@ contains
     ! (https://essd.copernicus.org/articles/15/5039/2023/essd-15-5039-2023.html)
     !
     ! Units for gamma_nitrif is dependent on the value of nitrif_b.
-    ! E.g., when nitrif_b = 1, then the units for gamma_nitrif become sec-1 only.
+    ! E.g., when nitrif_b = 2, the units for gamma_nitrif are mol N kg-1 day-1, but when nitrif_b = 1, they are day-1 only.
     call get_param(param_file, "generic_COBALT", "gamma_nitrif", cobalt%gamma_nitrif, "nitrification rate constant", &
-                   units="(moles kg)-1 sec-1", default= 3.5e6/(30.0*sperd))
+                   units="day-1 (mol N kg-1)-(nitrif_b-1)", default= 3.5e6/(30.0*sperd))
     call get_param(param_file, "generic_COBALT", "knh3_nitrif", cobalt%k_nh3_nitrif, "nitrification half-saturation", &
                    units="mol kg-1", default=3.1e-9)
     call get_param(param_file, "generic_COBALT", "irr_inhibit", cobalt%irr_inhibit, &

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1634,6 +1634,9 @@ contains
     ! Nitrification as in Paulot et al., 2020 (https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2019MS002026)
     ! Note: Values and functional form to be updated for ESM4.5 following the data compilation of Tang et al.,
     ! (https://essd.copernicus.org/articles/15/5039/2023/essd-15-5039-2023.html)
+	!
+	! Units for gamma_nitrif is dependent on the value of nitrif_b.
+	! E.g., when nitrif_b = 1, then the units for gamma_nitrif become sec-1 only.
     call get_param(param_file, "generic_COBALT", "gamma_nitrif", cobalt%gamma_nitrif, "nitrification rate constant", &
                    units="(moles kg)-1 sec-1", default= 3.5e6/(30.0*sperd))
     call get_param(param_file, "generic_COBALT", "knh3_nitrif", cobalt%k_nh3_nitrif, "nitrification half-saturation", &
@@ -1644,6 +1647,8 @@ contains
                    "oxygen half-saturation constant for nitrification", units="mol O2 kg-1", default= 3.9e-6)
     call get_param(param_file, "generic_COBALT", "o2_min_nit", cobalt%o2_min_nit, &
                    "Minimum oxygen level for nitrification", units="mol O2 kg-1", default=0.01e-6)
+    call get_param(param_file, "generic_COBALT", "nitrif_b", cobalt%nitrif_b, &
+                   "Ammonium exponent for nitrification", units="unitless", default=2)
     ! Anammox parameterization developed for ESM4.5.  This relatively new process is turned off in the default CEFI
     ! configuration by setting the rate constant to 0.  To activate, set this constant to 0.07 day-1.  Translated to
     ! sec-1 by the model
@@ -3738,7 +3743,7 @@ contains
              cobalt%juptake_nh4nitrif(i,j,k) = cobalt%gamma_nitrif * &
                   cobalt%f_nh3(i,j,k)/(cobalt%f_nh3(i,j,k)+cobalt%k_nh3_nitrif) *  &
                   (1.-cobalt%f_irr_aclm(i,j,k)/(cobalt%irr_inhibit+cobalt%f_irr_aclm(i,j,k))) * &
-                  cobalt%f_o2(i,j,k)/(cobalt%k_o2_nit+cobalt%f_o2(i,j,k)) * cobalt%f_nh4(i,j,k)**2
+                  cobalt%f_o2(i,j,k)/(cobalt%k_o2_nit+cobalt%f_o2(i,j,k)) * cobalt%f_nh4(i,j,k)**nitrif_b
 
              if (scheme_nitrif .eq. 3) then
                 cobalt%juptake_nh4nitrif(i,j,k) = cobalt%juptake_nh4nitrif(i,j,k)*cobalt%expkT(i,j,k)


### PR DESCRIPTION
This addresses issue #131, and makes the b exponent in nitrification a namelist variable, so it can be changed more readily. This allows for us to adopt new settings for nitrification consistent with values from the [Tang et al. (2023)](https://essd.copernicus.org/articles/15/5039/2023/essd-15-5039-2023.html) data compilation.

```
#override gamma_nitrif = 4.63e-7 ! equivalent to 0.04/sperd
#override knh3_nitrif = 2.86e-9
#override irr_inhibit = 4.08
#override k_o2_nit = 0.436e-6 
#override nitrif_b = 1
```