### PR TITLE
fixed  btm_*  and *_100 diagnostics

### DIFF
--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -2829,7 +2829,7 @@ contains
 
     ! send_diag for integeral outputs
     call cobalt_send_diagnostics(tracer_list,model_time,grid_tmask,Temp,Salt,rho_dzt,dzt, &
-         isc,iec,jsc,jec,isd,ied,jsd,jed,nk,grid_kmt,tau,phyto,zoo,bact,cobalt,post_vertdiff=.true.)
+         ilb,jlb,tau,phyto,zoo,bact,cobalt,post_vertdiff=.true.)
 
   end subroutine generic_COBALT_update_from_bottom
 
@@ -6435,7 +6435,7 @@ contains
 ! Send phytoplankton diagnostic data
 
     call cobalt_send_diagnostics(tracer_list,model_time,grid_tmask,Temp,Salt,rho_dzt,dzt, &
-         isc,iec,jsc,jec,isd,ied,jsd,jed,nk,grid_kmt,tau,phyto,zoo,bact,cobalt)
+         ilb,jlb,tau,phyto,zoo,bact,cobalt)
 
 !==============================================================================================================
 


### PR DESCRIPTION
As titled. When #133 was introduced, it was a large PR and unfortunately, we didn’t review it thoroughly. As a result, a silly bug slipped through—mainly incorrect dimensions for a few variables such as `Temp`, `Salt`, `rho_dzt`, `dzt`and a few others.

This PR fixes that issue by passing those variables with the correct dimensions. We also simplified the interface of `cobalt_send_diagnostics` and now use `g_tracer_get_common` to retrieve all the index values and masks. Below are screenshots demonstrating that we now have the correct outputs.
![Screenshot from 2025-05-13 11-11-46](https://github.com/user-attachments/assets/ec4ebe82-8766-4f7b-8869-3c3f80271cbb)
![Screenshot from 2025-05-13 11-13-36](https://github.com/user-attachments/assets/2b3615a8-7d99-44af-b588-471c483d7f02)





