### PR TITLE
Enhanced logic for initializing Cobalt tracers

### DIFF
--- a/generic_tracers/generic_tracer_utils.F90
+++ b/generic_tracers/generic_tracer_utils.F90
@@ -999,16 +999,23 @@ contains
 
     if(present(sink_rate)) g_tracer%sink_rate = sink_rate
 
-    call  g_tracer_add_param(trim(g_tracer%name)//"_requires_src_info",g_tracer%requires_src_info , .false.)
-
-    if(present(requires_src_info)) then
-       g_tracer%requires_src_info = requires_src_info 
-    elseif(trim(g_tracer%package_name) .eq. 'generic_cobalt' .or. &
-           trim(g_tracer%package_name) .eq. 'generic_abiotic' .or. &
-           trim(g_tracer%package_name) .eq. 'generic_bling') then !Niki: later we can make this just else
-       call  g_tracer_add_param('enforce_src_info', g_tracer%requires_src_info ,  .true.) 
+    ! Set default based on global option first (enforce_src_info)
+    if (trim(g_tracer%package_name) .eq. 'generic_cobalt' .or. &
+        trim(g_tracer%package_name) .eq. 'generic_abiotic' .or. &
+        trim(g_tracer%package_name) .eq. 'generic_bling') then
+        call g_tracer_add_param('enforce_src_info', g_tracer%requires_src_info, .true.)
+    else
+        g_tracer%requires_src_info = .false.
     endif
-       
+
+    ! Now allow per-tracer override (if defined in field_table or passed in)
+    call g_tracer_add_param(trim(g_tracer%name)//"_requires_src_info", g_tracer%requires_src_info, g_tracer%requires_src_info)
+
+    ! Finally allow hard-coded override if passed as optional argument
+    if (present(requires_src_info)) then
+        g_tracer%requires_src_info = requires_src_info
+    endif
+
     call  g_tracer_add_param(trim(g_tracer%name)//"_src_file",         g_tracer%src_file ,        'NULL') 
     call  g_tracer_add_param(trim(g_tracer%name)//"_src_var_name",     g_tracer%src_var_name ,    'NULL') 
     call  g_tracer_add_param(trim(g_tracer%name)//"_src_var_unit",     g_tracer%src_var_unit ,    'NULL') 


### PR DESCRIPTION
As titled. This PR allows COBALT to initialize individual tracers—whereas previously the code would initialize all tracer fields and ignore the `GENERIC_TRACER_IC` if `enforce_src_info = .true.`—in cases where they are not found in the IC or restart files. This change provides flexibility to initialize newly added tracers independently, without modifying the original IC or restart datasets.

Below are a few more details on how this behaves under different scenarios:

1. When `GENERIC_TRACER_IC_FILE` is used for tracer initialization:
In this case, the code will first attempt to read tracer fields from the file specified in `GENERIC_TRACER_IC_FILE`. If any specific tracer field is missing, the code will then check the `field_table` to see if those tracers are defined there.

For example, if `pcmlim_aclm_ndi` is missing from your IC file and you want this tracer field to be initialized with 0, you can add the following line to your `field_table` :
```
  pcmlim_aclm_ndi_requires_restart = f
```
**make sure `enforce_src_info = f` in your `field_table`**

In this setup,`pcmlim_aclm_ndi` will be initialized as 0 (default value in the codes).

If instead you want to initialize `pcmlim_aclm_ndi` with non-zero values, add the following line:
```
pcmlim_aclm_ndi_requires_src_info = t
pcmlim_aclm_ndi_src_file = INPUT/init_ocean_cobalt.res.nc
pcmlim_aclm_ndi_src_var_name = mu_mem_ndi
pcmlim_aclm_ndi_src_var_unit = none
pcmlim_aclm_ndi_dest_var_name = pcmlim_aclm_ndi
pcmlim_aclm_ndi_dest_var_unit = none
pcmlim_aclm_ndi_src_var_record = 1
pcmlim_aclm_ndi_src_var_gridspec = NONE
pcmlim_aclm_ndi_valid_min = 0.0
```

In this case, you must provide `init_ocean_cobalt.res.nc` in your INPUT folder so that `pcmlim_aclm_ndi` can be initialized from the data in the file.

2. If your model starts from restart files generated from previous runs but some tracer fields are missing:
You can follow the same approach as in the first scenario by adding the following line to your `field_table` to initialize as 0:
```
  pcmlim_aclm_ndi_requires_restart = f
```

or again from data:

```
pcmlim_aclm_ndi_requires_src_info = t
pcmlim_aclm_ndi_src_file = INPUT/init_ocean_cobalt.res.nc
pcmlim_aclm_ndi_src_var_name = mu_mem_ndi
pcmlim_aclm_ndi_src_var_unit = none
pcmlim_aclm_ndi_dest_var_name = pcmlim_aclm_ndi
pcmlim_aclm_ndi_dest_var_unit = none
pcmlim_aclm_ndi_src_var_record = 1
pcmlim_aclm_ndi_src_var_gridspec = NONE
pcmlim_aclm_ndi_valid_min = 0.0
```

Additionally, you will need to set `TRACERS_MAY_REINIT = True` in `MOM_override` to allow the model to reinitialize this specific tracer field.

**Important:**
Remember to change `TRACERS_MAY_REINIT` back to `False` after the first segment run. Otherwise, the model will continue to reinitialize this tracer field from 0 or the provided data in every subsequent run.

This PR has been tested with both NEP and NWA configurations, and the answers remain the same. We added the above instruction to our [wiki page](https://github.com/NOAA-GFDL/CEFI-regional-MOM6/wiki/Initialize-tracer-fields-not-present-in-the-IC-or-RESTART) too.

CC @charliestock , @andrew-c-ross , @amoebaliz , @theresa-cordero , @gabyneg , @uwagura , @jessluo 