### PR TITLE
updates for CMIP7 diagnostics

### DIFF
--- a/generic_tracers/cobalt_reg_diag.F90
+++ b/generic_tracers/cobalt_reg_diag.F90
@@ -2121,10 +2121,6 @@ module COBALT_reg_diag
     cobalt%id_ffe_geotherm = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("ffe_iceberg","iceberg iron efflux",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_ffe_iceberg = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
     vardesc_temp = vardesc("flithdet_btm","Lithogenic detrital sinking flux burial",'h','1','s','g m-2 s-1','f')
     cobalt%id_flithdet_btm = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -3305,7 +3301,6 @@ module COBALT_reg_diag
          cmor_standard_name="mole_concentration_of_dissolved_inorganic_carbon_abiotic_analogue_in_sea_water",  &
          cmor_long_name="Abiotic Dissolved Inorganic Carbon Concentration")
 
-! 2017/12/28 jgj Updated standard name in data request: added _abiotic_analogue
     vardesc_temp = vardesc("dissi14cabio_raw","Abiotic Dissolved Inorganic 14Carbon Concentration",'h','L','s','mol m-3','f')
     cobalt%id_dissi14cabio = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -3355,6 +3350,7 @@ module COBALT_reg_diag
          cmor_standard_name="mole_concentration_of_calcite_expressed_as_carbon_in_sea_water", &
          cmor_long_name="Calcite Concentration")
 
+    ! Note that COBALT only tracks aragonite detritus
     vardesc_temp = vardesc("arag_raw","Aragonite Concentration",'h','L','s','mol m-3','f')
     cobalt%id_arag = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -3362,47 +3358,47 @@ module COBALT_reg_diag
          cmor_standard_name="mole_concentration_of_aragonite_expressed_as_carbon_in_sea_water", &
          cmor_long_name="Aragonite Concentration")
 
-    vardesc_temp = vardesc("phydiat_raw","Mole Concentration of Diatoms expressed as Carbon in sea water",'h','L','s','mol m-3','f')
+    vardesc_temp = vardesc("phydiat_raw","Mole Concentration of Diatoms expressed as Carbon in Sea Water",'h','L','s','mol m-3','f')
     cobalt%id_phydiat = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="phydiat", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_diatoms_expressed_as_carbon_in_sea_water", &
-         cmor_long_name="Mole Concentration of Diatoms expressed as Carbon in sea water")
+         cmor_long_name="Mole Concentration of Diatoms expressed as Carbon in Sea Water")
 
-    vardesc_temp = vardesc("phydiaz_raw","Mole Concentration of Diazotrophs expressed as Carbon in sea water",'h','L','s','mol m-3','f')
+    vardesc_temp = vardesc("phydiaz_raw","Mole Concentration of Diazotrophs expressed as Carbon in Sea Water",'h','L','s','mol m-3','f')
     cobalt%id_phydiaz = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="phydiaz", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_diazotrophs_expressed_as_carbon_in_sea_water", &
-         cmor_long_name="Mole Concentration of Diazotrophs expressed as Carbon in sea water")
+         cmor_long_name="Mole Concentration of Diazotrophs expressed as Carbon in Sea Water")
 
-    vardesc_temp = vardesc("phypico_raw","Mole Concentration of Picophytoplankton expressed as Carbon in sea water",'h','L','s','mol m-3','f')
+    vardesc_temp = vardesc("phypico_raw","Mole Concentration of Picophytoplankton expressed as Carbon in Sea Water",'h','L','s','mol m-3','f')
     cobalt%id_phypico = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="phypico", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_picophytoplankton_expressed_as_carbon_in_sea_water", &
-         cmor_long_name="Mole Concentration of Picophytoplankton expressed as Carbon in sea water")
+         cmor_long_name="Mole Concentration of Picophytoplankton expressed as Carbon in Sea Water")
 
-    vardesc_temp = vardesc("phymisc_raw","Mole Concentration of Miscellaneous Phytoplankton expressed as Carbon in sea water",'h','L','s','mol m-3','f')
+    vardesc_temp = vardesc("phymisc_raw","Mole Concentration of Miscellaneous Phytoplankton expressed as Carbon in Sea Water",'h','L','s','mol m-3','f')
     cobalt%id_phymisc = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="phymisc", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_miscellaneous_phytoplankton_expressed_as_carbon_in_sea_water", &
-         cmor_long_name="Mole Concentration of Miscellaneous Phytoplankton expressed as Carbon in sea water")
+         cmor_long_name="Mole Concentration of Miscellaneous Phytoplankton expressed as Carbon in Sea Water")
 
-    vardesc_temp = vardesc("zmicro_raw","Mole Concentration of Microzooplankton expressed as Carbon in sea water",'h','L','s','mol m-3','f')
+    vardesc_temp = vardesc("zmicro_raw","Mole Concentration of Microzooplankton expressed as Carbon in Sea Water",'h','L','s','mol m-3','f')
     cobalt%id_zmicro = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="zmicro", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_microzooplankton_expressed_as_carbon_in_sea_water", &
-         cmor_long_name="Mole Concentration of Microzooplankton expressed as Carbon in sea water")
+         cmor_long_name="Mole Concentration of Microzooplankton expressed as Carbon in Sea Water")
 
-    vardesc_temp = vardesc("zmeso_raw","Mole Concentration of Mesozooplankton expressed as Carbon in sea water",'h','L','s','mol m-3','f')
+    vardesc_temp = vardesc("zmeso_raw","Mole Concentration of Mesozooplankton expressed as Carbon in Sea Water",'h','L','s','mol m-3','f')
     cobalt%id_zmeso = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="zmeso", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_mesozooplankton_expressed_as_carbon_in_sea_water", &
-         cmor_long_name="Mole Concentration of Mesozooplankton expressed as Carbon in sea water")
+         cmor_long_name="Mole Concentration of Mesozooplankton expressed as Carbon in Sea Water")
 
     vardesc_temp = vardesc("talk_raw","Total Alkalinity",'h','L','s','mol m-3','f')
     cobalt%id_talk = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
@@ -3439,7 +3435,7 @@ module COBALT_reg_diag
          cmor_standard_name="sea_water_ph_abiotic_analogue_reported_on_total_scale", &
          cmor_long_name="Abiotic pH")
 
-!! same name in model and CMOR, but different units - use _cmip for now
+    ! Same name in model and CMOR, but different units - use "_cmip" to differentiate
     vardesc_temp = vardesc("o2_raw","Dissolved Oxygen Concentration",'h','L','s','mol m-3','f')
     cobalt%id_o2_cmip = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -3454,7 +3450,7 @@ module COBALT_reg_diag
          cmor_standard_name="mole_concentration_of_dissolved_molecular_oxygen_in_sea_water_at_saturation", &
          cmor_long_name="Dissolved Oxygen Concentration at Saturation")
 
-!! same name in model and CMOR, but different units - use _cmip for now
+    ! Same name in model and CMOR, but different units - use "_cmip" to differentiate
     vardesc_temp = vardesc("no3_raw","Dissolved Nitrate Concentration",'h','L','s','mol m-3','f')
     cobalt%id_no3_cmip = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -3493,106 +3489,106 @@ module COBALT_reg_diag
          cmor_long_name="Total Dissolved Inorganic Silicon Concentration")
 
 !! same name in model and CMOR, but different units - use _cmip for now
-    vardesc_temp = vardesc("chl_raw","Mass Concentration of Total Phytoplankton expressed as Chlorophyll in sea water",'h','L','s','kg m-3','f')
+    vardesc_temp = vardesc("chl_raw","Mass Concentration of Total Phytoplankton expressed as Chlorophyll in Sea Water",'h','L','s','kg m-3','f')
     cobalt%id_chl_cmip = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="chl_cmip", cmor_units="kg m-3",                          &
          cmor_standard_name="mass_concentration_of_phytoplankton_expressed_as_chlorophyll_in_sea_water", &
-         cmor_long_name="Mass Concentration of Total Phytoplankton expressed as Chlorophyll in sea water")
+         cmor_long_name="Mass Concentration of Total Phytoplankton expressed as Chlorophyll in Sea Water")
 
-    vardesc_temp = vardesc("chldiat_raw","Mass Concentration of Diatoms expressed as Chlorophyll in sea water",'h','L','s','kg m-3','f')
+    vardesc_temp = vardesc("chldiat_raw","Mass Concentration of Diatoms expressed as Chlorophyll in Sea Water",'h','L','s','kg m-3','f')
     cobalt%id_chldiat = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="chldiat", cmor_units="kg m-3",                          &
          cmor_standard_name="mass_concentration_of_diatoms_expressed_as_chlorophyll_in_sea_water", &
-         cmor_long_name="Mass Concentration of Diatoms expressed as Chlorophyll in sea water")
+         cmor_long_name="Mass Concentration of Diatoms expressed as Chlorophyll in Sea Water")
 
-    vardesc_temp = vardesc("chldiaz_raw","Mass Concentration of Diazotrophs expressed as Chlorophyll in sea water",'h','L','s','kg m-3','f')
+    vardesc_temp = vardesc("chldiaz_raw","Mass Concentration of Diazotrophs expressed as Chlorophyll in Sea Water",'h','L','s','kg m-3','f')
     cobalt%id_chldiaz = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="chldiaz", cmor_units="kg m-3",                          &
          cmor_standard_name="mass_concentration_of_diazotrophs_expressed_as_chlorophyll_in_sea_water", &
-         cmor_long_name="Mass Concentration of Diazotrophs expressed as Chlorophyll in sea water")
+         cmor_long_name="Mass Concentration of Diazotrophs expressed as Chlorophyll in Sea Water")
 
-    vardesc_temp = vardesc("chlpico_raw","Mass Concentration of Picophytoplankton expressed as Chlorophyll in sea water",'h','L','s','kg m-3','f')
+    vardesc_temp = vardesc("chlpico_raw","Mass Concentration of Picophytoplankton expressed as Chlorophyll in Sea Water",'h','L','s','kg m-3','f')
     cobalt%id_chlpico = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="chlpico", cmor_units="kg m-3",                          &
          cmor_standard_name="mass_concentration_of_picophytoplankton_expressed_as_chlorophyll_in_sea_water", &
-         cmor_long_name="Mass Concentration of Picophytoplankton expressed as Chlorophyll in sea water")
+         cmor_long_name="Mass Concentration of Picophytoplankton expressed as Chlorophyll in Sea Water")
 
-    vardesc_temp = vardesc("chlmisc_raw","Mass Concentration of Other Phytoplankton expressed as Chlorophyll in sea water",'h','L','s','kg m-3','f')
+    vardesc_temp = vardesc("chlmisc_raw","Mass Concentration of Other Phytoplankton expressed as Chlorophyll in Sea Water",'h','L','s','kg m-3','f')
     cobalt%id_chlmisc = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="chlmisc", cmor_units="kg m-3",                          &
          cmor_standard_name="mass_concentration_of_miscellaneous_phytoplankton_expressed_as_chlorophyll_in_sea_water", &
-         cmor_long_name="Mass Concentration of Other Phytoplankton expressed as Chlorophyll in sea water")
+         cmor_long_name="Mass Concentration of Other Phytoplankton expressed as Chlorophyll in Sea Water")
 
 ! 2017/11/27 not in data request
-    vardesc_temp = vardesc("poc_raw","Mole Concentration of Particulate Organic Matter expressed as Carbon in sea water",'h','L','s','mol m-3','f')
+    vardesc_temp = vardesc("poc_raw","Mole Concentration of Particulate Organic Matter expressed as Carbon in Sea Water",'h','L','s','mol m-3','f')
     cobalt%id_poc = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="poc", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_particulate_organic_matter_expressed_as_carbon_in_sea_water", &
-         cmor_long_name="Mole Concentration of Particulate Organic Matter expressed as Carbon in sea water")
+         cmor_long_name="Mole Concentration of Particulate Organic Matter expressed as Carbon in Sea Water")
 
-    vardesc_temp = vardesc("pon_raw","Mole Concentration of Particulate Organic Matter expressed as Nitrogen in sea water",'h','L','s','mol N m-3','f')
+    vardesc_temp = vardesc("pon_raw","Mole Concentration of Particulate Organic Matter expressed as Nitrogen in Sea Water",'h','L','s','mol N m-3','f')
     cobalt%id_pon = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="pon", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_particulate_organic_matter_expressed_as_nitrogen_in_sea_water", &
-         cmor_long_name="Mole Concentration of Particulate Organic Matter expressed as Nitrogen in sea water")
+         cmor_long_name="Mole Concentration of Particulate Organic Matter expressed as Nitrogen in Sea Water")
 
-    vardesc_temp = vardesc("pop_raw","Mole Concentration of Particulate Organic Matter expressed as Phosphorus in sea water",'h','L','s','mol m-3','f')
+    vardesc_temp = vardesc("pop_raw","Mole Concentration of Particulate Organic Matter expressed as Phosphorus in Sea Water",'h','L','s','mol m-3','f')
     cobalt%id_pop = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="pop", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_particulate_organic_matter_expressed_as_phosphorus_in_sea_water", &
-         cmor_long_name="Mole Concentration of Particulate Organic Matter expressed as Phosphorus in sea water")
+         cmor_long_name="Mole Concentration of Particulate Organic Matter expressed as Phosphorus in Sea Water")
 
-    vardesc_temp = vardesc("bfe_raw","Mole Concentration of Particulate Organic Matter expressed as Iron in sea water",'h','L','s','mol m-3','f')
+    vardesc_temp = vardesc("bfe_raw","Mole Concentration of Particulate Organic Matter expressed as Iron in Sea Water",'h','L','s','mol m-3','f')
     cobalt%id_bfe = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="bfe", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_particulate_organic_matter_expressed_as_iron_in_sea_water", &
-         cmor_long_name="Mole Concentration of Particulate Organic Matter expressed as Iron in sea water")
+         cmor_long_name="Mole Concentration of Particulate Organic Matter expressed as Iron in Sea Water")
 
 ! CHECK3:
 ! 2017/12/28 jgj Updated standard name in data request to include _organic
-    vardesc_temp = vardesc("bsi_raw","Mole Concentration of Particulate Organic Matter expressed as Silicon in sea water",'h','L','s','mol m-3','f')
+    vardesc_temp = vardesc("bsi_raw","Mole Concentration of Particulate Organic Matter expressed as Silicon in Sea Water",'h','L','s','mol m-3','f')
     cobalt%id_bsi = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="bsi", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_particulate_organic_matter_expressed_as_silicon_in_sea_water", &
-         cmor_long_name="Mole Concentration of Particulate Organic Matter expressed as Silicon in sea water")
+         cmor_long_name="Mole Concentration of Particulate Organic Matter expressed as Silicon in Sea Water")
 
-    vardesc_temp = vardesc("phyn_raw","Mole Concentration of Total Phytoplankton expressed as Nitrogen in sea water",'h','L','s','mol m-3','f')
+    vardesc_temp = vardesc("phyn_raw","Mole Concentration of Total Phytoplankton expressed as Nitrogen in Sea Water",'h','L','s','mol m-3','f')
     cobalt%id_phyn = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="phyn", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_phytoplankton_expressed_as_nitrogen_in_sea_water", &
-         cmor_long_name="Mole Concentration of Total Phytoplankton expressed as Nitrogen in sea water")
+         cmor_long_name="Mole Concentration of Total Phytoplankton expressed as Nitrogen in Sea Water")
 
-    vardesc_temp = vardesc("phyp_raw","Mole Concentration of Total Phytoplankton expressed as Phosphorus in sea water",'h','L','s','mol m-3','f')
+    vardesc_temp = vardesc("phyp_raw","Mole Concentration of Total Phytoplankton expressed as Phosphorus in Sea Water",'h','L','s','mol m-3','f')
     cobalt%id_phyp = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="phyp", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_phytoplankton_expressed_as_phosphorus_in_sea_water", &
-         cmor_long_name="Mole Concentration of Total Phytoplankton expressed as Phosphorus in sea water")
+         cmor_long_name="Mole Concentration of Total Phytoplankton expressed as Phosphorus in Sea Water")
 
-    vardesc_temp = vardesc("phyfe_raw","Mole Concentration of Total Phytoplankton expressed as Iron in sea water",'h','L','s','mol m-3','f')
+    vardesc_temp = vardesc("phyfe_raw","Mole Concentration of Total Phytoplankton expressed as Iron in Sea Water",'h','L','s','mol m-3','f')
     cobalt%id_phyfe = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="phyfe", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_phytoplankton_expressed_as_iron_in_sea_water", &
-         cmor_long_name="Mole Concentration of Total Phytoplankton expressed as Iron in sea water")
+         cmor_long_name="Mole Concentration of Total Phytoplankton expressed as Iron in Sea Water")
 
-    vardesc_temp = vardesc("physi_raw","Mole Concentration of Total Phytoplankton expressed as Silicon in sea water",'h','L','s','mol m-3','f')
+    vardesc_temp = vardesc("physi_raw","Mole Concentration of Total Phytoplankton expressed as Silicon in Sea Water",'h','L','s','mol m-3','f')
     cobalt%id_physi = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="physi", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_phytoplankton_expressed_as_silicon_in_sea_water", &
-         cmor_long_name="Mole Concentration of Total Phytoplankton expressed as Silicon in sea water")
+         cmor_long_name="Mole Concentration of Total Phytoplankton expressed as Silicon in Sea Water")
 
     vardesc_temp = vardesc("co3_raw","Carbonate Ion Concentration",'h','L','s','mol m-3','f')
     cobalt%id_co3 = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
@@ -3616,20 +3612,20 @@ module COBALT_reg_diag
          cmor_long_name="Abiotic Carbonate Ion Concentration")
 
 ! 2018/01/17 jgj Updated standard name in data request to match equivalent surface variable
-    vardesc_temp = vardesc("co3satcalc_raw","Mole Concentration of Carbonate Ion in Equilibrium with Pure Calcite in sea water",'h','L','s','mol m-3','f')
+    vardesc_temp = vardesc("co3satcalc_raw","Mole Concentration of Carbonate Ion in Equilibrium with Pure Calcite in Sea Water",'h','L','s','mol m-3','f')
     cobalt%id_co3satcalc = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="co3satcalc", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_carbonate_expressed_as_carbon_at_equilibrium_with_pure_calcite_in_sea_water", &
-         cmor_long_name="Mole Concentration of Carbonate Ion in Equilibrium with Pure Calcite in sea water")
+         cmor_long_name="Mole Concentration of Carbonate Ion in Equilibrium with Pure Calcite in Sea Water")
 
 ! 2018/01/17 jgj Updated standard name in data request to match equivalent surface variable
-    vardesc_temp = vardesc("co3satarag_raw","Mole Concentration of Carbonate Ion in Equilibrium with Pure Aragonite in sea water",'h','L','s','mol m-3','f')
+    vardesc_temp = vardesc("co3satarag_raw","Mole Concentration of Carbonate Ion in Equilibrium with Pure Aragonite in Sea Water",'h','L','s','mol m-3','f')
     cobalt%id_co3satarag = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="co3satarag", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_carbonate_expressed_as_carbon_at_equilibrium_with_pure_aragonite_in_sea_water", &
-         cmor_long_name="Mole Concentration of Carbonate Ion in Equilibrium with Pure Aragonite in sea water")
+         cmor_long_name="Mole Concentration of Carbonate Ion in Equilibrium with Pure Aragonite in Sea Water")
 
 !------------------------------------------------------------------------------------------------------------------
 ! 3-D rates
@@ -3671,7 +3667,8 @@ module COBALT_reg_diag
          cmor_standard_name="tendency_of_mole_concentration_of_silicon_in_sea_water_due_to_biological_production", &
          cmor_long_name="Biogenic Silicon Production")
 
-! Oyr only
+    ! Note: COBALT only models the production of calcite detritus, so values will be smaller than estimates of total
+    ! calcite production by approximately a factor of 1 over the calcite-specific export ratio.
     vardesc_temp = vardesc("pcalc_raw","Calcite Production",'h','L','s','mol m-3 s-1','f')
     cobalt%id_pcalc = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -3679,7 +3676,8 @@ module COBALT_reg_diag
          cmor_standard_name="tendency_of_mole_concentration_of_calcite_expressed_as_carbon_in_sea_water_due_to_biological_production", &
          cmor_long_name="Calcite Production")
 
-! Oyr only
+    ! Note: COBALT only models the production of aragonite detritus, so values will be smaller than estimates of total
+    ! aragonite production by approximately a factor of 1 over the aragonite-specific export ratio.
     vardesc_temp = vardesc("parag_raw","Aragonite Production",'h','L','s','mol m-3 s-1','f')
     cobalt%id_parag = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -3696,12 +3694,26 @@ module COBALT_reg_diag
          cmor_standard_name="sinking_mole_flux_of_particulate_organic_matter_expressed_as_carbon_in_sea_water", &
          cmor_long_name="Sinking Particulate Organic Carbon Flux")
 
+    vardesc_temp = vardesc("expcob_raw","Sinking Flux of Particulate Organic Carbon Reaching the Ocean Bottom",'h','L','s','mol m-2 s-1','f')
+    cobalt%id_expcob = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
+         cmor_field_name="expcob", cmor_units="mol m-2 s-1",                          &
+         cmor_standard_name="sinking_mole_flux_of_particulate_organic_matter_expressed_as_carbon_in_sea_water", &
+         cmor_long_name="Sinking Flux of Particulate Organic Carbon Reaching the Ocean Bottom")
+
     vardesc_temp = vardesc("expn_raw","Sinking Particulate Organic Nitrogen Flux",'h','L','s','mol m-2 s-1','f')
     cobalt%id_expn_tp = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="expn", cmor_units="mol m-2 s-1",                          &
          cmor_standard_name="sinking_mole_flux_of_particulate_organic_nitrogen_in_sea_water", &
          cmor_long_name="Sinking Particulate Organic Nitrogen Flux")
+
+    vardesc_temp = vardesc("expnob_raw","Sinking Flux of Particulate Organic Nitrogen Reaching the Ocean Bottom",'h','L','s','mol m-2 s-1','f')
+    cobalt%id_expnob = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
+         cmor_field_name="expnob", cmor_units="mol m-2 s-1",                          &
+         cmor_standard_name="sinking_mole_flux_of_particulate_organic_nitrogen_in_sea_water", &
+         cmor_long_name="Sinking Flux of Particulate Organic Nitrogen Reaching the Ocean Bottom")
 
     vardesc_temp = vardesc("expp_raw","Sinking Particulate Organic Phosphorus Flux",'h','L','s','mol m-2 s-1','f')
     cobalt%id_expp_tp = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
@@ -3710,12 +3722,26 @@ module COBALT_reg_diag
          cmor_standard_name="sinking_mole_flux_of_particulate_organic_phosphorus_in_sea_water", &
          cmor_long_name="Sinking Particulate Organic Phosphorus Flux")
 
+    vardesc_temp = vardesc("exppob_raw","Sinking Flux of Particulate Organic Phosphorus Reaching the Ocean Bottom",'h','L','s','mol m-2 s-1','f')
+    cobalt%id_exppob = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
+         cmor_field_name="exppob", cmor_units="mol m-2 s-1",                          &
+         cmor_standard_name="sinking_mole_flux_of_particulate_organic_phosphorus_in_sea_water", &
+         cmor_long_name="Sinking Flux of Particulate Organic Phosphorus Reaching the Ocean Bottom")
+
     vardesc_temp = vardesc("expfe_raw","Sinking Particulate Iron Flux",'h','L','s','mol m-2 s-1','f')
     cobalt%id_expfe_tp = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="expfe", cmor_units="mol m-2 s-1",                          &
          cmor_standard_name="sinking_mole_flux_of_particulate_iron_in_sea_water", &
          cmor_long_name="Sinking Particulate Iron Flux")
+
+    vardesc_temp = vardesc("expfeob_raw","Sinking Flux of Particulate Iron Reaching the Ocean Bottom",'h','L','s','mol m-2 s-1','f')
+    cobalt%id_expfeob = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
+         cmor_field_name="expfeob", cmor_units="mol m-2 s-1",                          &
+         cmor_standard_name="sinking_mole_flux_of_particulate_iron_in_sea_water", &
+         cmor_long_name="Sinking Flux of Particulate Iron Reaching the Ocean Bottom")
 
     vardesc_temp = vardesc("expsi_raw","Sinking Particulate Silicon Flux",'h','L','s','mol m-2 s-1','f')
     cobalt%id_expsi_tp = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
@@ -3724,6 +3750,13 @@ module COBALT_reg_diag
          cmor_standard_name="sinking_mole_flux_of_particulate_silicon_in_sea_water", &
          cmor_long_name="Sinking Particulate Silicon Flux")
 
+    vardesc_temp = vardesc("expsiob_raw","Sinking Flux of Particulate Silicon Reaching the Ocean Bottom",'h','L','s','mol m-2 s-1','f')
+    cobalt%id_expsiob = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
+         cmor_field_name="expsiob", cmor_units="mol m-2 s-1",                          &
+         cmor_standard_name="sinking_mole_flux_of_particulate_silicon_in_sea_water", &
+         cmor_long_name="Sinking Flux of Particulate Silicon Reaching the Ocean Bottom")
+
     vardesc_temp = vardesc("expcalc_raw","Sinking Calcite Flux",'h','L','s','mol m-2 s-1','f')
     cobalt%id_expcalc_tp = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -3731,12 +3764,26 @@ module COBALT_reg_diag
          cmor_standard_name="sinking_mole_flux_of_calcite_expressed_as_carbon_in_sea_water", &
          cmor_long_name="Sinking Calcite Flux")
 
+    vardesc_temp = vardesc("expcalcob_raw","Sinking Flux of Calcite Reaching the Ocean Bottom",'h','L','s','mol m-2 s-1','f')
+    cobalt%id_expcalcob = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
+         cmor_field_name="expcalcob", cmor_units="mol m-2 s-1",                          &
+         cmor_standard_name="sinking_mole_flux_of_calcite_expressed_as_carbon_in_in_sea_water", &
+         cmor_long_name="Sinking Flux of Calcite Reaching the Ocean Bottom")
+
     vardesc_temp = vardesc("exparag_raw","Sinking Aragonite Flux",'h','L','s','mol m-2 s-1','f')
     cobalt%id_exparag_tp = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="exparag", cmor_units="mol m-2 s-1",                          &
          cmor_standard_name="sinking_mole_flux_of_aragonite_expressed_as_carbon_in_sea_water", &
          cmor_long_name="Sinking Aragonite Flux")
+
+    vardesc_temp = vardesc("exparagob_raw","Sinking Flux of Aragonite Reaching the Ocean Bottom",'h','L','s','mol m-2 s-1','f')
+    cobalt%id_exparagob = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
+         cmor_field_name="exparagob", cmor_units="mol m-2 s-1",                          &
+         cmor_standard_name="sinking_mole_flux_of_aragonite_expressed_as_carbon_in_sea_water", &
+         cmor_long_name="Sinking Flux of Aragonite Reaching the Ocean Bottom")
 
     !
     ! Option to save at interfaces
@@ -3755,21 +3802,21 @@ module COBALT_reg_diag
          cmor_standard_name="sinking_mole_flux_of_particulate_organic_nitrogen_in_sea_water", &
          cmor_long_name="Sinking Particulate Organic Nitrogen Flux")
          
-    vardesc_temp = vardesc("expp_raw_i","Sinking Particulate Organic Phosphorus Flux (@interfaces)",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("expp_raw_i","Sinking Particulate Organic Phosphorus Flux (@interfaces)",'h','i','s','mol m-2 s-1','f')
     cobalt%id_expp_i = register_diag_field(package_name, vardesc_temp%name, axes(1:1), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="expp_i", cmor_units="mol m-2 s-1",                          &
          cmor_standard_name="sinking_mole_flux_of_particulate_organic_phosphorus_in_sea_water", &
          cmor_long_name="Sinking Particulate Organic Phosphorus Flux")
          
-    vardesc_temp = vardesc("expfe_raw_i","Sinking Particulate Iron Flux (@interfaces)",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("expfe_raw_i","Sinking Particulate Iron Flux (@interfaces)",'h','i','s','mol m-2 s-1','f')
     cobalt%id_expfe_i = register_diag_field(package_name, vardesc_temp%name, axes(1:1), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="expfe_i", cmor_units="mol m-2 s-1",                          &
          cmor_standard_name="sinking_mole_flux_of_particulate_iron_in_sea_water", &
          cmor_long_name="Sinking Particulate Iron Flux")
 
-    vardesc_temp = vardesc("expsi_raw_i","Sinking Particulate Silicon Flux (@interfaces)",'h','L','s','mol m-2 s-1','f')
+    vardesc_temp = vardesc("expsi_raw_i","Sinking Particulate Silicon Flux (@interfaces)",'h','i','s','mol m-2 s-1','f')
     cobalt%id_expsi_i = register_diag_field(package_name, vardesc_temp%name, axes(1:1), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="expsi_i", cmor_units="mol m-2 s-1",                          &
@@ -3899,8 +3946,6 @@ module COBALT_reg_diag
          cmor_standard_name="tendency_of_mole_concentration_of_dissolved_iron_in_sea_water_due_to_dissolution_from_inorganic_particles", &
          cmor_long_name="Particle Source of Dissolved Iron")
 
-! CHECK3:
-! 2017/08/04 jgj: CMOR requires area:areacello, volume:volcello
     vardesc_temp = vardesc("graz_raw","Total Grazing of Phytoplankton by Zooplankton",'h','L','s','mol m-3 s-1','f')
     cobalt%id_graz = register_diag_field(package_name, vardesc_temp%name, axes(1:3), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -4100,6 +4145,7 @@ module COBALT_reg_diag
          cmor_standard_name="mole_concentration_of_calcite_expressed_as_carbon_in_sea_water", &
          cmor_long_name="Surface Calcite Concentration")
 
+    ! Note that COBALT onlt tracks aragonite detritus
     vardesc_temp = vardesc("aragos_raw","Surface Aragonite Concentration",'h','1','s','mol m-3','f')
     cobalt%id_aragos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -4107,47 +4153,47 @@ module COBALT_reg_diag
          cmor_standard_name="mole_concentration_of_aragonite_expressed_as_carbon_in_sea_water", &
          cmor_long_name="Surface Aragonite Concentration")
 
-    vardesc_temp = vardesc("phydiatos_raw","Surface Mole Concentration of Diatoms expressed as Carbon in sea water",'h','1','s','mol m-3','f')
+    vardesc_temp = vardesc("phydiatos_raw","Surface Mole Concentration of Diatoms expressed as Carbon in Sea Water",'h','1','s','mol m-3','f')
     cobalt%id_phydiatos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="phydiatos", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_diatoms_expressed_as_carbon_in_sea_water", &
-         cmor_long_name="Surface Mole Concentration of Diatoms expressed as Carbon in sea water")
+         cmor_long_name="Surface Mole Concentration of Diatoms expressed as Carbon in Sea Water")
 
-    vardesc_temp = vardesc("phydiazos_raw","Surface Mole Concentration of Diazotrophs expressed as Carbon in sea water",'h','1','s','mol m-3','f')
+    vardesc_temp = vardesc("phydiazos_raw","Surface Mole Concentration of Diazotrophs expressed as Carbon in Sea Water",'h','1','s','mol m-3','f')
     cobalt%id_phydiazos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="phydiazos", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_diazotrophs_expressed_as_carbon_in_sea_water", &
-         cmor_long_name="Surface Mole Concentration of Diazotrophs expressed as Carbon in sea water")
+         cmor_long_name="Surface Mole Concentration of Diazotrophs expressed as Carbon in Sea Water")
 
-    vardesc_temp = vardesc("phypicoos_raw","Surface Mole Concentration of Picophytoplankton expressed as Carbon in sea water",'h','1','s','mol m-3','f')
+    vardesc_temp = vardesc("phypicoos_raw","Surface Mole Concentration of Picophytoplankton expressed as Carbon in Sea Water",'h','1','s','mol m-3','f')
     cobalt%id_phypicoos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="phypicoos", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_picophytoplankton_expressed_as_carbon_in_sea_water", &
-         cmor_long_name="Surface Mole Concentration of Picophytoplankton expressed as Carbon in sea water")
+         cmor_long_name="Surface Mole Concentration of Picophytoplankton expressed as Carbon in Sea Water")
 
-    vardesc_temp = vardesc("phymiscos_raw","Surface Mole Concentration of Miscellaneous Phytoplankton expressed as Carbon in sea water",'h','1','s','mol m-3','f')
+    vardesc_temp = vardesc("phymiscos_raw","Surface Mole Concentration of Miscellaneous Phytoplankton expressed as Carbon in Sea Water",'h','1','s','mol m-3','f')
     cobalt%id_phymiscos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="phymiscos", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_miscellaneous_phytoplankton_expressed_as_carbon_in_sea_water", &
-         cmor_long_name="Surface Mole Concentration of Miscellaneous Phytoplankton expressed as Carbon in sea water")
+         cmor_long_name="Surface Mole Concentration of Miscellaneous Phytoplankton expressed as Carbon in Sea Water")
 
-    vardesc_temp = vardesc("zmicroos_raw","Surface Mole Concentration of Microzooplankton expressed as Carbon in sea water",'h','1','s','mol m-3','f')
+    vardesc_temp = vardesc("zmicroos_raw","Surface Mole Concentration of Microzooplankton expressed as Carbon in Sea Water",'h','1','s','mol m-3','f')
     cobalt%id_zmicroos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="zmicroos", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_microzooplankton_expressed_as_carbon_in_sea_water", &
-         cmor_long_name="Surface Mole Concentration of Microzooplankton expressed as Carbon in sea water")
+         cmor_long_name="Surface Mole Concentration of Microzooplankton expressed as Carbon in Sea Water")
 
-    vardesc_temp = vardesc("zmesoos_raw","Surface Mole Concentration of Mesozooplankton expressed as Carbon in sea water",'h','1','s','mol m-3','f')
+    vardesc_temp = vardesc("zmesoos_raw","Surface Mole Concentration of Mesozooplankton expressed as Carbon in Sea Water",'h','1','s','mol m-3','f')
     cobalt%id_zmesoos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="zmesoos", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_mesozooplankton_expressed_as_carbon_in_sea_water", &
-         cmor_long_name="Surface Mole Concentration of Mesozooplankton expressed as Carbon in sea water")
+         cmor_long_name="Surface Mole Concentration of Mesozooplankton expressed as Carbon in Sea Water")
 
     vardesc_temp = vardesc("talkos_raw","Surface Total Alkalinity",'h','1','s','mol m-3','f')
     cobalt%id_talkos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
@@ -4184,7 +4230,6 @@ module COBALT_reg_diag
          cmor_standard_name="sea_water_ph_abiotic_analogue_reported_on_total_scale", &
          cmor_long_name="Surface Abiotic pH")
 
-!! jgj 2017/08/04 removed _cmip in cmor_field_name - update diag table
     vardesc_temp = vardesc("o2os_raw","Surface Dissolved Oxygen Concentration",'h','1','s','mol m-3','f')
     cobalt%id_o2os = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -4192,7 +4237,6 @@ module COBALT_reg_diag
          cmor_standard_name="mole_concentration_of_dissolved_molecular_oxygen_in_sea_water", &
          cmor_long_name="Surface Dissolved Oxygen Concentration")
 
-! CHECK3: need 3-D field
     vardesc_temp = vardesc("o2satos_raw","Surface Dissolved Oxygen Concentration at Saturation",'h','1','s','mol m-3','f')
     cobalt%id_o2satos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -4200,7 +4244,6 @@ module COBALT_reg_diag
          cmor_standard_name="mole_concentration_of_dissolved_molecular_oxygen_in_sea_water_at_saturation", &
          cmor_long_name="Surface Dissolved Oxygen Concentration at Saturation")
 
-!! jgj 2017/08/04 removed _cmip in cmor_field_name - update diag table
     vardesc_temp = vardesc("no3os_raw","Surface Dissolved Nitrate Concentration",'h','1','s','mol m-3','f')
     cobalt%id_no3os = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -4239,99 +4282,97 @@ module COBALT_reg_diag
          cmor_standard_name="mole_concentration_of_dissolved_inorganic_silicon_in_sea_water", &
          cmor_long_name="Surface Total Dissolved Inorganic Silicon Concentration")
 
-!! jgj 2017/08/04 removed _cmip in cmor_field_name - update diag table
-! also in Oday (updated to match Omon long_name, standard_name)
-    vardesc_temp = vardesc("chlos_raw","Surface Mass Concentration of Total Phytoplankton expressed as Chlorophyll in sea water",'h','1','s','kg m-3','f')
+    vardesc_temp = vardesc("chlos_raw","Surface Mass Concentration of Total Phytoplankton expressed as Chlorophyll in Sea Water",'h','1','s','kg m-3','f')
     cobalt%id_chlos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="chlos", cmor_units="kg m-3",                          &
          cmor_standard_name="mass_concentration_of_phytoplankton_expressed_as_chlorophyll_in_sea_water", &
-         cmor_long_name="Surface Mass Concentration of Total Phytoplankton expressed as Chlorophyll in sea water")
+         cmor_long_name="Surface Mass Concentration of Total Phytoplankton expressed as Chlorophyll in Sea Water")
 
-    vardesc_temp = vardesc("chldiatos_raw","Surface Mass Concentration of Diatoms expressed as Chlorophyll in sea water",'h','1','s','kg m-3','f')
+    vardesc_temp = vardesc("chldiatos_raw","Surface Mass Concentration of Diatoms expressed as Chlorophyll in Sea Water",'h','1','s','kg m-3','f')
     cobalt%id_chldiatos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="chldiatos", cmor_units="kg m-3",                          &
          cmor_standard_name="mass_concentration_of_diatoms_expressed_as_chlorophyll_in_sea_water", &
-         cmor_long_name="Surface Mass Concentration of Diatoms expressed as Chlorophyll in sea water")
+         cmor_long_name="Surface Mass Concentration of Diatoms expressed as Chlorophyll in Sea Water")
 
-    vardesc_temp = vardesc("chldiazos_raw","Surface Mass Concentration of Diazotrophs expressed as Chlorophyll in sea water",'h','1','s','kg m-3','f')
+    vardesc_temp = vardesc("chldiazos_raw","Surface Mass Concentration of Diazotrophs expressed as Chlorophyll in Sea Water",'h','1','s','kg m-3','f')
     cobalt%id_chldiazos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="chldiazos", cmor_units="kg m-3",                          &
          cmor_standard_name="mass_concentration_of_diazotrophs_expressed_as_chlorophyll_in_sea_water", &
-         cmor_long_name="Surface Mass Concentration of Diazotrophs expressed as Chlorophyll in sea water")
+         cmor_long_name="Surface Mass Concentration of Diazotrophs expressed as Chlorophyll in Sea Water")
 
-    vardesc_temp = vardesc("chlpicoos_raw","Surface Mass Concentration of Picophytoplankton expressed as Chlorophyll in sea water",'h','1','s','kg m-3','f')
+    vardesc_temp = vardesc("chlpicoos_raw","Surface Mass Concentration of Picophytoplankton expressed as Chlorophyll in Sea Water",'h','1','s','kg m-3','f')
     cobalt%id_chlpicoos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="chlpicoos", cmor_units="kg m-3",                          &
          cmor_standard_name="mass_concentration_of_picophytoplankton_expressed_as_chlorophyll_in_sea_water", &
-         cmor_long_name="Surface Mass Concentration of Picophytoplankton expressed as Chlorophyll in sea water")
+         cmor_long_name="Surface Mass Concentration of Picophytoplankton expressed as Chlorophyll in Sea Water")
 
-    vardesc_temp = vardesc("chlmiscos_raw","Surface Mass Concentration of Other Phytoplankton expressed as Chlorophyll in sea water",'h','1','s','kg m-3','f')
+    vardesc_temp = vardesc("chlmiscos_raw","Surface Mass Concentration of Other Phytoplankton expressed as Chlorophyll in Sea Water",'h','1','s','kg m-3','f')
     cobalt%id_chlmiscos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="chlmiscos", cmor_units="kg m-3",                          &
          cmor_standard_name="mass_concentration_of_miscellaneous_phytoplankton_expressed_as_chlorophyll_in_sea_water", &
-         cmor_long_name="Surface Mass Concentration of Other Phytoplankton expressed as Chlorophyll in sea water")
+         cmor_long_name="Surface Mass Concentration of Other Phytoplankton expressed as Chlorophyll in Sea Water")
 
-    vardesc_temp = vardesc("ponos_raw","Surface Mole Concentration of Particulate Organic Matter expressed as Nitrogen in sea water",'h','1','s','mol N m-3','f')
+    vardesc_temp = vardesc("ponos_raw","Surface Mole Concentration of Particulate Organic Matter expressed as Nitrogen in Sea Water",'h','1','s','mol N m-3','f')
     cobalt%id_ponos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="ponos", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_particulate_organic_matter_expressed_as_nitrogen_in_sea_water", &
-         cmor_long_name="Surface Mole Concentration of Particulate Organic Matter expressed as Nitrogen in sea water")
+         cmor_long_name="Surface Mole Concentration of Particulate Organic Matter expressed as Nitrogen in Sea Water")
 
-    vardesc_temp = vardesc("popos_raw","Surface Mole Concentration of Particulate Organic Matter expressed as Phosphorus in sea water",'h','1','s','mol m-3','f')
+    vardesc_temp = vardesc("popos_raw","Surface Mole Concentration of Particulate Organic Matter expressed as Phosphorus in Sea Water",'h','1','s','mol m-3','f')
     cobalt%id_popos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="popos", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_particulate_organic_matter_expressed_as_phosphorus_in_sea_water", &
-         cmor_long_name="Surface Mole Concentration of Particulate Organic Matter expressed as Phosphorus in sea water")
+         cmor_long_name="Surface Mole Concentration of Particulate Organic Matter expressed as Phosphorus in Sea Water")
 
-    vardesc_temp = vardesc("bfeos_raw","Surface Mole Concentration of Particulate Organic Matter expressed as Iron in sea water",'h','1','s','mol m-3','f')
+    vardesc_temp = vardesc("bfeos_raw","Surface Mole Concentration of Particulate Organic Matter expressed as Iron in Sea Water",'h','1','s','mol m-3','f')
     cobalt%id_bfeos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="bfeos", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_particulate_organic_matter_expressed_as_iron_in_sea_water", &
-         cmor_long_name="Surface Mole Concentration of Particulate Organic Matter expressed as Iron in sea water")
+         cmor_long_name="Surface Mole Concentration of Particulate Organic Matter expressed as Iron in Sea Water")
 
-    vardesc_temp = vardesc("bsios_raw","Surface Mole Concentration of Particulate Organic Matter expressed as Silicon in sea water",'h','1','s','mol m-3','f')
+    vardesc_temp = vardesc("bsios_raw","Surface Mole Concentration of Particulate Organic Matter expressed as Silicon in Sea Water",'h','1','s','mol m-3','f')
     cobalt%id_bsios = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="bsios", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_particulate_organic_matter_expressed_as_silicon_in_sea_water", &
-         cmor_long_name="Surface Mole Concentration of Particulate Organic Matter expressed as Silicon in sea water")
+         cmor_long_name="Surface Mole Concentration of Particulate Organic Matter expressed as Silicon in Sea Water")
 
-    vardesc_temp = vardesc("phynos_raw","Surface Mole Concentration of Phytoplankton Nitrogen in sea water",'h','1','s','mol m-3','f')
+    vardesc_temp = vardesc("phynos_raw","Surface Mole Concentration of Phytoplankton Nitrogen in Sea Water",'h','1','s','mol m-3','f')
     cobalt%id_phynos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="phynos", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_phytoplankton_expressed_as_nitrogen_in_sea_water", &
-         cmor_long_name="Surface Mole Concentration of Phytoplankton Nitrogen in sea water")
+         cmor_long_name="Surface Mole Concentration of Phytoplankton Nitrogen in Sea Water")
 
-    vardesc_temp = vardesc("phypos_raw","Surface Mole Concentration of Total Phytoplankton expressed as Phosphorus in sea water",'h','1','s','mol m-3','f')
+    vardesc_temp = vardesc("phypos_raw","Surface Mole Concentration of Total Phytoplankton expressed as Phosphorus in Sea Water",'h','1','s','mol m-3','f')
     cobalt%id_phypos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="phypos", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_phytoplankton_expressed_as_phosphorus_in_sea_water", &
-         cmor_long_name="Surface Mole Concentration of Total Phytoplankton expressed as Phosphorus in sea water")
+         cmor_long_name="Surface Mole Concentration of Total Phytoplankton expressed as Phosphorus in Sea Water")
 
-! 2017/12/28 jgj Updated long name in data request: Surface Mole Concentration of Total Phytoplankton expressed as Iron in sea water
-    vardesc_temp = vardesc("phyfeos_raw","Surface Mole Concentration of Total Phytoplankton expressed as Iron in sea water",'h','1','s','mol m-3','f')
+! 2017/12/28 jgj Updated long name in data request: Surface Mole Concentration of Total Phytoplankton expressed as Iron in Sea Water
+    vardesc_temp = vardesc("phyfeos_raw","Surface Mole Concentration of Total Phytoplankton expressed as Iron in Sea Water",'h','1','s','mol m-3','f')
     cobalt%id_phyfeos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="phyfeos", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_phytoplankton_expressed_as_iron_in_sea_water", &
-         cmor_long_name="Surface Mole Concentration of Total Phytoplankton expressed as Iron in sea water")
+         cmor_long_name="Surface Mole Concentration of Total Phytoplankton expressed as Iron in Sea Water")
 
-    vardesc_temp = vardesc("physios_raw","Surface Mole Concentration of Total Phytoplankton expressed as Silicon in sea water",'h','1','s','mol m-3','f')
+    vardesc_temp = vardesc("physios_raw","Surface Mole Concentration of Total Phytoplankton expressed as Silicon in Sea Water",'h','1','s','mol m-3','f')
     cobalt%id_physios = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="physios", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_phytoplankton_expressed_as_silicon_in_sea_water", &
-         cmor_long_name="Surface Mole Concentration of Total Phytoplankton expressed as Silicon in sea water")
+         cmor_long_name="Surface Mole Concentration of Total Phytoplankton expressed as Silicon in Sea Water")
 
     vardesc_temp = vardesc("co3os_raw","Surface Carbonate Ion Concentration",'h','1','s','mol m-3','f')
     cobalt%id_co3os = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
@@ -4354,19 +4395,19 @@ module COBALT_reg_diag
          cmor_standard_name="mole_concentration_of_carbonate_abiotic_analogue_expressed_as_carbon_in_sea_water", &
          cmor_long_name="Surface Abiotic Carbonate Ion Concentration")
 
-    vardesc_temp = vardesc("co3satcalcos_raw","Surface Mole Concentration of Carbonate Ion in Equilibrium with Pure Calcite in sea water",'h','1','s','mol m-3','f')
+    vardesc_temp = vardesc("co3satcalcos_raw","Surface Mole Concentration of Carbonate Ion in Equilibrium with Pure Calcite in Sea Water",'h','1','s','mol m-3','f')
     cobalt%id_co3satcalcos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="co3satcalcos", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_carbonate_expressed_as_carbon_at_equilibrium_with_pure_calcite_in_sea_water", &
-         cmor_long_name="Surface Mole Concentration of Carbonate Ion in Equilibrium with Pure Calcite in sea water")
+         cmor_long_name="Surface Mole Concentration of Carbonate Ion in Equilibrium with Pure Calcite in Sea Water")
 
-    vardesc_temp = vardesc("co3sataragos_raw","Surface Mole Concentration of Carbonate Ion in Equilibrium with Pure Aragonite in sea water",'h','1','s','mol m-3','f')
+    vardesc_temp = vardesc("co3sataragos_raw","Surface Mole Concentration of Carbonate Ion in Equilibrium with Pure Aragonite in Sea Water",'h','1','s','mol m-3','f')
     cobalt%id_co3sataragos = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="co3sataragos", cmor_units="mol m-3",                          &
          cmor_standard_name="mole_concentration_of_carbonate_expressed_as_carbon_at_equilibrium_with_pure_aragonite_in_sea_water", &
-         cmor_long_name="Surface Mole Concentration of Carbonate Ion in Equilibrium with Pure Aragonite in sea water")
+         cmor_long_name="Surface Mole Concentration of Carbonate Ion in Equilibrium with Pure Aragonite in Sea Water")
 
 !------------------------------------------------------------------------------------------------------------------
 ! 2-D fields (from Omon)
@@ -4412,6 +4453,20 @@ module COBALT_reg_diag
          cmor_field_name="intppmisc", cmor_units="mol m-2 s-1",                          &
          cmor_standard_name="net_primary_mole_productivity_of_biomass_expressed_as_carbon_by_miscellaneous_phytoplankton", &
          cmor_long_name="Net Primary Organic Carbon Production by Other Phytoplankton")
+
+    vardesc_temp = vardesc("intppnano_raw","Net Primary Organic Carbon Production by Nanophytoplankton",'h','1','s','mol m-2 s-1','f')
+    cobalt%id_intppmisc = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
+         cmor_field_name="intppnano", cmor_units="mol m-2 s-1",                          &
+         cmor_standard_name="net_primary_mole_productivity_of_biomass_expressed_as_carbon_by_nanophytoplankton", &
+         cmor_long_name="Net Primary Organic Carbon Production by Nanophytoplankton")
+
+    vardesc_temp = vardesc("intppmicro_raw","Net Primary Organic Carbon Production by Microphytoplankton",'h','1','s','mol m-2 s-1','f')
+    cobalt%id_intppmisc = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
+         cmor_field_name="intppmicro", cmor_units="mol m-2 s-1",                          &
+         cmor_standard_name="net_primary_mole_productivity_of_biomass_expressed_as_carbon_by_microphytoplankton", &
+         cmor_long_name="Net Primary Organic Carbon Production by Microphytoplankton")
 
     vardesc_temp = vardesc("intpbn_raw","Nitrogen Production",'h','1','s','mol m-2 s-1','f')
     cobalt%id_intpbn = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
@@ -4576,8 +4631,6 @@ module COBALT_reg_diag
          cmor_standard_name="surface_molecular_oxygen_partial_pressure_difference_between_sea_water_and_air", &
          cmor_long_name="Delta PO2")
 
-! CHECK3:
-! 2017/08/04 jgj: CMOR requires positive down, area:areacello
     vardesc_temp = vardesc("fgco2_raw","Surface Downward Flux of Total CO2",'h','1','s','kg m-2 s-1','f')
     cobalt%id_fgco2 = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -4585,8 +4638,6 @@ module COBALT_reg_diag
          cmor_standard_name="surface_downward_mass_flux_of_carbon_dioxide_expressed_as_carbon", &
          cmor_long_name="Surface Downward Flux of Total CO2")
 
-! CHECK3:
-! 2017/08/04 jgj: CMOR requires positive down, area:areacello
     vardesc_temp = vardesc("fgco2nat_raw","Surface Downward Flux of Natural CO2",'h','1','s','kg m-2 s-1','f')
     cobalt%id_fgco2nat = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -4594,8 +4645,6 @@ module COBALT_reg_diag
          cmor_standard_name="surface_downward_mass_flux_of_carbon_dioxide_natural_analogue_expressed_as_carbon", &
          cmor_long_name="Surface Downward Flux of Natural CO2")
 
-! CHECK3:
-! 2017/08/04 jgj: CMOR requires positive down, area:areacello
     vardesc_temp = vardesc("fgco2abio_raw","Surface Downward Flux of Abiotic CO2",'h','1','s','kg m-2 s-1','f')
     cobalt%id_fgco2abio = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -4603,8 +4652,6 @@ module COBALT_reg_diag
          cmor_standard_name="surface_downward_mass_flux_of_carbon_dioxide_abiotic_analogue_expressed_as_carbon", &
          cmor_long_name="Surface Downward Flux of Abiotic CO2")
 
-! CHECK3:
-! 2017/08/04 jgj: CMOR requires positive down, area:areacello
     vardesc_temp = vardesc("fg14co2abio_raw","Surface Downward Flux of Abiotic 14CO2",'h','1','s','kg m-2 s-1','f')
     cobalt%id_fg14co2abio = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -4612,8 +4659,6 @@ module COBALT_reg_diag
          cmor_standard_name="surface_downward_mass_flux_of_carbon14_dioxide_abiotic_analogue_expressed_as_carbon", &
          cmor_long_name="Surface Downward Flux of Abiotic 14CO2")
 
-! CHECK3:
-! 2017/08/04 jgj: CMOR requires positive down, area:areacello
     vardesc_temp = vardesc("fgo2_raw","Surface Downward Flux of O2",'h','1','s','mol m-2 s-1','f')
     cobalt%id_fgo2 = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
@@ -4681,7 +4726,7 @@ module COBALT_reg_diag
     cobalt%id_frfe = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="frfe", cmor_units="mol m-2 s-1",                          &
-         cmor_standard_name="tendency_of_ocean_mole_content_of_iron_due_to_sedimentation", &
+         cmor_standard_name="minus_tendency_of_ocean_mole_content_of_iron_due_to_sedimentation", &
          cmor_long_name="Iron Loss to Sediments")
 
     vardesc_temp = vardesc("o2min_raw","Oxygen Minimum Concentration",'h','1','s','mol m-3','f')

--- a/generic_tracers/cobalt_reg_diag.F90
+++ b/generic_tracers/cobalt_reg_diag.F90
@@ -3826,7 +3826,7 @@ module COBALT_reg_diag
     cobalt%id_expcalcob = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="expcalcob", cmor_units="mol m-2 s-1",                          &
-         cmor_standard_name="sinking_mole_flux_of_calcite_expressed_as_carbon_in_in_sea_water", &
+         cmor_standard_name="sinking_mole_flux_of_calcite_expressed_as_carbon_in_sea_water", &
          cmor_long_name="Sinking Flux of Calcite Reaching the Ocean Bottom")
 
     vardesc_temp = vardesc("exparag_raw","Sinking Aragonite Flux",'h','L','s','mol m-2 s-1','f')
@@ -4513,14 +4513,14 @@ module COBALT_reg_diag
          cmor_long_name="Net Primary Organic Carbon Production by Other Phytoplankton")
 
     vardesc_temp = vardesc("intppnano_raw","Net Primary Organic Carbon Production by Nanophytoplankton",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_intppmisc = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
+    cobalt%id_intppnano = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="intppnano", cmor_units="mol m-2 s-1",                          &
          cmor_standard_name="net_primary_mole_productivity_of_biomass_expressed_as_carbon_by_nanophytoplankton", &
          cmor_long_name="Net Primary Organic Carbon Production by Nanophytoplankton")
 
     vardesc_temp = vardesc("intppmicro_raw","Net Primary Organic Carbon Production by Microphytoplankton",'h','1','s','mol m-2 s-1','f')
-    cobalt%id_intppmisc = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
+    cobalt%id_intppmicro = register_diag_field(package_name, vardesc_temp%name, axes(1:2), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="intppmicro", cmor_units="mol m-2 s-1",                          &
          cmor_standard_name="net_primary_mole_productivity_of_biomass_expressed_as_carbon_by_microphytoplankton", &

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -52,6 +52,7 @@ module COBALT_send_diag
       integer, dimension(:,:), Allocatable :: k_bot
       real, dimension(:,:), Allocatable :: rho_dzt_100,rho_dzt_200,rho_dzt_bot    
       integer :: k_100,k_200
+      real, dimension(:,:), Allocatable :: field_2d !used to calculate some 2d fields before saving 
       real, dimension(:,:,:), Allocatable :: flux_i !used to save fluxes at the interfaces
 
 
@@ -490,15 +491,15 @@ module COBALT_send_diag
 
 
           ! The carbon layer integral (organic + inorganic).  Note that this can be calculated with or without a constant
-          ! background level of recalcitrant dissolved organic carbon by setting cobalt%doc_background.  This is included
-          ! at a level of 40 micromoles kg-1 by default.
+          ! background level of recalcitrant dissolved organic carbon by setting cobalt%doc_background. Since CMIP7 requested
+          ! explicit pools only, the default was set to 0 from previous values ~40 micromoles kg-1.
           cobalt%tot_layer_int_c(:,:,:) = (cobalt%p_dic(:,:,:,tau) + cobalt%doc_background + cobalt%p_cadet_arag(:,:,:,tau) +&
             cobalt%p_cadet_calc(:,:,:,tau) + cobalt%c_2_n * (cobalt%p_ndi(:,:,:,tau) + cobalt%p_nlg(:,:,:,tau) + &
             cobalt%p_nmd(:,:,:,tau) + cobalt%p_nsm(:,:,:,tau) + cobalt%p_nbact(:,:,:,tau) + cobalt%p_ldon(:,:,:,tau) + &
             cobalt%p_sldon(:,:,:,tau) + cobalt%p_srdon(:,:,:,tau) + cobalt%p_ndet(:,:,:,tau) + cobalt%p_nsmz(:,:,:,tau) + &
             cobalt%p_nmdz(:,:,:,tau) + cobalt%p_nlgz(:,:,:,tau))) * rho_dzt(:,:,:)
 
-          ! dissolved organic component also includes an optional background doc
+          ! dissolved organic component also includes an optional background doc (0 by default)
           cobalt%tot_layer_int_doc(:,:,:) = (cobalt%c_2_n * (cobalt%p_ldon(:,:,:,tau) + cobalt%p_sldon(:,:,:,tau) + &
             cobalt%p_srdon(:,:,:,tau)) + cobalt%doc_background) * rho_dzt(:,:,:)
 
@@ -629,7 +630,7 @@ module COBALT_send_diag
               rho_dzt(i,j,1)
             cobalt%f_silg_100(i,j) = cobalt%p_silg(i,j,1,tau)*rho_dzt(i,j,1)
             cobalt%f_simd_100(i,j) = cobalt%p_simd(i,j,1,tau)*rho_dzt(i,j,1)
-            ! sinking fluxes (should we just handle these with by remapping the appropriate 3D variable onto 100m?)
+            ! sinking fluxes (should handle these with by remapping the appropriate 3D variable onto 100m)
             ! need to add fast sinking detritus
             cobalt%fndet_100(i,j) = cobalt%p_ndet(i,j,1,tau) * cobalt%Rho_0 * cobalt%wsink
             cobalt%fpdet_100(i,j) = cobalt%p_pdet(i,j,1,tau) * cobalt%Rho_0 * cobalt%wsink
@@ -875,9 +876,10 @@ module COBALT_send_diag
           ! need to add fast sinking detritus once implemented
           used = g_send_data(cobalt%id_detoc,  cobalt%p_ndet(:,:,:,tau) * cobalt%c_2_n * cobalt%Rho_0, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-          ! Includes on calcite and aragonite detritus, not comparable to total calcite/aragonite st surface
+          ! Includes only calcite detritus, so concentration will be small relative to total particulate calcite
           used = g_send_data(cobalt%id_calc,  cobalt%p_cadet_calc(:,:,:,tau) * cobalt%Rho_0, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! Includes only aragonite detritus, so concentration will be small relative to total particulate aragonite 
           used = g_send_data(cobalt%id_arag,  cobalt%p_cadet_arag(:,:,:,tau) * cobalt%Rho_0, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_phydiat, (cobalt%nlg_diatoms+cobalt%nmd_diatoms)*cobalt%c_2_n*cobalt%Rho_0, &
@@ -922,6 +924,7 @@ module COBALT_send_diag
           ! Chlorophyll: CMIP asks for in kg Chl m-3
           used = g_send_data(cobalt%id_chl_cmip, cobalt%f_chl * cobalt%Rho_0 / 1.0e9, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          ! Chlorophyll for other phytoplankton groups derived from biomass and Chl:C ratios 
           used = g_send_data(cobalt%id_chldiat, (phyto(LARGE)%theta * cobalt%nlg_diatoms + &
             phyto(MEDIUM)%theta * cobalt%nmd_diatoms) * cobalt%c_2_n * cobalt%Rho_0 * 12.0e-3, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
@@ -1032,35 +1035,63 @@ module COBALT_send_diag
             cobalt%c_2_n*cobalt%Rho_0*grid_tmask(:,:,:)
           used = g_send_data(cobalt%id_expc_i, flux_i, model_time, rmask = grid_tmask, &
             is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk+1)
+          ! Bottom flux added for CMIP7, grid_tmask for nk corresponds to bottom flux at nk+1
+          used = g_send_data(cobalt%id_expcob, flux_i(:,:,nk+1), model_time, rmask = grid_tmask(:,:,nk), &
+            is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_froc, flux_i(:,:,nk+1), model_time, rmask = grid_tmask(:,:,nk), &
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec) 
           flux_i(:,:,2:nk+1) = (cobalt%p_ndet(:,:,:,tau)*cobalt%wsink + &
             cobalt%p_nsm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + cobalt%p_nmd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
             cobalt%p_nlg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + cobalt%p_ndi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:)) * &
             cobalt%Rho_0*grid_tmask(:,:,:)
           used = g_send_data(cobalt%id_expn_i, flux_i, model_time, rmask = grid_tmask, &
             is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk+1)
+          used = g_send_data(cobalt%id_expnob, flux_i(:,:,nk+1), model_time, rmask = grid_tmask(:,:,nk), &
+            is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          ! minus_tendency_of_ocean_mole_content_of_elemental_nitrogen_due_to_denitrification_and_sedimentation
+          used = g_send_data(cobalt%id_frn,  flux_i(:,:,nk+1) + cobalt%fno3denit_sed + cobalt%wc_vert_int_jno3denit + &
+            cobalt%wc_vert_int_jnamx, model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           flux_i(:,:,2:nk+1) = (cobalt%p_pdet(:,:,:,tau)*cobalt%wsink + &
             cobalt%p_psm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + cobalt%p_pmd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
             cobalt%p_plg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + cobalt%p_pdi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:)) * &
             cobalt%Rho_0*grid_tmask(:,:,:)
           used = g_send_data(cobalt%id_expp_i, flux_i, model_time, rmask = grid_tmask, &
             is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk+1)
+          used = g_send_data(cobalt%id_exppob, flux_i(:,:,nk+1), model_time, rmask = grid_tmask(:,:,nk), &
+            is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
           flux_i(:,:,2:nk+1) = (cobalt%p_fedet(:,:,:,tau)*cobalt%wsink + &
             cobalt%p_fesm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + cobalt%p_femd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
             cobalt%p_felg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + cobalt%p_fedi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:)) * &
             cobalt%Rho_0*grid_tmask(:,:,:)
           used = g_send_data(cobalt%id_expfe_i, flux_i, model_time, rmask = grid_tmask, &
             is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk+1)
+          used = g_send_data(cobalt%id_expfeob, flux_i(:,:,nk+1), model_time, rmask = grid_tmask(:,:,nk), &
+            is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          ! Iron loss to the sediments; minus_tendency_of_ocean_mole_content_of_iron_due_to_sedimentation
+          ! Interpreting this as the outward rather than net flux because fsfe contains sediment dissolution 
+          used = g_send_data(cobalt%id_frfe, flux_i(:,:,nk+1), &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           flux_i(:,:,2:nk+1) = (cobalt%p_sidet(:,:,:,tau)*cobalt%wsink + &
-            cobalt%p_femd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + cobalt%p_felg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:)) * &
+            cobalt%p_simd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + cobalt%p_silg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:)) * &
             cobalt%Rho_0*grid_tmask(:,:,:)
           used = g_send_data(cobalt%id_expsi_i, flux_i, model_time, rmask = grid_tmask, &
             is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk+1)
+          used = g_send_data(cobalt%id_expsiob, flux_i(:,:,nk+1), model_time, rmask = grid_tmask(:,:,nk), &
+            is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
           flux_i(:,:,2:nk+1) = cobalt%p_cadet_calc(:,:,:,tau)*cobalt%Rho_0*cobalt%wsink
           used = g_send_data(cobalt%id_expcalc_i, flux_i, model_time, rmask = grid_tmask, &
             is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk+1)
+          used = g_send_data(cobalt%id_expcalcob, flux_i(:,:,nk+1), model_time, rmask = grid_tmask(:,:,nk), &
+            is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
           flux_i(:,:,2:nk+1) = cobalt%p_cadet_arag(:,:,:,tau)*cobalt%Rho_0*cobalt%wsink
           used = g_send_data(cobalt%id_exparag_i, flux_i, model_time, rmask = grid_tmask, &
             is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk+1)
+          used = g_send_data(cobalt%id_exparagob, flux_i(:,:,nk+1), model_time, rmask = grid_tmask(:,:,nk), &
+            is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
+          ! minus_tendency_of_ocean_mole_content_of_inorganic_carbon_due_to_sedimentation
+          ! Include calcite and aragonite sinking; icfriver include dissolution from the sediment and other sources
+          used = g_send_data(cobalt%id_fric, (cobalt%p_cadet_arag(:,:,nk,tau) + cobalt%p_cadet_calc(:,:,nk,tau))* &
+            cobalt%Rho_0*cobalt%wsink, model_time, rmask=grid_tmask(:,:,nk), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
           deallocate(flux_i)
           !
           ! Surface CMIP variables (extract directly at specified depth from 3D fields?)
@@ -1079,8 +1110,10 @@ module COBALT_send_diag
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_detocos, cobalt%p_ndet(:,:,1,tau) * cobalt%c_2_n * cobalt%Rho_0,  &
             model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          ! Includes only calcite detritus, so concentration will be small relative to total particulate calcite
           used = g_send_data(cobalt%id_calcos, cobalt%p_cadet_calc(:,:,1,tau) * cobalt%Rho_0, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          ! Includes only aragonite detritus, so concentration will be small relative to total particulate aragonite
           used = g_send_data(cobalt%id_aragos, cobalt%p_cadet_arag(:,:,1,tau) * cobalt%Rho_0, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_phydiatos, (cobalt%nlg_diatoms(:,:,1) + cobalt%nmd_diatoms(:,:,1)) * &
@@ -1116,6 +1149,8 @@ module COBALT_send_diag
             model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_sios,  cobalt%p_sio4(:,:,1,tau) * cobalt%Rho_0, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          ! Native units of f_chl are micrograms Chl kg-1 (i.e., ug Chl kg-1); CMIP requests kgChl m-3, so:   
+          ! ug kg-1 * kg m-3 / 1.0e9 ug kg-1 = kg Chl m-3
           used = g_send_data(cobalt%id_chlos,  cobalt%f_chl(:,:,1) * cobalt%Rho_0 / 1.0e9, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_chldiatos,  (phyto(LARGE)%theta(:,:,1) * cobalt%nlg_diatoms(:,:,1) + &
@@ -1207,7 +1242,11 @@ module COBALT_send_diag
           !  model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
 
           !
-          ! 100m sinking flux (should derive 3D field and MOM6 interpolation?)
+          ! 100m sinking flux.  These are legacy diagnostics derived by finding the grid cell containing 100m and
+          ! assigning the sinking flux in this grid cell to 100m.  The bottom flux was also used in waters shallower
+          ! than 100m.  This approach was replaced in CMIP7 and beyond with a vertical interpolation of expc onto
+          ! 100m managed through the diagnostic table.  The old approach will be maintained for some time, but is
+          ! less accurate than the new approach and yields values that will not match those in the 3D expc.
           !
           used = g_send_data(cobalt%id_epc100, cobalt%fntot_100 * cobalt%c_2_n,  &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
@@ -1224,7 +1263,7 @@ module COBALT_send_diag
           used = g_send_data(cobalt%id_eparag100, cobalt%fcadet_arag_100,   &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           !
-          ! Vertical integrals (kg m-2)
+          ! Vertical integrals (convert from moles m-2 to kg m-2)
           !
           used = g_send_data(cobalt%id_intdic, cobalt%wc_vert_int_dic*12.0e-3,   &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
@@ -1602,8 +1641,6 @@ module COBALT_send_diag
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_ffe_geotherm,  cobalt%ffe_geotherm, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_ffe_iceberg,  cobalt%ffe_iceberg, &
-            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_fnso4red_sed,cobalt%fnso4red_sed, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_fno3denit_sed, cobalt%fno3denit_sed, &
@@ -1952,105 +1989,152 @@ module COBALT_send_diag
           !
           ! CMIP 100m biomass-weighted limitation terms 
           ! (recommend using surface to avoid aliasing the limitation with information from below the nutricline)
-          ! (***needs to update these for 4P formulation***) 
           !
-          used = g_send_data(cobalt%id_limndiat, phyto(LARGE)%nlim_bw_100, &
+          allocate( field_2d(isd:ied,jsd:jed) )
+          ! biomass-weighted diatom nitrogen limitation (contributions from medium and large)
+          field_2d(:,:) = & 
+            ( phyto(MEDIUM)%nlim_bw_100(:,:)*phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
+              phyto(LARGE)%nlim_bw_100(:,:)*phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) ) / &
+            ( phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
+              phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) )
+          used = g_send_data(cobalt%id_limndiat, field_2d, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           ! Not outputting/serving limndiaz because diazotrophs are not N limited
           ! used = g_send_data(cobalt%id_limndiaz, phyto(DIAZO)%nlim_bw_100, &
           !  model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_limnpico, phyto(SMALL)%nlim_bw_100, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_limnmisc, phyto(LARGE)%nlim_bw_100, &
+          ! biomass-weighted misc nitrogen limitation (contributions from medium and large)
+          field_2d(:,:) = &
+            ( phyto(MEDIUM)%nlim_bw_100(:,:)*(1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
+              phyto(LARGE)%nlim_bw_100(:,:)*(1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) ) / &
+            ( (1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
+              (1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) )
+          used = g_send_data(cobalt%id_limnmisc, field_2d, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_limirrdiat, phyto(LARGE)%irrlim_bw_100, &
+
+          ! biomass-weighted diatom irradiance limitation (contributions from medium and large)
+          field_2d(:,:) = &
+            ( phyto(MEDIUM)%irrlim_bw_100(:,:)*phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
+              phyto(LARGE)%irrlim_bw_100(:,:)*phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) ) / &
+            ( phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
+              phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) )
+          used = g_send_data(cobalt%id_limirrdiat, field_2d, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_limirrdiaz, phyto(DIAZO)%irrlim_bw_100, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_limirrpico, phyto(SMALL)%irrlim_bw_100, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_limirrmisc, phyto(LARGE)%irrlim_bw_100, &
+          ! biomass-weighted misc irradiance limitation (contributions from medium and large)
+          field_2d(:,:) = &
+            ( phyto(MEDIUM)%irrlim_bw_100(:,:)*(1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
+              phyto(LARGE)%irrlim_bw_100(:,:)*(1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) ) / &
+            ( (1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
+              (1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) )
+          used = g_send_data(cobalt%id_limirrmisc, field_2d, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_limfediat, phyto(LARGE)%def_fe_bw_100, &
+
+          ! biomass-weighted diatom iron limitation (contributions from medium and large)
+          field_2d(:,:) = &
+            ( phyto(MEDIUM)%def_fe_bw_100(:,:)*phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
+              phyto(LARGE)%def_fe_bw_100(:,:)*phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) ) / &
+            ( phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
+              phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) )
+          used = g_send_data(cobalt%id_limfediat, field_2d, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_limfediaz, phyto(DIAZO)%def_fe_bw_100, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_limfepico, phyto(SMALL)%def_fe_bw_100, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_limfemisc, phyto(LARGE)%def_fe_bw_100,  &
+          ! biomass-weighted misc iron limitation (contributions from medium and large)
+          field_2d(:,:) = &
+            ( phyto(MEDIUM)%def_fe_bw_100(:,:)*(1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
+              phyto(LARGE)%def_fe_bw_100(:,:)*(1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) ) / &
+            ( (1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
+              (1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) )
+          used = g_send_data(cobalt%id_limfemisc, field_2d,  &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_limpdiat, phyto(LARGE)%plim_bw_100, &
+          
+          ! biomass-weighted diatom phosphorus limitation (contributions from medium and large)
+          field_2d(:,:) = &
+            ( phyto(MEDIUM)%plim_bw_100(:,:)*phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
+              phyto(LARGE)%plim_bw_100(:,:)*phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) ) / &
+            ( phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
+              phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) )
+          used = g_send_data(cobalt%id_limpdiat, field_2d, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_limpdiaz, phyto(DIAZO)%plim_bw_100, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_limppico, phyto(SMALL)%plim_bw_100, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_limpmisc, phyto(LARGE)%plim_bw_100, &
+          ! biomass-weighted misc phosphorus limitation (contributions from medium and large)
+          field_2d(:,:) = &
+            ( phyto(MEDIUM)%plim_bw_100(:,:)*(1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
+              phyto(LARGE)%plim_bw_100(:,:)*(1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) ) / &
+            ( (1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
+              (1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) )
+          used = g_send_data(cobalt%id_limpmisc, field_2d, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          deallocate(field_2d)
 
-          ! should this be 100m or full water column?
-          used = g_send_data(cobalt%id_intpp,  cobalt%jprod_allphytos_100 * cobalt%c_2_n, &
+          ! Switched to full water column to be consistent with latest CMIP diagnostics and ensure all NPP is captured
+          ! For primary production, included the standard CMIP breakdown by functional type (diatom, diazotroph, 
+          ! picophyto and misc) and a breakdown strictly by size classes (pico, nano, micro) for FISH-MIP
+          ! Total = diat + diaz + pico + misc (standard CMIP)
+          ! Total = pico + nano + micro (by size class)
+          used = g_send_data(cobalt%id_intpp,  cobalt%wc_vert_int_npp * cobalt%c_2_n, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_intppnitrate,  (phyto(DIAZO)%jprod_n_new_100 +  phyto(LARGE)%jprod_n_new_100 + &
-            phyto(MEDIUM)%jprod_n_new_100 + phyto(SMALL)%jprod_n_new_100) * cobalt%c_2_n, &
+          used = g_send_data(cobalt%id_intppnitrate, cobalt%wc_vert_int_juptake_no3 * cobalt%c_2_n, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_intppdiat,  cobalt%jprod_diat_100 * cobalt%c_2_n,  &
+          used = g_send_data(cobalt%id_intppdiat,  cobalt%wc_vert_int_npp_diat * cobalt%c_2_n, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_intppdiaz,  phyto(DIAZO)%jprod_n_100 * cobalt%c_2_n, &
+          used = g_send_data(cobalt%id_intppdiaz,  cobalt%wc_vert_int_npp_diaz * cobalt%c_2_n, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_intpppico,  phyto(SMALL)%jprod_n_100 * cobalt%c_2_n, &
+          used = g_send_data(cobalt%id_intppmisc,  cobalt%wc_vert_int_npp_misc* cobalt%c_2_n, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_intppmisc, (phyto(LARGE)%jprod_n_100 + phyto(MEDIUM)%jprod_n_100 - &
-            cobalt%jprod_diat_100) *cobalt%c_2_n, model_time, rmask = grid_tmask(:,:,1), &
+          used = g_send_data(cobalt%id_intpppico, cobalt%wc_vert_int_npp_pico * cobalt%c_2_n, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intppnano, cobalt%wc_vert_int_npp_nano * cobalt%c_2_n, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intppmicro, cobalt%wc_vert_int_npp_micro * cobalt%c_2_n, &
+            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intpbn,  cobalt%wc_vert_int_juptake_nh4 + cobalt%wc_vert_int_juptake_no3 + &
+            cobalt%wc_vert_int_nfix, model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          used = g_send_data(cobalt%id_intpbp,  cobalt%wc_vert_int_juptake_po4, model_time, rmask = grid_tmask(:,:,1), &
             is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_intpbn,  cobalt%jprod_allphytos_100, &
-            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_intpbp, (phyto(DIAZO)%juptake_po4_100 +  phyto(LARGE)%juptake_po4_100 +  &
-            phyto(MEDIUM)%juptake_po4_100 + phyto(SMALL)%juptake_po4_100), model_time, rmask = grid_tmask(:,:,1), &
+          used = g_send_data(cobalt%id_intpbfe, cobalt%wc_vert_int_juptake_fe, model_time, rmask = grid_tmask(:,:,1), &
             is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_intpbfe,  (phyto(DIAZO)%juptake_fe_100 +  phyto(LARGE)%juptake_fe_100 +  &
-            phyto(MEDIUM)%juptake_fe_100 + phyto(SMALL)%juptake_fe_100), model_time, rmask = grid_tmask(:,:,1), &
+          used = g_send_data(cobalt%id_intpbsi, cobalt%wc_vert_int_juptake_si, model_time, rmask = grid_tmask(:,:,1), &
             is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_intpbsi,  phyto(LARGE)%juptake_sio4_100, &
+          ! Note: COBALT only models the production of calcite detritus, so values will be smaller than estimates of total
+          ! calcite production by approximately a factor of 1 over the calcite-specific export ratio.
+          used = g_send_data(cobalt%id_intpcalcite,  cobalt%wc_vert_int_jprod_cadet_calc, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_intpcalcite,  cobalt%jprod_cadet_calc_100, &
+          ! Note: COBALT only models the production of aragonite detritus, so values will be smaller than estimates of total
+          ! aragonite production by approximately a factor of 1 over the aragonite-specific export ratio.
+          used = g_send_data(cobalt%id_intparag,  cobalt%wc_vert_int_jprod_cadet_arag, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_intparag,  cobalt%jprod_cadet_arag_100, &
-            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          ! CAS: Updated on 3/9/2021 to include sediment dissolution based on variable long name, also added
-          !      aragonite flux to the sediment (which is instantaneously redissolved)
+          ! tendency_of_ocean_mole_content_of_inorganic_carbon_due_to_runoff_and_sediment_dissolution
           used = g_send_data(cobalt%id_icfriver,  cobalt%runoff_flux_dic + cobalt%fcased_redis + &
-            cobalt%fcadet_arag_btm,model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          ! CAS: Updated on 3/9/2021 to exclude calcite dissolution but include the aragonite flux to
-          !      the bottom
-          used = g_send_data(cobalt%id_fric,  cobalt%fcadet_calc_btm + cobalt%fcadet_arag_btm,  &
+            cobalt%fcadet_arag_btm + (cobalt%fntot_btm - cobalt%fn_burial)*cobalt%c_2_n, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          ! CAS: variable includes release from sediment, but there is no organic carbon release from
-          !      sediment in COBALT
+          ! tendency_of_ocean_mole_content_of_organic_carbon_due_to_runoff_and_sediment_dissolution 
           used = g_send_data(cobalt%id_ocfriver, cobalt%c_2_n* &
             (cobalt%runoff_flux_ldon+cobalt%runoff_flux_sldon+cobalt%runoff_flux_srdon), &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          ! CAS: Updated on 3/9/2021 to reflect that the total loss of organic carbon at sediments is
-          !      equal to the total flux, not just the burial
-          used = g_send_data(cobalt%id_froc,cobalt%c_2_n*cobalt%fndet_btm, &
-            model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_intpn2,  cobalt%wc_vert_int_nfix,  &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          ! CAS: Updated on 3/9/2021 to include nh4 deposition and riverine fluxes of organic nitrogen
+          ! tendency_of_ocean_mole_content_of_elemental_nitrogen_due_to_deposition_and_fixation_and_runoff
+          ! also include sediment dissolution to be consistent with other terms
           used = g_send_data(cobalt%id_fsn,  cobalt%runoff_flux_no3 + cobalt%dry_no3 + cobalt%wet_no3 + &
             cobalt%dry_nh4 + cobalt%wet_nh4 + cobalt%runoff_flux_ldon + cobalt%runoff_flux_sldon + &
-            cobalt%runoff_flux_srdon + cobalt%wc_vert_int_nfix, model_time, rmask = grid_tmask(:,:,1), &
-            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          ! JYL: Updated on 3/21/2021 to include anammox
-          used = g_send_data(cobalt%id_frn,  cobalt%fno3denit_sed + cobalt%wc_vert_int_jno3denit + &
-            cobalt%wc_vert_int_jnamx + cobalt%fn_burial, model_time, rmask = grid_tmask(:,:,1), &
-            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          ! CAS: Updated on 3/9/2021 to include ffe_iceberg
-          used = g_send_data(cobalt%id_fsfe,  cobalt%runoff_flux_fed + cobalt%dry_fed + cobalt%wet_fed + &
-            cobalt%ffe_sed+cobalt%ffe_geotherm+cobalt%ffe_iceberg, model_time, rmask = grid_tmask(:,:,1), & 
-            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          used = g_send_data(cobalt%id_frfe,  cobalt%ffedet_btm, &
+            cobalt%runoff_flux_srdon + cobalt%wc_vert_int_nfix + cobalt%fntot_btm - cobalt%fn_burial, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
+          ! Tendency_of_ocean_mole_content_of_iron_due_to_deposition_and_runoff_and_sediment_dissolution
+          ! included iceberg and geothermal sources to get the full budget 
+          used = g_send_data(cobalt%id_fsfe,  cobalt%runoff_flux_fed + cobalt%dry_fed + cobalt%wet_fed + &
+            cobalt%ffe_sed+cobalt%ffe_geotherm+cobalt%wc_vert_int_jfe_iceberg, model_time, rmask = grid_tmask(:,:,1), & 
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
 
 ! 2016/08/15 - we will not be providing these fields
 ! CHECK: rate was computed offline for TOPAZ by saving a reference history file, dividing by secs_per_month and differencing monthly averages
@@ -2112,12 +2196,6 @@ module COBALT_send_diag
 !        used = g_send_data(cobalt%id_fbddtalk,  cobalt%jalk_100,   &
 !        model_time, rmask = grid_tmask(:,:,1),&
 !        is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-
-!==============================================================================================================
-! JGJ 2016/08/08 CMIP6 OcnBgchem day: Marine Biogeochemical daily fields
-! chlos and phycos - in Omon and Oday
-!==============================================================================================================
-! 2016/08/15 JGJ: 100m integrals w/o CMOR conversion
 
           used = g_send_data(cobalt%id_jdic_100, cobalt%jdic_100, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -2058,7 +2058,7 @@ module COBALT_send_diag
           field_2d(:,:) = & 
             ( phyto(MEDIUM)%nlim_bw_100(:,:)*phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
               phyto(LARGE)%nlim_bw_100(:,:)*phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) ) / &
-            ( phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
+            max(epsln, phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
               phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) )
           used = g_send_data(cobalt%id_limndiat, field_2d, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -2071,7 +2071,7 @@ module COBALT_send_diag
           field_2d(:,:) = &
             ( phyto(MEDIUM)%nlim_bw_100(:,:)*(1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
               phyto(LARGE)%nlim_bw_100(:,:)*(1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) ) / &
-            ( (1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
+            max(epsln, (1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
               (1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) )
           used = g_send_data(cobalt%id_limnmisc, field_2d, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
@@ -2080,7 +2080,7 @@ module COBALT_send_diag
           field_2d(:,:) = &
             ( phyto(MEDIUM)%irrlim_bw_100(:,:)*phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
               phyto(LARGE)%irrlim_bw_100(:,:)*phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) ) / &
-            ( phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
+            max(epsln, phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
               phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) )
           used = g_send_data(cobalt%id_limirrdiat, field_2d, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
@@ -2092,7 +2092,7 @@ module COBALT_send_diag
           field_2d(:,:) = &
             ( phyto(MEDIUM)%irrlim_bw_100(:,:)*(1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
               phyto(LARGE)%irrlim_bw_100(:,:)*(1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) ) / &
-            ( (1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
+            max(epsln, (1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
               (1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) )
           used = g_send_data(cobalt%id_limirrmisc, field_2d, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
@@ -2101,7 +2101,7 @@ module COBALT_send_diag
           field_2d(:,:) = &
             ( phyto(MEDIUM)%def_fe_bw_100(:,:)*phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
               phyto(LARGE)%def_fe_bw_100(:,:)*phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) ) / &
-            ( phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
+            max(epsln, phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
               phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) )
           used = g_send_data(cobalt%id_limfediat, field_2d, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
@@ -2113,7 +2113,7 @@ module COBALT_send_diag
           field_2d(:,:) = &
             ( phyto(MEDIUM)%def_fe_bw_100(:,:)*(1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
               phyto(LARGE)%def_fe_bw_100(:,:)*(1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) ) / &
-            ( (1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
+            max(epsln, (1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
               (1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) )
           used = g_send_data(cobalt%id_limfemisc, field_2d,  &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
@@ -2122,7 +2122,7 @@ module COBALT_send_diag
           field_2d(:,:) = &
             ( phyto(MEDIUM)%plim_bw_100(:,:)*phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
               phyto(LARGE)%plim_bw_100(:,:)*phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) ) / &
-            ( phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
+            max(epsln, phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
               phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) )
           used = g_send_data(cobalt%id_limpdiat, field_2d, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
@@ -2134,7 +2134,7 @@ module COBALT_send_diag
           field_2d(:,:) = &
             ( phyto(MEDIUM)%plim_bw_100(:,:)*(1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
               phyto(LARGE)%plim_bw_100(:,:)*(1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) ) / &
-            ( (1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
+            max(epsln, (1.0 - phyto(MEDIUM)%silim_bw_100(:,:))*phyto(MEDIUM)%f_n_100(:,:) + &
               (1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) )
           used = g_send_data(cobalt%id_limpmisc, field_2d, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -114,6 +114,7 @@ module cobalt_types
      real, ALLOCATABLE, dimension(:,:)  ::  plim_bw_100      !<
      real, ALLOCATABLE, dimension(:,:)  ::  def_fe_bw_100    !<
      real, ALLOCATABLE, dimension(:,:)  ::  irrlim_bw_100    !<
+     real, ALLOCATABLE, dimension(:,:)  ::  silim_bw_100     !<
      real, ALLOCATABLE, dimension(:,:)  ::  fn_btm           !<
      real, ALLOCATABLE, dimension(:,:)  ::  ffe_btm          !<
      real, ALLOCATABLE, dimension(:,:)  ::  fp_btm           !<
@@ -781,7 +782,6 @@ module cobalt_types
           cased_redis_delz,&
           ffe_sed,&
           ffe_geotherm,&
-          ffe_iceberg,&
           fnso4red_sed,&
           fno3denit_sed,&
           fnoxic_sed,&
@@ -841,8 +841,6 @@ module cobalt_types
           zsatarag,&
           zsatcalc,&
           daylength,&
-!==============================================================================================================
-! JGJ 2016/08/08 CMIP6 Ocnbgc
           f_alk_int_100, &
           f_dic_int_100, &
           f_din_int_100, &
@@ -867,15 +865,26 @@ module cobalt_types
           wc_vert_int_o2,&
           wc_vert_int_alk,&
           wc_vert_int_npp, &
+          wc_vert_int_npp_diat, &
+          wc_vert_int_npp_diaz, &
+          wc_vert_int_npp_misc, &
+          wc_vert_int_npp_pico, &
+          wc_vert_int_npp_nano, &
+          wc_vert_int_npp_micro, &
           wc_vert_int_jdiss_sidet,&
           wc_vert_int_jdiss_cadet,&
           wc_vert_int_jo2resp,&
           wc_vert_int_jprod_cadet,&
+          wc_vert_int_jprod_cadet_arag,&
+          wc_vert_int_jprod_cadet_calc,& 
           wc_vert_int_jno3denit,&
           wc_vert_int_jprod_no3nitrif,&
           wc_vert_int_juptake_nh4,&
           wc_vert_int_jprod_nh4,&
           wc_vert_int_juptake_no3,&
+          wc_vert_int_juptake_po4,&
+          wc_vert_int_juptake_si,&
+          wc_vert_int_juptake_fe,&
           wc_vert_int_nfix,&
           wc_vert_int_jnamx,&
           wc_vert_int_jfe_iceberg,&
@@ -1084,7 +1093,6 @@ module cobalt_types
           id_cased_redis_delz  = -1,   &
           id_ffe_sed       = -1,       &
           id_ffe_geotherm  = -1,       &
-          id_ffe_iceberg = -1,         &
           id_fnso4red_sed= -1,       &
           id_fno3denit_sed = -1,       &
           id_fnoxic_sed    = -1,       &
@@ -1171,16 +1179,27 @@ module cobalt_types
           id_wc_vert_int_si = -1,      &
           id_wc_vert_int_o2 = -1,      &
           id_wc_vert_int_alk = -1,     &
-          id_wc_vert_int_npp = -1, &
+          id_wc_vert_int_npp = -1,     &
+          id_wc_vert_int_npp_diat = -1, &
+          id_wc_vert_int_npp_diaz = -1, &
+          id_wc_vert_int_npp_misc = -1, &
+          id_wc_vert_int_npp_pico = -1, &
+          id_wc_vert_int_npp_nano = -1, &
+          id_wc_vert_int_npp_micro = -1,&
           id_wc_vert_int_jdiss_sidet = -1, &
           id_wc_vert_int_jdiss_cadet = -1, &
           id_wc_vert_int_jo2resp = -1,     &
           id_wc_vert_int_jprod_cadet = -1, &
+          id_wc_vert_int_jprod_cadet_arag = -1, &
+          id_wc_vert_int_jprod_cadet_calc = -1, &
           id_wc_vert_int_jno3denit = -1,   &
           id_wc_vert_int_jprod_no3nitrif = -1, &
           id_wc_vert_int_juptake_nh4 = -1, &
           id_wc_vert_int_jprod_nh4 = -1, &
           id_wc_vert_int_juptake_no3 = -1, &
+          id_wc_vert_int_juptake_po4 = -1, &
+          id_wc_vert_int_juptake_si = -1, &
+          id_wc_vert_int_juptake_fe = -1, &
           id_wc_vert_int_nfix = -1,        &
           id_wc_vert_int_jfe_iceberg = -1, &
           id_wc_vert_int_jno3_iceberg = -1, &
@@ -1409,6 +1428,8 @@ module cobalt_types
           id_intppdiaz          = -1, &
           id_intpppico          = -1, &
           id_intppmisc          = -1, &
+          id_intppnano          = -1, &
+          id_intppmicro         = -1, &
           id_intpbn             = -1, &
           id_intpbp             = -1, &
           id_intpbfe            = -1, &
@@ -1422,6 +1443,13 @@ module cobalt_types
           id_epsi100            = -1, &
           id_epcalc100          = -1, &
           id_eparag100          = -1, &
+          id_exparagob          = -1, &
+          id_expcalcob          = -1, &
+          id_expcob             = -1, &
+          id_expfeob            = -1, &
+          id_expnob             = -1, &
+          id_exppob             = -1, &
+          id_expsiob            = -1, &
           id_intdic             = -1, &
           id_intdoc             = -1, &
           id_intpoc             = -1, &

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -6822,7 +6822,7 @@ contains
           enddo
           phyto(MEDIUM)%silim_bw_100(i,j) = phyto(MEDIUM)%silim_bw_100(i,j) + phyto(MEDIUM)%silim(i,j,k_100)* &
                 phyto(MEDIUM)%f_n(i,j,k_100)*drho_dzt/(phyto(MEDIUM)%f_n_100(i,j)+epsln)
-          phyto(LARGE)%silim_bw_100(i,j) = phyto(LARGE)%silim_bw_100(i,j) + phyto(n)%silim(i,j,k_100)* &
+          phyto(LARGE)%silim_bw_100(i,j) = phyto(LARGE)%silim_bw_100(i,j) + phyto(LARGE)%silim(i,j,k_100)* &
                 phyto(LARGE)%f_n(i,j,k_100)*drho_dzt/(phyto(LARGE)%f_n_100(i,j)+epsln)
         endif
     enddo; enddo  !} i, j

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1659,9 +1659,11 @@ contains
     call get_param(param_file, "generic_COBALT", "gamma_sldop", cobalt%gamma_sldop, &
                   "rate constant for converting semi-labile DOP to labile DOP at 0 deg. C", units="day-1", & 
                   default=1.0/90.0, scale =I_sperd)
-    ! background concentration of refractory DOC used for diagnostics that request and estimate of the total DOC
+    ! Background concentration of refractory DOC used for diagnostics that request and estimate of the total DOC
+    ! Changed default to 0 from 4.0e-5 because CMIP7 requested explicit pools only.  If you want to get a better
+    ! estimate of the total doc pool, a constant value of ~4.0e5 for the refractory pool could be added
     call get_param(param_file, "generic_COBALT", "doc_background", cobalt%doc_background, &
-                  "background refractory dissolved organic carbon concentration", units="moles kg-1", default=4.0e-5)
+                  "background refractory dissolved organic carbon concentration", units="moles kg-1", default=0.0)
     !
     !-----------------------------------------------------------------------
     ! Nitrification / Anammox
@@ -3656,8 +3658,7 @@ contains
             endif
           enddo
 
-          ! Calculate the chlorophyll.  Coversions give mg Chl (1000 kg)-1 ~ mg Chl m-3
-          ! Note: Better to make this c_2_n*12*cobalt%Rho_0*1000*theta*f_n?  ~3.5% difference
+          ! Calculate the chlorophyll in micrograms Chl kg-1; 12.0e6 = 12 gC molC-1 * 1e6 ugC gC-1
           phyto(n)%chl(i,j,k) = cobalt%c_2_n*12.0e6*phyto(n)%theta(i,j,k)*phyto(n)%f_n(i,j,k)
           cobalt%f_chl(i,j,k) = cobalt%f_chl(i,j,k)+phyto(n)%chl(i,j,k)
 
@@ -4917,11 +4918,12 @@ contains
 !-------------------------------------------------------------------------------------------------
 !
 
-    ! Nutrient inputs associated with icebergs/frozen runoff.  This is currently entered as a surface flux.  The
+    ! Nutrient inputs associated with icebergs/frozen runoff.  This is currently entered in the top grid cell.  The
     ! parameters "jfe_iceberg_ratio", "jno3_iceberg_ratio" and "jpo4_iceberg_ratio" are the ratios of nutrient input
     ! per kg of runoff.  For iron, values can be set within the broad ranges discussed in Laufkotter et al. (2018).
-    ! These inputs are currently entered at the ocean surface, but they have defined within a 3D array to allow
+    ! While inputs are currently entered at the ocean surface, they have defined within a 3D array to allow
     ! eventual consideration of depth-dependent inputs.
+    ! frunoff units are kg m-2 sec-1; jfe_iceberg_ratio = mol Fe kg-1 melt; rho_dzt = kg m-2
     do j = jsc, jec ; do i = isc, iec !{
        ! CAS: Is this check relevant for MOM6?
        if (grid_kmt(i,j) .gt. 0) then !{
@@ -5254,9 +5256,9 @@ contains
 !-----------------------------------------------------------------------
 !
     !
-    !-------------------------------------------------------------------
-    ! 6.1: Update the prognostics tracer fields via their pointers.
-    !-------------------------------------------------------------------
+    !---------------------------------------------------------------------------
+    ! 6.1: Get the pointers to the full tracer values before source/sink update
+    !---------------------------------------------------------------------------
     !
     call g_tracer_get_pointer(tracer_list,'alk'    ,'field',cobalt%p_alk    )
     call g_tracer_get_pointer(tracer_list,'cadet_arag','field',cobalt%p_cadet_arag)
@@ -5572,7 +5574,6 @@ contains
        cobalt%p_sio4(i,j,k,tau) = cobalt%p_sio4(i,j,k,tau) + cobalt%jsio4(i,j,k) * dt * grid_tmask(i,j,k)
     enddo; enddo ; enddo  !} i,j,k
 
-    ! 2016/06/13 JGJ: keep original Fed calculation
     do k = 1, nk ; do j = jsc, jec ; do i = isc, iec  !{
        !
        ! Fed
@@ -5629,7 +5630,6 @@ contains
        cobalt%p_sidet(i,j,k,tau) = cobalt%p_sidet(i,j,k,tau) + cobalt%jsidet(i,j,k)*dt*grid_tmask(i,j,k)
     enddo; enddo ; enddo  !} i,j,k
 
-    ! 2016/06/13 JGJ: keep original jfedet calculation
     do k = 1, nk ; do j = jsc, jec ; do i = isc, iec  !{
        !
        ! Fedet
@@ -5923,7 +5923,7 @@ contains
 
     !
     !-----------------------------------------------------------------------
-    ! 6: Source/sink diagnostic calculations
+    ! 7: Source/sink diagnostic calculations
     !-----------------------------------------------------------------------
     !
 
@@ -6054,15 +6054,27 @@ contains
        cobalt%wc_vert_int_alk(i,j) = 0.0
        ! Fluxes
        cobalt%wc_vert_int_npp(i,j) = 0.0              ! wc integrated net primary production
+       ! Include breakdowns by functional group and by size to support CMIP7/FISH-MIP 
+       cobalt%wc_vert_int_npp_diat(i,j) = 0.0         ! wc integrated net primary production, diatoms
+       cobalt%wc_vert_int_npp_diaz(i,j) = 0.0         ! wc integrated net primary production, diazotrophs
+       cobalt%wc_vert_int_npp_misc(i,j) = 0.0         ! wc integrated net primary production, misc
+       cobalt%wc_vert_int_npp_pico(i,j) = 0.0         ! wc integrated net primary production, picophytoplankton
+       cobalt%wc_vert_int_npp_nano(i,j) = 0.0         ! wc integrated net primary production, nanophytoplankton 
+       cobalt%wc_vert_int_npp_micro(i,j) = 0.0        ! wc integrated net primary production, microphytoplankton 
        cobalt%wc_vert_int_jdiss_sidet(i,j) = 0.0      ! wc integrated dissolution of silica detritus     
        cobalt%wc_vert_int_jdiss_cadet(i,j) = 0.0      ! wc integrated dissolution of calcite detritus
        cobalt%wc_vert_int_jo2resp(i,j) = 0.0          ! wc integrated oxygen consumption
        cobalt%wc_vert_int_jprod_cadet(i,j) = 0.0      ! wc integrated production of calcite detritus
+       cobalt%wc_vert_int_jprod_cadet_arag(i,j) = 0.0 ! wc integrated production of calcite detritus
+       cobalt%wc_vert_int_jprod_cadet_calc(i,j) = 0.0 ! wc integrated production of calcite detritus
        cobalt%wc_vert_int_jno3denit(i,j) = 0.0        ! wc integrated nitrate use in denitrification
        cobalt%wc_vert_int_jprod_no3nitrif(i,j) = 0.0  ! wc integrated nitrate production in nitrification
        cobalt%wc_vert_int_juptake_nh4(i,j) = 0.0      ! wc integrated nh4 uptake by phytoplankton (recycled production)
        cobalt%wc_vert_int_jprod_nh4(i,j) = 0.0        ! wc integrated production of nh4 through remineralization
        cobalt%wc_vert_int_juptake_no3(i,j) = 0.0      ! wc integrated no3 uptake by phytoplankton (new production)
+       cobalt%wc_vert_int_juptake_po4(i,j) = 0.0      ! wc integrated po4 uptake by phytoplankton
+       cobalt%wc_vert_int_juptake_si(i,j) = 0.0       ! wc integrated si uptake by phytoplankton
+       cobalt%wc_vert_int_juptake_fe(i,j) = 0.0       ! wc integrated fe uptake by phytoplankton
        cobalt%wc_vert_int_nfix(i,j) = 0.0             ! wc integrated nitrogen fixation
        cobalt%wc_vert_int_jnamx(i,j) = 0.0            ! wc integrated N lost to N2 via anammox
        cobalt%wc_vert_int_jfe_iceberg(i,j) = 0.0      ! wc integrated iron additions from icebergs
@@ -6086,6 +6098,19 @@ contains
           cobalt%wc_vert_int_npp(i,j) = cobalt%wc_vert_int_npp(i,j) + (phyto(SMALL)%jprod_n(i,j,k) + &
               phyto(MEDIUM)%jprod_n(i,j,k) + phyto(LARGE)%jprod_n(i,j,k) + phyto(DIAZO)%jprod_n(i,j,k))* &
               rho_dzt(i,j,k)*grid_tmask(i,j,k)
+          cobalt%wc_vert_int_npp_diat(i,j) = cobalt%wc_vert_int_npp_diat(i,j) + &
+              (phyto(MEDIUM)%jprod_n(i,j,k)*phyto(MEDIUM)%silim(i,j,k) + &
+               phyto(LARGE)%jprod_n(i,j,k)*phyto(LARGE)%silim(i,j,k))*rho_dzt(i,j,k)*grid_tmask(i,j,k)
+          cobalt%wc_vert_int_npp_diaz(i,j) = cobalt%wc_vert_int_npp_diaz(i,j) +  phyto(DIAZO)%jprod_n(i,j,k) * &
+               rho_dzt(i,j,k)*grid_tmask(i,j,k)
+          cobalt%wc_vert_int_npp_misc(i,j) = (phyto(MEDIUM)%jprod_n(i,j,k)*(1.0 - phyto(MEDIUM)%silim(i,j,k)) + &
+               phyto(LARGE)%jprod_n(i,j,k)*(1.0 - phyto(LARGE)%silim(i,j,k)))*rho_dzt(i,j,k)*grid_tmask(i,j,k)
+          cobalt%wc_vert_int_npp_pico(i,j) = cobalt%wc_vert_int_npp_pico(i,j) +  phyto(SMALL)%jprod_n(i,j,k) * &
+               rho_dzt(i,j,k)*grid_tmask(i,j,k)
+          cobalt%wc_vert_int_npp_nano(i,j) = cobalt%wc_vert_int_npp_nano(i,j) +  phyto(MEDIUM)%jprod_n(i,j,k) * &
+               rho_dzt(i,j,k)*grid_tmask(i,j,k)
+          cobalt%wc_vert_int_npp_micro(i,j) = cobalt%wc_vert_int_npp_micro(i,j) +  (phyto(LARGE)%jprod_n(i,j,k) + &
+               phyto(DIAZO)%jprod_n(i,j,k))*rho_dzt(i,j,k)*grid_tmask(i,j,k)
           cobalt%wc_vert_int_jdiss_sidet(i,j) = cobalt%wc_vert_int_jdiss_sidet(i,j) + &
              cobalt%jdiss_sidet(i,j,k) * rho_dzt(i,j,k) * grid_tmask(i,j,k)
           cobalt%wc_vert_int_jdiss_cadet(i,j) = cobalt%wc_vert_int_jdiss_cadet(i,j) + &
@@ -6094,6 +6119,11 @@ contains
              cobalt%jo2resp_wc(i,j,k) * rho_dzt(i,j,k) * grid_tmask(i,j,k)
           cobalt%wc_vert_int_jprod_cadet(i,j) = cobalt%wc_vert_int_jprod_cadet(i,j) + &
              (cobalt%jprod_cadet_calc(i,j,k)+cobalt%jprod_cadet_arag(i,j,k))*rho_dzt(i,j,k)*grid_tmask(i,j,k)
+          ! separate out calciate and aragonite production for CMIP7 diagnostics
+          cobalt%wc_vert_int_jprod_cadet_arag(i,j) = cobalt%wc_vert_int_jprod_cadet_arag(i,j) + &
+             cobalt%jprod_cadet_arag(i,j,k)*rho_dzt(i,j,k)*grid_tmask(i,j,k)
+          cobalt%wc_vert_int_jprod_cadet_calc(i,j) = cobalt%wc_vert_int_jprod_cadet_calc(i,j) + &
+             cobalt%jprod_cadet_calc(i,j,k)*rho_dzt(i,j,k)*grid_tmask(i,j,k)
           cobalt%wc_vert_int_jno3denit(i,j) = cobalt%wc_vert_int_jno3denit(i,j) + &
              cobalt%jno3denit_wc(i,j,k) * rho_dzt(i,j,k) * grid_tmask(i,j,k)
           cobalt%wc_vert_int_jprod_no3nitrif(i,j) = cobalt%wc_vert_int_jprod_no3nitrif(i,j) + &
@@ -6106,6 +6136,14 @@ contains
           cobalt%wc_vert_int_juptake_no3(i,j) = cobalt%wc_vert_int_juptake_no3(i,j) + &
              (phyto(SMALL)%juptake_no3(i,j,k) + phyto(MEDIUM)%juptake_no3(i,j,k) + phyto(LARGE)%juptake_no3(i,j,k) + &
               phyto(DIAZO)%juptake_no3(i,j,k))*rho_dzt(i,j,k) * grid_tmask(i,j,k)
+          cobalt%wc_vert_int_juptake_po4(i,j) = cobalt%wc_vert_int_juptake_po4(i,j) + &
+             (phyto(SMALL)%juptake_po4(i,j,k) + phyto(MEDIUM)%juptake_po4(i,j,k) + phyto(LARGE)%juptake_po4(i,j,k) + &
+              phyto(DIAZO)%juptake_po4(i,j,k))*rho_dzt(i,j,k) * grid_tmask(i,j,k)
+          cobalt%wc_vert_int_juptake_fe(i,j) = cobalt%wc_vert_int_juptake_fe(i,j) + &
+             (phyto(SMALL)%juptake_fe(i,j,k) + phyto(MEDIUM)%juptake_fe(i,j,k) + phyto(LARGE)%juptake_fe(i,j,k) + &
+              phyto(DIAZO)%juptake_fe(i,j,k))*rho_dzt(i,j,k) * grid_tmask(i,j,k)
+          cobalt%wc_vert_int_juptake_si(i,j) = cobalt%wc_vert_int_juptake_si(i,j) + &
+             (phyto(MEDIUM)%juptake_sio4(i,j,k) + phyto(LARGE)%juptake_sio4(i,j,k))*rho_dzt(i,j,k) * grid_tmask(i,j,k)
           cobalt%wc_vert_int_nfix(i,j) = cobalt%wc_vert_int_nfix(i,j) + phyto(DIAZO)%juptake_n2(i,j,k) * &
              rho_dzt(i,j,k) * grid_tmask(i,j,k)
           cobalt%wc_vert_int_jnamx(i,j)=cobalt%wc_vert_int_jnamx(i,j)+cobalt%jnamx(i,j,k)* &
@@ -6218,12 +6256,16 @@ contains
        phyto(DIAZO)%jprod_n_n2_100(i,j) = phyto(DIAZO)%juptake_n2(i,j,1) * rho_dzt(i,j,1)
        cobalt%jprod_diat_100(i,j) = (phyto(LARGE)%jprod_n(i,j,1)*phyto(LARGE)%silim(i,j,1) + &
                              phyto(MEDIUM)%jprod_n(i,j,1)*phyto(MEDIUM)%silim(i,j,1)) *rho_dzt(i,j,1)
-       ! May need to add these to update the biomass-weighted limitation terms for COBALTv3
-       !cobalt%nmd_diat_100(i,j) =
-       !cobalt%nlg_diat_100(i,j) = 
-       !cobalt%nmd_misc_100(i,j) =
-       !cobalt%nlg_misc_100(i,j) = 
        phyto(LARGE)%juptake_sio4_100(i,j) = phyto(LARGE)%juptake_sio4(i,j,1) * rho_dzt(i,j,1)
+       phyto(MEDIUM)%juptake_sio4_100(i,j) = phyto(MEDIUM)%juptake_sio4(i,j,1) * rho_dzt(i,j,1)
+
+       ! Biomass diagnostics are calculated after the tri-diagonal solver, but we need an estimate
+       ! of these now as well to calculate the biomass-weighted nutrient limitation terms for CMIP
+       phyto(DIAZO)%f_n_100(i,j) = cobalt%p_ndi(i,j,1,tau) * rho_dzt(i,j,1)
+       phyto(LARGE)%f_n_100(i,j) = cobalt%p_nlg(i,j,1,tau) * rho_dzt(i,j,1)
+       phyto(MEDIUM)%f_n_100(i,j) = cobalt%p_nmd(i,j,1,tau) * rho_dzt(i,j,1)
+       phyto(SMALL)%f_n_100(i,j) = cobalt%p_nsm(i,j,1,tau) * rho_dzt(i,j,1)
+
        do n = 1, NUM_ZOO  !{
           zoo(n)%jprod_n_100(i,j) = zoo(n)%jprod_n(i,j,1) * rho_dzt(i,j,1)
           zoo(n)%jingest_n_100(i,j) = zoo(n)%jingest_n(i,j,1) * rho_dzt(i,j,1)
@@ -6299,6 +6341,13 @@ contains
                  phyto(LARGE)%juptake_sio4(i,j,k)*rho_dzt(i,j,k)
              phyto(MEDIUM)%juptake_sio4_100(i,j) = phyto(MEDIUM)%juptake_sio4_100(i,j) + &
                  phyto(MEDIUM)%juptake_sio4(i,j,k)*rho_dzt(i,j,k)
+
+             ! Biomass diagnostics are calculated after the tri-diagonal solver, but we need an estimate
+             ! of these now as well to calculate the biomass-weighted nutrient limitation terms for CMIP
+             phyto(DIAZO)%f_n_100(i,j) = phyto(DIAZO)%f_n_100(i,j) + cobalt%p_ndi(i,j,k,tau) * rho_dzt(i,j,k)
+             phyto(LARGE)%f_n_100(i,j) = phyto(LARGE)%f_n_100(i,j) + cobalt%p_nlg(i,j,k,tau) * rho_dzt(i,j,k)
+             phyto(MEDIUM)%f_n_100(i,j) = phyto(MEDIUM)%f_n_100(i,j) + cobalt%p_nmd(i,j,k,tau) * rho_dzt(i,j,k)
+             phyto(SMALL)%f_n_100(i,j) = phyto(SMALL)%f_n_100(i,j) + cobalt%p_nsm(i,j,k,tau) * rho_dzt(i,j,k)
 
              do n = 1, NUM_ZOO !{
                 zoo(n)%jprod_n_100(i,j) = zoo(n)%jprod_n_100(i,j) + zoo(n)%jprod_n(i,j,k)* &
@@ -6381,6 +6430,13 @@ contains
            phyto(MEDIUM)%juptake_sio4_100(i,j) = phyto(MEDIUM)%juptake_sio4_100(i,j) + &
                phyto(MEDIUM)%juptake_sio4(i,j,k_100)*drho_dzt
 
+           ! Biomass diagnostics are calculated after the tri-diagonal solver, but we need an estimate
+           ! of these now as well to calculate the biomass-weighted nutrient limitation terms for CMIP
+           phyto(DIAZO)%f_n_100(i,j) = phyto(DIAZO)%f_n_100(i,j) + cobalt%p_ndi(i,j,k_100,tau) * drho_dzt
+           phyto(LARGE)%f_n_100(i,j) = phyto(LARGE)%f_n_100(i,j) + cobalt%p_nlg(i,j,k_100,tau) * drho_dzt
+           phyto(MEDIUM)%f_n_100(i,j) = phyto(MEDIUM)%f_n_100(i,j) + cobalt%p_nmd(i,j,k_100,tau) * drho_dzt
+           phyto(SMALL)%f_n_100(i,j) = phyto(SMALL)%f_n_100(i,j) + cobalt%p_nsm(i,j,k_100,tau) * drho_dzt
+
            do n = 1, NUM_ZOO !{
                zoo(n)%jprod_n_100(i,j) = zoo(n)%jprod_n_100(i,j) + zoo(n)%jprod_n(i,j,k_100)* &
                  drho_dzt
@@ -6456,6 +6512,10 @@ contains
           phyto(n)%irrlim_bw_100(i,j) = phyto(n)%irrlim(i,j,1)* &
                 phyto(n)%f_n(i,j,1)*rho_dzt(i,j,1)/(phyto(n)%f_n_100(i,j)+epsln)
        enddo   !} n
+       phyto(MEDIUM)%silim_bw_100(i,j) = phyto(MEDIUM)%silim(i,j,1)* &
+             phyto(MEDIUM)%f_n(i,j,1)*rho_dzt(i,j,1)/(phyto(MEDIUM)%f_n_100(i,j)+epsln)
+       phyto(LARGE)%silim_bw_100(i,j) = phyto(LARGE)%silim(i,j,1)* &
+             phyto(LARGE)%f_n(i,j,1)*rho_dzt(i,j,1)/(phyto(LARGE)%f_n_100(i,j)+epsln)
     enddo; enddo  !} i, j
 
     do j = jsc, jec ; do i = isc, iec ; !{
@@ -6476,6 +6536,10 @@ contains
                 phyto(n)%irrlim_bw_100(i,j) = phyto(n)%irrlim_bw_100(i,j) + phyto(n)%irrlim(i,j,k)* &
                    phyto(n)%f_n(i,j,k)*rho_dzt(i,j,k)/(phyto(n)%f_n_100(i,j)+epsln)
              enddo
+             phyto(MEDIUM)%silim_bw_100(i,j) = phyto(MEDIUM)%silim_bw_100(i,j) + phyto(MEDIUM)%silim(i,j,k)* &
+                   phyto(MEDIUM)%f_n(i,j,k)*rho_dzt(i,j,k)/(phyto(MEDIUM)%f_n_100(i,j)+epsln)
+             phyto(LARGE)%silim_bw_100(i,j) = phyto(LARGE)%silim_bw_100(i,j) + phyto(LARGE)%silim(i,j,k)* &
+                   phyto(LARGE)%f_n(i,j,k)*rho_dzt(i,j,k)/(phyto(LARGE)%f_n_100(i,j)+epsln)
           endif
        enddo  !} k
 
@@ -6493,10 +6557,14 @@ contains
              phyto(n)%irrlim_bw_100(i,j) = phyto(n)%irrlim_bw_100(i,j) + phyto(n)%irrlim(i,j,k_100)* &
                 phyto(n)%f_n(i,j,k_100)*drho_dzt/(phyto(n)%f_n_100(i,j)+epsln)
           enddo
+          phyto(MEDIUM)%silim_bw_100(i,j) = phyto(MEDIUM)%silim_bw_100(i,j) + phyto(MEDIUM)%silim(i,j,k_100)* &
+                phyto(MEDIUM)%f_n(i,j,k_100)*drho_dzt/(phyto(MEDIUM)%f_n_100(i,j)+epsln)
+          phyto(LARGE)%silim_bw_100(i,j) = phyto(LARGE)%silim_bw_100(i,j) + phyto(n)%silim(i,j,k_100)* &
+                phyto(LARGE)%f_n(i,j,k_100)*drho_dzt/(phyto(LARGE)%f_n_100(i,j)+epsln)
         endif
     enddo; enddo  !} i, j
     deallocate(rho_dzt_100)
-
+    
     do j = jsc, jec ; do i = isc, iec ; !{
       if (grid_kmt(i,j) .gt. 0) then !{
          cobalt%cased_2d(i,j) = cobalt%f_cased(i,j,1)
@@ -6592,7 +6660,6 @@ contains
     call g_tracer_get_values(tracer_list,'ldop','runoff_tracer_flux',cobalt%runoff_flux_ldop,isd,jsd)
     call g_tracer_get_values(tracer_list,'sldop','runoff_tracer_flux',cobalt%runoff_flux_sldop,isd,jsd)
     call g_tracer_get_values(tracer_list,'srdop','runoff_tracer_flux',cobalt%runoff_flux_srdop,isd,jsd)
-! JGJ: Added for CMIP6
     call g_tracer_get_values(tracer_list,'dic','stf_gas',cobalt%stf_gas_dic,isd,jsd)
     call g_tracer_get_values(tracer_list,'o2','stf_gas',cobalt%stf_gas_o2,isd,jsd)
     call g_tracer_get_values(tracer_list,'dic','deltap',cobalt%deltap_dic,isd,jsd)
@@ -7366,7 +7433,6 @@ contains
     allocate(cobalt%cased_redis_delz(isd:ied, jsd:jed))   ; cobalt%cased_redis_delz=0.0
     allocate(cobalt%ffe_sed(isd:ied, jsd:jed))            ; cobalt%ffe_sed=0.0
     allocate(cobalt%ffe_geotherm(isd:ied, jsd:jed))       ; cobalt%ffe_geotherm=0.0
-    allocate(cobalt%ffe_iceberg(isd:ied, jsd:jed))        ; cobalt%ffe_iceberg=0.0
     allocate(cobalt%fnso4red_sed(isd:ied, jsd:jed))       ; cobalt%fnso4red_sed=0.0
     allocate(cobalt%fno3denit_sed(isd:ied, jsd:jed))      ; cobalt%fno3denit_sed=0.0
     allocate(cobalt%fnoxic_sed(isd:ied, jsd:jed))         ; cobalt%fnoxic_sed=0.0
@@ -7404,17 +7470,28 @@ contains
     allocate(cobalt%wc_vert_int_si(isd:ied, jsd:jed))         ; cobalt%wc_vert_int_si=0.0
     allocate(cobalt%wc_vert_int_o2(isd:ied, jsd:jed))         ; cobalt%wc_vert_int_o2=0.0
     allocate(cobalt%wc_vert_int_alk(isd:ied, jsd:jed))        ; cobalt%wc_vert_int_alk=0.0
-    allocate(cobalt%wc_vert_int_npp(isd:ied, jsd:jed))     ; cobalt%wc_vert_int_npp=0.0
+    allocate(cobalt%wc_vert_int_npp(isd:ied, jsd:jed))        ; cobalt%wc_vert_int_npp=0.0
+    allocate(cobalt%wc_vert_int_npp_diat(isd:ied, jsd:jed))   ; cobalt%wc_vert_int_npp_diat=0.0
+    allocate(cobalt%wc_vert_int_npp_diaz(isd:ied, jsd:jed))   ; cobalt%wc_vert_int_npp_diaz=0.0
+    allocate(cobalt%wc_vert_int_npp_misc(isd:ied, jsd:jed))   ; cobalt%wc_vert_int_npp_misc=0.0
+    allocate(cobalt%wc_vert_int_npp_pico(isd:ied, jsd:jed))   ; cobalt%wc_vert_int_npp_pico=0.0
+    allocate(cobalt%wc_vert_int_npp_nano(isd:ied, jsd:jed))   ; cobalt%wc_vert_int_npp_nano=0.0
+    allocate(cobalt%wc_vert_int_npp_micro(isd:ied, jsd:jed))  ; cobalt%wc_vert_int_npp_micro=0.0
     allocate(cobalt%wc_vert_int_jdiss_sidet(isd:ied, jsd:jed))  ; cobalt%wc_vert_int_jdiss_sidet=0.0
     allocate(cobalt%wc_vert_int_jdiss_cadet(isd:ied, jsd:jed))  ; cobalt%wc_vert_int_jdiss_cadet=0.0
     allocate(cobalt%wc_vert_int_jo2resp(isd:ied, jsd:jed))      ; cobalt%wc_vert_int_jo2resp=0.0
     allocate(cobalt%wc_vert_int_jprod_cadet(isd:ied, jsd:jed))  ; cobalt%wc_vert_int_jprod_cadet=0.0
+    allocate(cobalt%wc_vert_int_jprod_cadet_arag(isd:ied, jsd:jed))  ; cobalt%wc_vert_int_jprod_cadet_arag=0.0
+    allocate(cobalt%wc_vert_int_jprod_cadet_calc(isd:ied, jsd:jed))  ; cobalt%wc_vert_int_jprod_cadet_calc=0.0
     allocate(cobalt%wc_vert_int_jno3denit(isd:ied, jsd:jed))    ; cobalt%wc_vert_int_jno3denit=0.0
     allocate(cobalt%wc_vert_int_jprod_no3nitrif(isd:ied, jsd:jed)) ; cobalt%wc_vert_int_jprod_no3nitrif=0.0
     allocate(cobalt%wc_vert_int_jnamx(isd:ied, jsd:jed)) ; cobalt%wc_vert_int_jnamx=0.0
     allocate(cobalt%wc_vert_int_juptake_nh4(isd:ied, jsd:jed))  ; cobalt%wc_vert_int_juptake_nh4=0.0
     allocate(cobalt%wc_vert_int_jprod_nh4(isd:ied, jsd:jed))  ; cobalt%wc_vert_int_jprod_nh4=0.0
     allocate(cobalt%wc_vert_int_juptake_no3(isd:ied, jsd:jed))  ; cobalt%wc_vert_int_juptake_no3=0.0
+    allocate(cobalt%wc_vert_int_juptake_po4(isd:ied, jsd:jed))  ; cobalt%wc_vert_int_juptake_po4=0.0
+    allocate(cobalt%wc_vert_int_juptake_fe(isd:ied, jsd:jed))  ; cobalt%wc_vert_int_juptake_fe=0.0
+    allocate(cobalt%wc_vert_int_juptake_si(isd:ied, jsd:jed))  ; cobalt%wc_vert_int_juptake_si=0.0
     allocate(cobalt%wc_vert_int_nfix(isd:ied, jsd:jed))         ; cobalt%wc_vert_int_nfix=0.0
     allocate(cobalt%wc_vert_int_jfe_iceberg(isd:ied, jsd:jed))  ; cobalt%wc_vert_int_jfe_iceberg=0.0
     allocate(cobalt%wc_vert_int_jno3_iceberg(isd:ied, jsd:jed))  ; cobalt%wc_vert_int_jno3_iceberg=0.0
@@ -7439,6 +7516,7 @@ contains
        allocate(phyto(n)%plim_bw_100(isd:ied,jsd:jed)) ; phyto(n)%plim_bw_100 = 0.0
        allocate(phyto(n)%irrlim_bw_100(isd:ied,jsd:jed)) ; phyto(n)%irrlim_bw_100 = 0.0
        allocate(phyto(n)%def_fe_bw_100(isd:ied,jsd:jed)) ; phyto(n)%def_fe_bw_100 = 0.0
+       allocate(phyto(n)%silim_bw_100(isd:ied,jsd:jed)) ; phyto(n)%silim_bw_100 = 0.0
        ! sinking fluxes
        allocate(phyto(n)%fn_btm(isd:ied,jsd:jed)) ; phyto(n)%fn_btm = 0.0
        allocate(phyto(n)%fp_btm(isd:ied,jsd:jed)) ; phyto(n)%fp_btm = 0.0
@@ -7648,6 +7726,7 @@ contains
        deallocate(phyto(n)%nlim_bw_100)
        deallocate(phyto(n)%plim_bw_100)
        deallocate(phyto(n)%irrlim_bw_100)
+       deallocate(phyto(n)%silim_bw_100)
        deallocate(phyto(n)%def_fe_bw_100)
     enddo
     deallocate(phyto(DIAZO)%juptake_n2)
@@ -7932,7 +8011,6 @@ contains
     deallocate(cobalt%cased_redis_delz)
     deallocate(cobalt%ffe_sed)
     deallocate(cobalt%ffe_geotherm)
-    deallocate(cobalt%ffe_iceberg)
     deallocate(cobalt%fnso4red_sed)
     deallocate(cobalt%fno3denit_sed)
     deallocate(cobalt%fnoxic_sed)
@@ -8019,16 +8097,27 @@ contains
     deallocate(cobalt%wc_vert_int_o2)
     deallocate(cobalt%wc_vert_int_alk)
     deallocate(cobalt%wc_vert_int_npp)
+    deallocate(cobalt%wc_vert_int_npp_diat)
+    deallocate(cobalt%wc_vert_int_npp_diaz)
+    deallocate(cobalt%wc_vert_int_npp_misc)
+    deallocate(cobalt%wc_vert_int_npp_pico)
+    deallocate(cobalt%wc_vert_int_npp_nano)
+    deallocate(cobalt%wc_vert_int_npp_micro)
     deallocate(cobalt%wc_vert_int_jdiss_sidet)
     deallocate(cobalt%wc_vert_int_jdiss_cadet)
     deallocate(cobalt%wc_vert_int_jo2resp)
     deallocate(cobalt%wc_vert_int_jprod_cadet)
+    deallocate(cobalt%wc_vert_int_jprod_cadet_arag)
+    deallocate(cobalt%wc_vert_int_jprod_cadet_calc)
     deallocate(cobalt%wc_vert_int_jno3denit)
     deallocate(cobalt%wc_vert_int_jprod_no3nitrif)
     deallocate(cobalt%wc_vert_int_jnamx)
     deallocate(cobalt%wc_vert_int_juptake_nh4)
     deallocate(cobalt%wc_vert_int_jprod_nh4)
     deallocate(cobalt%wc_vert_int_juptake_no3)
+    deallocate(cobalt%wc_vert_int_juptake_po4)
+    deallocate(cobalt%wc_vert_int_juptake_fe)
+    deallocate(cobalt%wc_vert_int_juptake_si)
     deallocate(cobalt%wc_vert_int_nfix)
     deallocate(cobalt%wc_vert_int_jfe_iceberg)
     deallocate(cobalt%wc_vert_int_jno3_iceberg)


### PR DESCRIPTION
This PR makes a number of additions and updates so that COBALTv3 can produce CMIP7 diagnostics.  It still needs testing - as I was having trouble getting the 1D test case to run - and it likely needs some additional commits, but I thought I would get the ball rolling 

Changes and additions include:

Added a new set of requested diagnostics for the bottom fluxes of carbon (expcob), aragonite (exparagob), calcite (expcalcob), iron (expfeob), nitrogen (expnob), phosphorus (exppob), and silicon (expsiob).

Switched production integrals from 100m to full water column values, as this seems more consistent with the request.  Variables impacted include integrated nutrient tendency terms (intparag, intpbfe, intpbn, intpbp, intpbsi, intpcalcite) and the integrated primary production terms that were broken down by functional type.

Added the newly requested phytoplankton productivity integral “intppnano”.  This diagnostic could create some confusion since the classic CMIP phytoplankton productivity diagnostics are not strictly organized by size.  I thus also added the diagnostics “intppmicro” to create one set of diagnostics falling in the Sieburth size classes (pico, nano, micro) and a second set aligning with the classic CMIP classes (pico, diaz, diat, misc).  Micro includes large and diazotrophs in this scheme, “diat” and “misc” contain a mix of medium and large depending on the degree of silicate limitation.

Made updates to a number of rather cryptically named CMIP7 diagnostics that appear to be aimed at allowing basic budgets.  The key to unravelling what is wanted with these seems to be looking at their standard name rather than their title.  The title of the variable “icfriver”, for example, is “Flux of Inorganic Carbon into Ocean Surface by Runoff”, suggesting that it should hold the river dic flux.  The standard name, however is: 

Tendency_of_ocean_mole_content_of_inorganic_carbon_due_to_runoff_and_sediment_dissolution

So, despite what the title suggests, it should include both the runoff of carbon and sources of DIC from the sediment.

Similarly challenging interpretations exist for other budget terms (frfe, fric, frn, froc, fsfe, fsn, icfriver,  ocfriver.  I have done my best to get these updated for COBALTv3.  I will confirm that one can make a closed budget with these terms over time.

This PR also includes some clean up of stray comments and commented out bits of code.  There is still work to be done on this front.