### PR TITLE
Nitrate constraint on anaerobic remineralization of DOM by bacteria to avoid negative nitrate values

### DIFF
--- a/generic_tracers/cobalt_reg_diag.F90
+++ b/generic_tracers/cobalt_reg_diag.F90
@@ -1508,6 +1508,10 @@ module COBALT_reg_diag
     bact(1)%id_temp_lim = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
+    vardesc_temp = vardesc("no3lim_Bact","Nitrate limitation of bacteria",'h','L','s','dimensionless','f')
+    bact(1)%id_no3lim = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
     !
     ! Register general COBALT diagnostics
     !

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -1445,6 +1445,8 @@ module COBALT_send_diag
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(bact(1)%id_temp_lim, bact(1)%temp_lim, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+	  used = g_send_data(bact(1)%id_no3lim, bact(1)%no3lim, &
+       	    model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
 
           !
           ! Send zooplankton ingestion, production and limitation diagnostic data

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -384,6 +384,7 @@ module cobalt_types
     real, ALLOCATABLE, dimension(:,:,:) ::      ldonlim          !< limitation due to organic substrate
     real, ALLOCATABLE, dimension(:,:,:) ::      o2lim            !< limitation due to oxygen
     real, ALLOCATABLE, dimension(:,:,:) ::      temp_lim         !< Temperature limitation
+    real, ALLOCATABLE, dimension(:,:,:) ::      no3lim           !< limitation due to nitrate
     integer ::  id_jzloss_n         = -1  !< ID associated with diagnostics for losses of n due to consumption by zooplankton
     integer ::  id_jzloss_p         = -1  !< ID associated with diagnostics for losses of p due to consumption by zooplankton
     integer ::  id_jhploss_n        = -1  !< ID associated with diagnostics for losses of n due to consumption by unresolved higher preds
@@ -398,6 +399,7 @@ module cobalt_types
     integer ::  id_temp_lim         = -1  !< ID associated with diagnostics for temperature limitation
     integer ::  id_o2lim            = -1  !< ID associated with diagnostics for limitation due to oxygen
     integer ::  id_ldonlim          = -1  !< ID associated with diagnostics for limitation due to organic substrate
+    integer ::  id_no3lim           = -1  !< ID associated with diagnostics for limitation due to nitrate
     integer ::  id_jprod_n_100      = -1  !< ID associated with diagnostics for bacteria nitrogen prod. integral in upper 100m
     integer ::  id_jzloss_n_100     = -1  !< ID associated with diagnostics for bacteria nitrogen loss to zooplankton integral in upper 100m
     integer ::  id_jvirloss_n_100   = -1  !< ID associated with diagnostics for bacteria nitrogen loss to viruses integral in upper 100m

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -4017,8 +4017,15 @@ contains
        ! anaerobic remineralization.
        bact(1)%o2lim(i,j,k) = max(cobalt%f_o2(i,j,k),cobalt%o2_min)/  &
                               (cobalt%k_o2 + max(cobalt%f_o2(i,j,k),cobalt%o2_min))
+       ! Note that nitrate availability affects the anaerobic remineralization of dissolved organic material 
+       ! as that of particulate organic material
+       if (cobalt%f_o2(i,j,k) .gt. cobalt%o2_min) then !{
+          bact(1)%no3lim(i,j,k) = 1.0
+       else
+          bact(1)%no3lim(i,j,k) = max(0.0, cobalt%f_no3(i,j,k)/(cobalt%k_no3_denit + cobalt%f_no3(i,j,k)))
+       endif
        bact(1)%juptake_ldon(i,j,k) = vmax_bact*bact(1)%temp_lim(i,j,k)*bact(1)%ldonlim(i,j,k)* &
-               bact(1)%o2lim(i,j,k)*bact(1)%f_n(i,j,k)
+               bact(1)%o2lim(i,j,k)*bact(1)%no3lim(i,j,k)*bact(1)%f_n(i,j,k)
        bact_uptake_ratio = ( cobalt%f_ldop(i,j,k)/max(cobalt%f_ldon(i,j,k),epsln) )
        bact(1)%juptake_ldop(i,j,k) = bact(1)%juptake_ldon(i,j,k)*bact_uptake_ratio
        ! calculate bacteria production if N-limited, adjust down if P-limited
@@ -7378,6 +7385,7 @@ contains
     allocate(bact(1)%o2lim(isd:ied,jsd:jed,nk))            ; bact(1)%o2lim           = 0.0
     allocate(bact(1)%ldonlim(isd:ied,jsd:jed,nk))          ; bact(1)%ldonlim         = 0.0
     allocate(bact(1)%temp_lim(isd:ied,jsd:jed,nk))         ; bact(1)%temp_lim        = 0.0
+    allocate(bact(1)%no3lim(isd:ied,jsd:jed,nk))           ; bact(1)%no3lim          = 0.0
     !
     ! CAS: allocate and initialize array elements for all zooplankton groups
     !
@@ -7966,6 +7974,7 @@ contains
     deallocate(bact(1)%o2lim)
     deallocate(bact(1)%ldonlim)
     deallocate(bact(1)%temp_lim)
+    deallocate(bact(1)%no3lim)
 
     ! zooplankton
     do n = 1, NUM_ZOO


### PR DESCRIPTION
This PR is to add nitrate constraint on anaerobic remineralization of dissolved organic material by bacteria, similar to on that of particulate organic material, to avoid nitrate consumption in low-oxygen conditions when nitrate concentrations is reduced to zero (especially when anammox is switched on and fixed nitrogen loss is enlarged). 