### PR TITLE
Correction for enhanced CaCO3 dissolution 

### DIFF
--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -4933,9 +4933,11 @@ contains
     if (cobalt%do_resp_ca_diss) then
         do k=1,nk ; do j=jsc,jec ; do i=isc,iec  !{
            cobalt%jdiss_cadet_arag(i,j,k) = cobalt%jdiss_cadet_arag(i,j,k) + &
-                                            cobalt%resp_ca_2_n_arag * cobalt%jremin_ndet(i,j,k)
+                                            cobalt%resp_ca_2_n_arag * cobalt%f_cadet_arag(i,j,k) * &
+                                            cobalt%jremin_ndet(i,j,k)
            cobalt%jdiss_cadet_calc(i,j,k) = cobalt%jdiss_cadet_calc(i,j,k) + &
-                                            cobalt%resp_ca_2_n_calc * cobalt%jremin_ndet(i,j,k)
+                                            cobalt%resp_ca_2_n_calc * cobalt%f_cadet_calc(i,j,k) * &
+                                            cobalt%jremin_ndet(i,j,k)
         enddo; enddo; enddo  !} i,j,k
     endif     
     ! >> 


### PR DESCRIPTION
This update modifies the section of code that executes when do_resp_ca_diss is enabled, which applies enhanced CaCO₃ dissolution associated with organic matter remineralization. The change introduces a constraint using the local concentration of aragonite (f_cadet_arag) and calcite (f_cadet_calc), ensuring that the enhanced dissolution is physically limited by the availability of particulate CaCO₃.

Without this constraint, the remineralization-driven dissolution can become unrealistically large in regions with strong organic matter remin, even when particulate CaCO₃ is low — in some cases leading to negative concentrations of aragonite or calcite.

A figure illustrating the impact of this correction is included. The results look similar to previous simulations but now avoid unphysical negative values.

<img width="1247" alt="correct_enhanced_diss" src="https://github.com/user-attachments/assets/9295847d-4081-457a-9c8b-1409831ee791" />

 