### PR TITLE
Enhance logic for no3lim

### DIFF
--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -4019,7 +4019,7 @@ contains
                               (cobalt%k_o2 + max(cobalt%f_o2(i,j,k),cobalt%o2_min))
        ! Note that nitrate availability affects the anaerobic remineralization of dissolved organic material 
        ! as that of particulate organic material
-       if (cobalt%f_o2(i,j,k) .gt. cobalt%o2_min) then !{
+       if (cobalt%f_o2(i,j,k) .gt. cobalt%o2_min .or. cobalt%gamma_nh4amx .eq. 0.0) then !{
           bact(1)%no3lim(i,j,k) = 1.0
        else
           bact(1)%no3lim(i,j,k) = max(0.0, cobalt%f_no3(i,j,k)/(cobalt%k_no3_denit + cobalt%f_no3(i,j,k)))


### PR DESCRIPTION
PR #148 adds a nitrate constraint to prevent nitrate consumption under low-oxygen conditions. This new logic introduces a slight change to our NWA and NEP baselines.

@charliestock, as I recall, we didn’t see negative nitrate concentrations when anammox was off (`cobalt%gamma_nh4amx` == 0), correct? This PR simply enhances the logic for the `no3lim` term, making it active only when anammox is on and under low-oxygen conditions. By doing this, we can preserve the baseline for our CEFI regional applications.