### PR TITLE
Correction for coefficient unit 

### DIFF
--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1489,10 +1489,10 @@ contains
     ! << Respiration-driven CaCO3 dissolution ratios from param file
     call get_param(param_file, "generic_COBALT", "resp_ca_2_n_arag", cobalt%resp_ca_2_n_arag, &
                    "ratio of aragonite dissolution to organic matter remineralization (respiration-driven)", &
-                   units="mol dissolved arag mol org. C-1", default = 0.0, scale = c2n)
+                   units="kg (mol N)-1", default = 0.0, scale = c2n)
     call get_param(param_file, "generic_COBALT", "resp_ca_2_n_calc", cobalt%resp_ca_2_n_calc, &
                    "ratio of calcite dissolution to organic matter remineralization (respiration-driven)", &
-                   units="mol dissolved calc mol org. C-1", default = 0.0, scale = c2n)
+                   units="kg (mol N)-1", default = 0.0, scale = c2n)
     ! >>          
 
     ! Organic matter remineralization: Oxygen and temperature dependence follows Laufkotter et al. (2017).

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -4933,9 +4933,11 @@ contains
     if (cobalt%do_resp_ca_diss) then
         do k=1,nk ; do j=jsc,jec ; do i=isc,iec  !{
            cobalt%jdiss_cadet_arag(i,j,k) = cobalt%jdiss_cadet_arag(i,j,k) + &
-                                            cobalt%resp_ca_2_n_arag * cobalt%jremin_ndet(i,j,k)
+                                            cobalt%resp_ca_2_n_arag * cobalt%f_cadet_arag(i,j,k) * &
+                                            cobalt%jremin_ndet(i,j,k)
            cobalt%jdiss_cadet_calc(i,j,k) = cobalt%jdiss_cadet_calc(i,j,k) + &
-                                            cobalt%resp_ca_2_n_calc * cobalt%jremin_ndet(i,j,k)
+                                            cobalt%resp_ca_2_n_calc * cobalt%f_cadet_calc(i,j,k) * &
+                                            cobalt%jremin_ndet(i,j,k)
         enddo; enddo; enddo  !} i,j,k
     endif     
     ! >> 


### PR DESCRIPTION
This PR updates the units of the coefficients resp_ca_2_n_calc and resp_ca_2_n_arag following changes to the enhanced CaCO₃ dissolution calculation implemented in [PR#149](https://github.com/NOAA-CEFI-Regional-Ocean-Modeling/ocean_BGC/pull/149).

No other modifications were made. This update only involves adjusting the units of these coefficients to ensure consistency with the revised formulation.