### PR TITLE
Add functionality to set the fraction of HP detritus that is fast-sinking

### DIFF
--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -558,7 +558,7 @@ module cobalt_types
           hp_ipa_lgz,       & ! "  "  "  "  "  "  "  "  "   large zooplankton to hp
           hp_ipa_det,       & ! "  "  "  "  "  "  "  "  "   detritus to hp
           hp_phi_det,       & ! fraction of ingested N to detritus
-		  frac_fastsinking    ! fraction of higher predator detritus that is fast-sinking
+          frac_fastsinking    ! fraction of higher predator detritus that is fast-sinking
 
      real, dimension(3)                    :: total_atm_co2
 

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -557,7 +557,8 @@ module cobalt_types
           hp_ipa_mdz,       & ! "  "  "  "  "  "  "  "  "   medium zooplankton to hp
           hp_ipa_lgz,       & ! "  "  "  "  "  "  "  "  "   large zooplankton to hp
           hp_ipa_det,       & ! "  "  "  "  "  "  "  "  "   detritus to hp
-          hp_phi_det          ! fraction of ingested N to detritus
+          hp_phi_det,       & ! fraction of ingested N to detritus
+		  frac_fastsinking    ! fraction of higher predator detritus that is fast-sinking
 
      real, dimension(3)                    :: total_atm_co2
 

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1439,6 +1439,9 @@ contains
     call get_param(param_file, "generic_COBALT", "hp_phi_det", cobalt%hp_phi_det, &
                    "fraction of ingestion by higher predators to detritus", units="none", default=0.35)
 
+    call get_param(param_file, "generic_COBALT", "frac_fastsinking", cobalt%frac_fastsinking, &
+            "Fraction of N and P detritus higher predators that is fast-sinking", default=1.0)
+
     ! Radiocarbon
     call get_param(param_file, "generic_COBALT", "half_life_14c", cobalt%half_life_14c, "half_life_14c", units="s", default= 5730.0 )                  ! s
     call get_param(param_file, "generic_COBALT", "lambda_14c",    cobalt%lambda_14c,    "lambda_14c",    units="-s", &
@@ -4624,9 +4627,16 @@ contains
 
        ! Production of detritus and dissolved organic material from higher predator egestion
        if (cobalt%do_fastsinking) then
-          ! Assume all the egestion from higher predators will sink quickly and go to fast-sinking detritus
-          cobalt%jprod_ndet_fast(i,j,k) = cobalt%jprod_ndet_fast(i,j,k) + cobalt%hp_phi_det*cobalt%hp_jingest_n(i,j,k)
-          cobalt%jprod_pdet_fast(i,j,k) = cobalt%jprod_pdet_fast(i,j,k) + cobalt%hp_phi_det*cobalt%hp_jingest_p(i,j,k)
+          ! A portion of the egestion (determined by frac_fastsinking) from higher predators will sink quickly and go to fast-sinking detritus
+          cobalt%jprod_ndet_fast(i,j,k) = cobalt%jprod_ndet_fast(i,j,k) + &
+		                                  cobalt%frac_fastsinking*cobalt%hp_phi_det*cobalt%hp_jingest_n(i,j,k)
+          cobalt%jprod_pdet_fast(i,j,k) = cobalt%jprod_pdet_fast(i,j,k) + &
+		                                  cobalt%frac_fastsinking*cobalt%hp_phi_det*cobalt%hp_jingest_p(i,j,k)
+
+          cobalt%jprod_ndet(i,j,k) = cobalt%jprod_ndet(i,j,k) + &
+		                             (1.0-cobalt%frac_fastsinking)*cobalt%hp_phi_det*cobalt%hp_jingest_n(i,j,k)
+          cobalt%jprod_pdet(i,j,k) = cobalt%jprod_pdet(i,j,k) + &
+		                             (1.0-cobalt%frac_fastsinking)*cobalt%hp_phi_det*cobalt%hp_jingest_p(i,j,k)
        else
           ! Just add the HP ndet to the cumulative total. Calculate from phi_det and hp_jingest.
           cobalt%jprod_ndet(i,j,k) = cobalt%jprod_ndet(i,j,k) + cobalt%hp_phi_det*cobalt%hp_jingest_n(i,j,k)

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1440,7 +1440,7 @@ contains
                    "fraction of ingestion by higher predators to detritus", units="none", default=0.35)
 
     call get_param(param_file, "generic_COBALT", "frac_fastsinking", cobalt%frac_fastsinking, &
-            "Fraction of N and P detritus higher predators that is fast-sinking", default=1.0)
+                   "Fraction of N and P detritus higher predators that is fast-sinking", units="none", default=1.0)
 
     ! Radiocarbon
     call get_param(param_file, "generic_COBALT", "half_life_14c", cobalt%half_life_14c, "half_life_14c", units="s", default= 5730.0 )                  ! s

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -4629,14 +4629,14 @@ contains
        if (cobalt%do_fastsinking) then
           ! A portion of the egestion (determined by frac_fastsinking) from higher predators will sink quickly and go to fast-sinking detritus
           cobalt%jprod_ndet_fast(i,j,k) = cobalt%jprod_ndet_fast(i,j,k) + &
-		                                  cobalt%frac_fastsinking*cobalt%hp_phi_det*cobalt%hp_jingest_n(i,j,k)
+	                                  cobalt%frac_fastsinking*cobalt%hp_phi_det*cobalt%hp_jingest_n(i,j,k)
           cobalt%jprod_pdet_fast(i,j,k) = cobalt%jprod_pdet_fast(i,j,k) + &
-		                                  cobalt%frac_fastsinking*cobalt%hp_phi_det*cobalt%hp_jingest_p(i,j,k)
+	                                  cobalt%frac_fastsinking*cobalt%hp_phi_det*cobalt%hp_jingest_p(i,j,k)
 
           cobalt%jprod_ndet(i,j,k) = cobalt%jprod_ndet(i,j,k) + &
-		                             (1.0-cobalt%frac_fastsinking)*cobalt%hp_phi_det*cobalt%hp_jingest_n(i,j,k)
+                                     (1.0-cobalt%frac_fastsinking)*cobalt%hp_phi_det*cobalt%hp_jingest_n(i,j,k)
           cobalt%jprod_pdet(i,j,k) = cobalt%jprod_pdet(i,j,k) + &
-		                             (1.0-cobalt%frac_fastsinking)*cobalt%hp_phi_det*cobalt%hp_jingest_p(i,j,k)
+                                     (1.0-cobalt%frac_fastsinking)*cobalt%hp_phi_det*cobalt%hp_jingest_p(i,j,k)
        else
           ! Just add the HP ndet to the cumulative total. Calculate from phi_det and hp_jingest.
           cobalt%jprod_ndet(i,j,k) = cobalt%jprod_ndet(i,j,k) + cobalt%hp_phi_det*cobalt%hp_jingest_n(i,j,k)


### PR DESCRIPTION
As titled. This pull request adds namelist functionality that can modulate the fraction of higher predator detritus that goes to the fast sinking detritus pool vs. the bulk detritus pool. The default value is 1.0 and thus, shouldn't change answers.