### PR TITLE
Remove diagnoseMLDbyEnergy option

### DIFF
--- a/generic_tracers/MOM_generic_tracer.F90
+++ b/generic_tracers/MOM_generic_tracer.F90
@@ -774,8 +774,9 @@ subroutine MOM_generic_tracer_column_physics(h_old, h_new, ea, eb, fluxes, Hml, 
       call diagnoseMLDbyDensityDifference(-1, h_old, tv, CS%mld_pha_drho, G, GV, US, CS%diag, &
               CS%mld_pha_href, id_ref_z=-1, id_ref_rho=-1, MLD_out=mld_pha)
     elseif (CS%mld_pha_use_delta_eng) then
-      call diagnoseMLDbyEnergy((/-1, -1, -1/), h_old, tv, G, GV, US, (/CS%mld_pha_deng, &
-              CS%mld_pha_deng, CS%mld_pha_deng/), CS%diag, MLD_out=mld_pha)
+      !call diagnoseMLDbyEnergy((/-1, -1, -1/), h_old, tv, G, GV, US, (/CS%mld_pha_deng, &
+      !        CS%mld_pha_deng, CS%mld_pha_deng/), CS%diag, MLD_out=mld_pha)
+      call MOM_error(FATAL, "Photoacclimation MLD using delta energy MLD not supported") 
     endif
   endif
 

--- a/generic_tracers/MOM_generic_tracer.F90
+++ b/generic_tracers/MOM_generic_tracer.F90
@@ -460,6 +460,7 @@ subroutine initialize_MOM_generic_tracer(restart, day, G, GV, US, h, tv, param_f
                    "The density difference for a density difference based photoacclimation MLD [kg m-3].", &
                     units='kg/m3', default=0.03, scale=US%kg_m3_to_R, do_not_log=.not.CS%mld_pha_use_delta_rho)
     elseif (CS%mld_pha_use_delta_eng) then
+      call MOM_error(FATAL, "Photoacclimation MLD using delta energy MLD not supported") 
       call get_param(param_file, "MOM", "PHA_MLD_DENG", CS%mld_pha_deng, &
                    "The energy for an energy difference based photoacclimation MLD.", default=25.0, &
                    units='J/m2',scale=US%W_m2_to_RZ3_T3*US%s_to_T, do_not_log=.not.CS%mld_pha_use_delta_eng)


### PR DESCRIPTION
A recent PR to MOM6 [PR 922](https://github.com/NOAA-GFDL/MOM6/pull/922) added a new non-optional argument to `diagnoseMLDbyEnergy`.  This created a problem where `diagnoseMLDbyEnergy` is called in `MOM_generic_tracers.F90`.

We could add this new argument, however that would make ocean_bgc crash with older versions of MOM6. We could require users have an updated version of MOM6, but since the option to use a energy based MLD for the photoacclimation depth was primarily done for completeness, and I think no one is using that option, I suggest we remove it. I have added a fatal error if the option is selected. 

Since these subroutines are within MOM6 and not tested with `MOM_generic_tracer` it seems like a good idea to remove this unneeded dependency. 
