### PR TITLE
Improvements on the generation of silica detritus

### DIFF
--- a/generic_tracers/cobalt_reg_diag.F90
+++ b/generic_tracers/cobalt_reg_diag.F90
@@ -715,25 +715,27 @@ module COBALT_reg_diag
                            'h','L','s','mol Fe kg-1 s-1','f')
     phyto(SMALL)%id_jmortloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
-    vardesc_temp = vardesc("jmortloss_sio2_Di","Diazotroph silica loss to mortality",&
+    !
+    ! Register diagnostics for phytoplankton silica dissolution from respiration and mortality
+    !
+    vardesc_temp = vardesc("jdissloss_si_Di","Diazotroph silica dissolution from respiration and mortality",&
                            'h','L','s','mol Si kg-1 s-1','f')
-    phyto(DIAZO)%id_jmortloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+    phyto(DIAZO)%id_jdissloss_si = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jmortloss_sio2_Lg","Large phyto silica loss to mortality",&
+    vardesc_temp = vardesc("jdissloss_si_Lg","Large phyto silica dissolution from respiration and mortality",&
                            'h','L','s','mol Si kg-1 s-1','f')
-    phyto(LARGE)%id_jmortloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+    phyto(LARGE)%id_jdissloss_si = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jmortloss_sio2_Md","Medium phyto silica loss to mortality",&
+    vardesc_temp = vardesc("jdissloss_si_Md","Medium phyto silica dissolution from respiration and mortality",&
                            'h','L','s','mol Si kg-1 s-1','f')
-    phyto(MEDIUM)%id_jmortloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+    phyto(MEDIUM)%id_jdissloss_si = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jmortloss_sio2_Sm","Small phyto silica loss to mortality",&
+    vardesc_temp = vardesc("jdissloss_si_Sm","Small phyto silica dissolution from respiration and mortality",&
                            'h','L','s','mol Si kg-1 s-1','f')
-    phyto(SMALL)%id_jmortloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+    phyto(SMALL)%id_jdissloss_si = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
     !
     ! Register diagnostics for phytoplankton exudation
@@ -798,20 +800,6 @@ module COBALT_reg_diag
     phyto(SMALL)%id_jexuloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jexuloss_sio2_Lg","Large phyto silica loss via exudation",&
-                           'h','L','s','mol Si kg-1 s-1','f')
-    phyto(LARGE)%id_jexuloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
-    vardesc_temp = vardesc("jexuloss_sio2_Md","Medium phyto silica loss via exudation",&
-                           'h','L','s','mol Si kg-1 s-1','f')
-    phyto(MEDIUM)%id_jexuloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-
-    vardesc_temp = vardesc("jexuloss_sio2_Sm","Small phyto silica loss via exudation",&
-                           'h','L','s','mol Si kg-1 s-1','f')
-    phyto(SMALL)%id_jexuloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
-         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
     !
     ! Phytoplankton losses to higher predators (0 by default)
     !

--- a/generic_tracers/cobalt_reg_diag.F90
+++ b/generic_tracers/cobalt_reg_diag.F90
@@ -798,6 +798,20 @@ module COBALT_reg_diag
     phyto(SMALL)%id_jexuloss_fe = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
+    vardesc_temp = vardesc("jexuloss_sio2_Lg","Large phyto silica loss via exudation",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(LARGE)%id_jexuloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jexuloss_sio2_Md","Medium phyto silica loss via exudation",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(MEDIUM)%id_jexuloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jexuloss_sio2_Sm","Small phyto silica loss via exudation",&
+                           'h','L','s','mol Si kg-1 s-1','f')
+    phyto(SMALL)%id_jexuloss_sio2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
     !
     ! Phytoplankton losses to higher predators (0 by default)
     !

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -1396,9 +1396,7 @@ module COBALT_send_diag
               model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
             used = g_send_data(phyto(n)%id_jvirloss_sio2, phyto(n)%jvirloss_sio2, &
               model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_jmortloss_sio2, phyto(n)%jmortloss_sio2, &
-              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-            used = g_send_data(phyto(n)%id_jexuloss_sio2, phyto(n)%jexuloss_sio2, &
+            used = g_send_data(phyto(n)%id_jdissloss_si, phyto(n)%jdissloss_si, &
               model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
             used = g_send_data(phyto(n)%id_jhploss_sio2, phyto(n)%jhploss_sio2, &
               model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -1398,6 +1398,8 @@ module COBALT_send_diag
               model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
             used = g_send_data(phyto(n)%id_jmortloss_sio2, phyto(n)%jmortloss_sio2, &
               model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+            used = g_send_data(phyto(n)%id_jexuloss_sio2, phyto(n)%jexuloss_sio2, &
+              model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
             used = g_send_data(phyto(n)%id_jhploss_sio2, phyto(n)%jhploss_sio2, &
               model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
             ! Uptake

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -201,11 +201,10 @@ module cobalt_types
      integer ::  id_jmortloss_fe  = -1
      integer ::  id_jmortloss_n   = -1
      integer ::  id_jmortloss_p   = -1
-     integer ::  id_jmortloss_sio2= -1
+     integer ::  id_jdissloss_si = -1
      integer ::  id_jexuloss_n   = -1
      integer ::  id_jexuloss_p   = -1
      integer ::  id_jexuloss_fe  = -1
-	 integer ::  id_jexuloss_sio2 = -1
      integer ::  id_jhploss_fe   = -1
      integer ::  id_jhploss_n    = -1
      integer ::  id_jhploss_p    = -1

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -98,6 +98,7 @@ module cobalt_types
      real ::  vir               !< Viral lysis loss coefficient (s-1 (mole N kg)-1)
      real ::  mort              !< mortality loss coefficient (s-1)
      real ::  exu               !< Maximum ingestion rate (dimensionless (fraction of NPP))
+     real ::  phi_sidiss_mort   !< Fraction of phytoplankton silica converted to dissolved silicate due to mortality or exudation
      real ::  tmp_pcmlim_aclm_ML !< Variable for storing depth average nutrient*temperature limitation in mixed layer
      real, ALLOCATABLE, dimension(:,:)  ::  jprod_n_100      !<
      real, ALLOCATABLE, dimension(:,:)  ::  jprod_n_new_100  !<
@@ -149,6 +150,7 @@ module cobalt_types
      real, ALLOCATABLE, dimension(:,:,:)  ::  jexuloss_fe    !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  jexuloss_n     !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  jexuloss_p     !<
+     real, ALLOCATABLE, dimension(:,:,:)  ::  jexuloss_sio2  !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  jhploss_fe     !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  jhploss_n      !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  jhploss_p      !<
@@ -204,6 +206,7 @@ module cobalt_types
      integer ::  id_jexuloss_n   = -1
      integer ::  id_jexuloss_p   = -1
      integer ::  id_jexuloss_fe  = -1
+	 integer ::  id_jexuloss_sio2 = -1
      integer ::  id_jhploss_fe   = -1
      integer ::  id_jhploss_n    = -1
      integer ::  id_jhploss_p    = -1
@@ -276,6 +279,7 @@ module cobalt_types
     real phi_ldop          !< fraction of ingested N/P to labile dop
     real phi_sldop         !< fraction of ingested N/P to semi-labile dop
     real phi_srdop         !< fraction of ingested N/P to semi-refractory dop
+    real phi_det_si        !< fraction of ingested Si to sidet
     real q_p_2_n           !< p:n ratio of zooplankton
     real ipa_smp           !< innate prey availability of low-light adapt. small phytos
     real ipa_mdp           !< innate prey availability of medium phytoplankton

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -146,11 +146,10 @@ module cobalt_types
      real, ALLOCATABLE, dimension(:,:,:)  ::  jmortloss_fe   !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  jmortloss_n    !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  jmortloss_p    !<
-     real, ALLOCATABLE, dimension(:,:,:)  ::  jmortloss_sio2 !<
+     real, ALLOCATABLE, dimension(:,:,:)  ::  jdissloss_si   !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  jexuloss_fe    !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  jexuloss_n     !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  jexuloss_p     !<
-     real, ALLOCATABLE, dimension(:,:,:)  ::  jexuloss_sio2  !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  jhploss_fe     !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  jhploss_n      !<
      real, ALLOCATABLE, dimension(:,:,:)  ::  jhploss_p      !<

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -4652,7 +4652,7 @@ contains
            cobalt%jprod_ndet(i,j,k) = cobalt%jprod_ndet(i,j,k) + phyto(m)%jaggloss_n(i,j,k)
            cobalt%jprod_pdet(i,j,k) = cobalt%jprod_pdet(i,j,k) + phyto(m)%jaggloss_p(i,j,k)
            cobalt%jprod_fedet(i,j,k) = cobalt%jprod_fedet(i,j,k) + phyto(m)%jaggloss_fe(i,j,k)
-           cobalt%jprod_sidet(i,j,k) = cobalt%jprod_sidet(i,j,k) + phyto(m)%jaggloss_sio2(i,j,k)
+           cobalt%jprod_sidet(i,j,k) = cobalt%jprod_sidet(i,j,k) + phyto(m)%jaggloss_sio2(i,j,k) + phyto(m)%jmortloss_sio2(i,j,k)
        enddo !} m
 
        ! Dissolved organic and inorganic production from viral lysis, exudation, and phytoplankton mortality
@@ -4673,8 +4673,7 @@ contains
                    (phyto(m)%jvirloss_p(i,j,k) + phyto(m)%jmortloss_p(i,j,k))
            cobalt%jprod_fed(i,j,k) = cobalt%jprod_fed(i,j,k)   + phyto(m)%jvirloss_fe(i,j,k) + &
                                        phyto(m)%jmortloss_fe(i,j,k) + phyto(m)%jexuloss_fe(i,j,k)
-           cobalt%jprod_sio4(i,j,k) = cobalt%jprod_sio4(i,j,k) + phyto(m)%jvirloss_sio2(i,j,k) + &
-                                      phyto(m)%jmortloss_sio2(i,j,k)
+           cobalt%jprod_sio4(i,j,k) = cobalt%jprod_sio4(i,j,k) + phyto(m)%jvirloss_sio2(i,j,k)
        enddo !} m
 
        ! Sources of dissolved organic material from viral lysis due to bacteria

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1042,10 +1042,10 @@ contains
                    units="day-1", default=0.0, scale=I_sperd)
     ! Diatom silica exudation or loss due to mortality and basal respiration
     call get_param(param_file, "generic_COBALT", "phi_sidiss_mort_Md", phyto(MEDIUM)%phi_sidiss_mort, &
-                   "fraction of medium diatom silica exuded or lost as silicate", &
+                   "fraction of medium diatom silica dissolved during respiration and mortality", &
                    units="none", default=0.0)
     call get_param(param_file, "generic_COBALT", "phi_sidiss_mort_Lg", phyto(LARGE)%phi_sidiss_mort, &
-                   "fraction of larger diatom silica exuded or lost as silicate", &
+                   "fraction of larger diatom silica dissolved during respiration and mortality", &
                    units="none", default=0.0)
     !
     ! Phytoplankton loss of organic carbon to exudation is assumed to be a constant fraction of NPP following Baines
@@ -1367,7 +1367,7 @@ contains
     call get_param(param_file, "generic_COBALT", "phi_sldop_lgz", zoo(3)%phi_sldop, &
                    "fraction of P ingestion by large zooplankton to semi-labile dissolved organic phosphorus", &
                    units="none", default=0.3*(0.30-zoo(3)%phi_det))
-    ! Partitioning of silica detritus production from zooplankton is by default slightly higher than organic matter detritus
+    ! Partitioning of silica detritus production from zooplankton is by default the same as organic matter detritus
     call get_param(param_file, "generic_COBALT", "phi_det_si_smz", zoo(1)%phi_det_si, &
                    "fraction of silica ingestion by small zooplankton to si detritus", units="none", default=0.0)
     call get_param(param_file, "generic_COBALT", "phi_det_si_mdz", zoo(2)%phi_det_si, &
@@ -4526,7 +4526,8 @@ contains
             phyto(n)%jmortloss_fe(i,j,k) = phyto(n)%jmortloss_n(i,j,k)*phyto(n)%q_fe_2_n(i,j,k)
             ! silica dissolution from phytoplankton mortality is also multiplied by a scaling factor that 
             ! determines the amount of silica test left over as the phytoplankton dies
-            phyto(n)%jdissloss_si(i,j,k) = phyto(n)%phi_sidiss_mort*phyto(n)%jmortloss_n(i,j,k)*phyto(n)%q_si_2_n(i,j,k)
+            phyto(n)%jdissloss_si(i,j,k) = phyto(n)%jdissloss_si(i,j,k) + &
+                    phyto(n)%phi_sidiss_mort*phyto(n)%jmortloss_n(i,j,k)*phyto(n)%q_si_2_n(i,j,k)
             ! calculate the vertical sinking
             phyto(n)%vmove(i,j,k) = phyto(n)%sink_max*phyto(n)%stress_fac(i,j,k)
        enddo !} n

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1353,7 +1353,7 @@ contains
                    "fraction of N ingestion by small zooplankton to semi-labile dissolved organic nitrogen", &
                    units="none", default=0.3*(0.30-zoo(1)%phi_det))
     call get_param(param_file, "generic_COBALT", "phi_sldon_mdz", zoo(2)%phi_sldon, &
-                /   "fraction of N ingestion by medium zooplankton to semi-labile dissolved organic nitrogen", &
+                   "fraction of N ingestion by medium zooplankton to semi-labile dissolved organic nitrogen", &
                    units="none", default=0.3*(0.30-zoo(2)%phi_det))
     call get_param(param_file, "generic_COBALT", "phi_sldon_lgz", zoo(3)%phi_sldon, &
                    "fraction of N ingestion by large zooplankton to semi-labile dissolved organic nitrogen", &

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1043,10 +1043,10 @@ contains
 	! Diatom silica exudation or loss due to mortality and basal respiration
     call get_param(param_file, "generic_COBALT", "phi_sidiss_mort_Md", phyto(MEDIUM)%phi_sidiss_mort, &
                    "fraction of medium diatom silica exuded or lost as silicate", &
-                   units="none", default=0.5)
+                   units="none", default=0.0)
     call get_param(param_file, "generic_COBALT", "phi_sidiss_mort_Lg", phyto(LARGE)%phi_sidiss_mort, &
                    "fraction of larger diatom silica exuded or lost as silicate", &
-                   units="none", default=0.5)
+                   units="none", default=0.0)
     !
 	! Phytoplankton loss of organic carbon to exudation is assumed to be a constant fraction of NPP following Baines
     ! and Pace (1991) (https://aslopubs.onlinelibrary.wiley.com/doi/abs/10.4319/lo.1991.36.6.1078)
@@ -1371,9 +1371,9 @@ contains
     call get_param(param_file, "generic_COBALT", "phi_det_si_smz", zoo(1)%phi_det_si, &
                    "fraction of silica ingestion by small zooplankton to si detritus", units="none", default=0.0)
     call get_param(param_file, "generic_COBALT", "phi_det_si_mdz", zoo(2)%phi_det_si, &
-                   "fraction of silica ingestion by medium zooplankton to si detritus", units="none", default=0.20)
+                   "fraction of silica ingestion by medium zooplankton to si detritus", units="none", default=0.15)
     call get_param(param_file, "generic_COBALT", "phi_det_si_lgz", zoo(3)%phi_det_si, &
-                   "fraction of silica ingestion by large zooplankton to si detritus", units="none", default=0.35)
+                   "fraction of silica ingestion by large zooplankton to si detritus", units="none", default=0.30)
 	!
     !----------------------------------------------------------------------
     ! Partitioning of viral losses to various dissolved pools
@@ -3953,8 +3953,8 @@ contains
 
        ! If growth is negative, silica gets lost to mortality similar to the other elements
 	   ! multiplied by a conversion efficiency that determines the fraction of the silica shell left over in silg and simd
-	   phyto(MEDIUM)%jexuloss_sio2(i,j,k) = min(0.0,phyto(MEDIUM)%mu(i,j,k)*cobalt%f_simd(i,j,k)*phyto(MEDIUM)%phi_sidiss_mort)
-	   phyto(LARGE)%jexuloss_sio2(i,j,k) = min(0.0,phyto(LARGE)%mu(i,j,k)*cobalt%f_silg(i,j,k)*phyto(LARGE)%phi_sidiss_mort)
+	   phyto(MEDIUM)%jexuloss_sio2(i,j,k) = -1.0 * min(0.0,phyto(MEDIUM)%mu(i,j,k)*cobalt%f_simd(i,j,k)*phyto(MEDIUM)%phi_sidiss_mort)
+	   phyto(LARGE)%jexuloss_sio2(i,j,k) = -1.0 * min(0.0,phyto(LARGE)%mu(i,j,k)*cobalt%f_silg(i,j,k)*phyto(LARGE)%phi_sidiss_mort)
 
        ! Note that this is si_2_n in large phytoplankton pool, not in diatoms themselves (q_si_2_n_lg_diatoms)
        phyto(LARGE)%q_si_2_n(i,j,k) = cobalt%f_silg(i,j,k)/(phyto(LARGE)%f_n(i,j,k)+epsln)

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1040,8 +1040,15 @@ contains
     call get_param(param_file, "generic_COBALT", "mort_Md", phyto(MEDIUM)%mort, &
                    "mortality (cell death) rate constant for medium phytoplankton @ 0 deg. C", &
                    units="day-1", default=0.0, scale=I_sperd)
+	! Diatom silica exudation or loss due to mortality and basal respiration
+    call get_param(param_file, "generic_COBALT", "phi_sidiss_mort_Md", phyto(MEDIUM)%phi_sidiss_mort, &
+                   "fraction of medium diatom silica exuded or lost as silicate", &
+                   units="none", default=0.5)
+    call get_param(param_file, "generic_COBALT", "phi_sidiss_mort_Lg", phyto(LARGE)%phi_sidiss_mort, &
+                   "fraction of larger diatom silica exuded or lost as silicate", &
+                   units="none", default=0.5)
     !
-    ! Phytoplankton loss of organic carbon to exudation is assumed to be a constant fraction of NPP following Baines
+	! Phytoplankton loss of organic carbon to exudation is assumed to be a constant fraction of NPP following Baines
     ! and Pace (1991) (https://aslopubs.onlinelibrary.wiley.com/doi/abs/10.4319/lo.1991.36.6.1078)
     !
     call get_param(param_file, "generic_COBALT", "exu_Sm",phyto(SMALL)%exu, &
@@ -1360,7 +1367,14 @@ contains
     call get_param(param_file, "generic_COBALT", "phi_sldop_lgz", zoo(3)%phi_sldop, &
                    "fraction of P ingestion by large zooplankton to semi-labile dissolved organic phosphorus", &
                    units="none", default=0.3*(0.30-zoo(3)%phi_det))
-    !
+    ! Partitioning of silica detritus production from zooplankton is by default slightly higher than organic matter detritus
+    call get_param(param_file, "generic_COBALT", "phi_det_si_smz", zoo(1)%phi_det_si, &
+                   "fraction of silica ingestion by small zooplankton to si detritus", units="none", default=0.0)
+    call get_param(param_file, "generic_COBALT", "phi_det_si_mdz", zoo(2)%phi_det_si, &
+                   "fraction of silica ingestion by medium zooplankton to si detritus", units="none", default=0.20)
+    call get_param(param_file, "generic_COBALT", "phi_det_si_lgz", zoo(3)%phi_det_si, &
+                   "fraction of silica ingestion by large zooplankton to si detritus", units="none", default=0.35)
+	!
     !----------------------------------------------------------------------
     ! Partitioning of viral losses to various dissolved pools
     !----------------------------------------------------------------------
@@ -3923,16 +3937,24 @@ contains
     ! Silicate uptake
     !
     do k = 1, nk  ; do j = jsc, jec ; do i = isc, iec   !{
+	   ! Diatoms are modeled as the fraction of the medium and large phytoplankton based on silica limitation
        cobalt%nlg_diatoms(i,j,k)=phyto(LARGE)%f_n(i,j,k)*phyto(LARGE)%silim(i,j,k)
        cobalt%nmd_diatoms(i,j,k)=phyto(MEDIUM)%f_n(i,j,k)*phyto(MEDIUM)%silim(i,j,k)
        cobalt%nlg_misc(i,j,k)=phyto(LARGE)%f_n(i,j,k) - phyto(LARGE)%f_n(i,j,k)*phyto(LARGE)%silim(i,j,k)
        cobalt%nmd_misc(i,j,k)=phyto(MEDIUM)%f_n(i,j,k) - phyto(MEDIUM)%f_n(i,j,k)*phyto(MEDIUM)%silim(i,j,k)
+
+	   ! silim present in here twice to first determine the biomass of the diatoms, and secondly to determine the uptake
        phyto(LARGE)%juptake_sio4(i,j,k) = &
              max(phyto(LARGE)%juptake_no3(i,j,k)+phyto(LARGE)%juptake_nh4(i,j,k),0.0)*phyto(LARGE)%silim(i,j,k)* &
              phyto(LARGE)%silim(i,j,k)*phyto(LARGE)%si_2_n_max
        phyto(MEDIUM)%juptake_sio4(i,j,k) = &
              max(phyto(MEDIUM)%juptake_no3(i,j,k)+phyto(MEDIUM)%juptake_nh4(i,j,k),0.0)*phyto(MEDIUM)%silim(i,j,k)* &
              phyto(MEDIUM)%silim(i,j,k)*phyto(MEDIUM)%si_2_n_max
+
+       ! If growth is negative, silica gets lost to mortality similar to the other elements
+	   ! multiplied by a conversion efficiency that determines the fraction of the silica shell left over in silg and simd
+	   phyto(MEDIUM)%jexuloss_sio2(i,j,k) = min(0.0,phyto(MEDIUM)%mu(i,j,k)*cobalt%f_simd(i,j,k)*phyto(MEDIUM)%phi_sidiss_mort)
+	   phyto(LARGE)%jexuloss_sio2(i,j,k) = min(0.0,phyto(LARGE)%mu(i,j,k)*cobalt%f_silg(i,j,k)*phyto(LARGE)%phi_sidiss_mort)
 
        ! Note that this is si_2_n in large phytoplankton pool, not in diatoms themselves (q_si_2_n_lg_diatoms)
        phyto(LARGE)%q_si_2_n(i,j,k) = cobalt%f_silg(i,j,k)/(phyto(LARGE)%f_n(i,j,k)+epsln)
@@ -4501,7 +4523,7 @@ contains
                    phyto(n)%f_n(i,j,k)/(cobalt%refuge_conc + phyto(n)%f_n(i,j,k))
             phyto(n)%jmortloss_p(i,j,k) = phyto(n)%jmortloss_n(i,j,k)*phyto(n)%q_p_2_n(i,j,k)
             phyto(n)%jmortloss_fe(i,j,k) = phyto(n)%jmortloss_n(i,j,k)*phyto(n)%q_fe_2_n(i,j,k)
-            phyto(n)%jmortloss_sio2(i,j,k) = phyto(n)%jmortloss_n(i,j,k)*phyto(n)%q_si_2_n(i,j,k)
+            phyto(n)%jmortloss_sio2(i,j,k) = phyto(n)%phi_sidiss_mort*phyto(n)%jmortloss_n(i,j,k)*phyto(n)%q_si_2_n(i,j,k)
             ! calculate the vertical sinking
             phyto(n)%vmove(i,j,k) = phyto(n)%sink_max*phyto(n)%stress_fac(i,j,k)
        enddo !} n
@@ -4610,7 +4632,7 @@ contains
            zoo(m)%jprod_ldop(i,j,k) = zoo(m)%phi_ldop*zoo(m)%jingest_p(i,j,k)
            zoo(m)%jprod_srdop(i,j,k) = zoo(m)%phi_srdop*zoo(m)%jingest_p(i,j,k)
            zoo(m)%jprod_fedet(i,j,k) = zoo(m)%phi_det*zoo(m)%jingest_fe(i,j,k)
-           zoo(m)%jprod_sidet(i,j,k) = zoo(m)%phi_det*zoo(m)%jingest_sio2(i,j,k)
+           zoo(m)%jprod_sidet(i,j,k) = zoo(m)%phi_det_si*zoo(m)%jingest_sio2(i,j,k)
 		   
            ! augment cumulative production variables for detritus and dissolved organics
            cobalt%jprod_ndet(i,j,k) = cobalt%jprod_ndet(i,j,k) + zoo(m)%jprod_ndet(i,j,k)
@@ -4652,7 +4674,7 @@ contains
            cobalt%jprod_ndet(i,j,k) = cobalt%jprod_ndet(i,j,k) + phyto(m)%jaggloss_n(i,j,k)
            cobalt%jprod_pdet(i,j,k) = cobalt%jprod_pdet(i,j,k) + phyto(m)%jaggloss_p(i,j,k)
            cobalt%jprod_fedet(i,j,k) = cobalt%jprod_fedet(i,j,k) + phyto(m)%jaggloss_fe(i,j,k)
-           cobalt%jprod_sidet(i,j,k) = cobalt%jprod_sidet(i,j,k) + phyto(m)%jaggloss_sio2(i,j,k) + phyto(m)%jmortloss_sio2(i,j,k)
+           cobalt%jprod_sidet(i,j,k) = cobalt%jprod_sidet(i,j,k) + phyto(m)%jaggloss_sio2(i,j,k)
        enddo !} m
 
        ! Dissolved organic and inorganic production from viral lysis, exudation, and phytoplankton mortality
@@ -4672,8 +4694,9 @@ contains
            cobalt%jprod_srdop(i,j,k) = cobalt%jprod_srdop(i,j,k) + cobalt%lysis_phi_srdop* &
                    (phyto(m)%jvirloss_p(i,j,k) + phyto(m)%jmortloss_p(i,j,k))
            cobalt%jprod_fed(i,j,k) = cobalt%jprod_fed(i,j,k)   + phyto(m)%jvirloss_fe(i,j,k) + &
-                                       phyto(m)%jmortloss_fe(i,j,k) + phyto(m)%jexuloss_fe(i,j,k)
-           cobalt%jprod_sio4(i,j,k) = cobalt%jprod_sio4(i,j,k) + phyto(m)%jvirloss_sio2(i,j,k)
+                   phyto(m)%jmortloss_fe(i,j,k) + phyto(m)%jexuloss_fe(i,j,k)
+           cobalt%jprod_sio4(i,j,k) = cobalt%jprod_sio4(i,j,k) + phyto(m)%jvirloss_sio2(i,j,k) + &
+		           phyto(m)%jmortloss_sio2(i,j,k) + phyto(m)%jexuloss_sio2(i,j,k)
        enddo !} m
 
        ! Sources of dissolved organic material from viral lysis due to bacteria
@@ -5640,7 +5663,7 @@ contains
        cobalt%jsilg(i,j,k) = phyto(LARGE)%juptake_sio4(i,j,k) - &
                              phyto(LARGE)%jzloss_sio2(i,j,k) - phyto(LARGE)%jhploss_sio2(i,j,k) - &
                              phyto(LARGE)%jaggloss_sio2(i,j,k) - phyto(LARGE)%jvirloss_sio2(i,j,k) - &
-                             phyto(LARGE)%jmortloss_sio2(i,j,k)
+                             phyto(LARGE)%jmortloss_sio2(i,j,k) - phyto(LARGE)%jexuloss_sio2(i,j,k)
        cobalt%p_silg(i,j,k,tau) = cobalt%p_silg(i,j,k,tau) + cobalt%jsilg(i,j,k)*dt*grid_tmask(i,j,k)
        !
        ! Medium Phytoplankton Silicon
@@ -5648,7 +5671,7 @@ contains
        cobalt%jsimd(i,j,k) = phyto(MEDIUM)%juptake_sio4(i,j,k) - &
                              phyto(MEDIUM)%jzloss_sio2(i,j,k) - phyto(MEDIUM)%jhploss_sio2(i,j,k) - &
                              phyto(MEDIUM)%jaggloss_sio2(i,j,k) - phyto(MEDIUM)%jvirloss_sio2(i,j,k) - &
-                             phyto(MEDIUM)%jmortloss_sio2(i,j,k)
+                             phyto(MEDIUM)%jmortloss_sio2(i,j,k) - phyto(MEDIUM)%jexuloss_sio2(i,j,k)
        cobalt%p_simd(i,j,k,tau) = cobalt%p_simd(i,j,k,tau) + cobalt%jsimd(i,j,k)*dt*grid_tmask(i,j,k)
        !
        ! Diazotrophic Phytoplankton Iron

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -7432,6 +7432,7 @@ contains
        allocate(phyto(n)%jexuloss_fe(isd:ied,jsd:jed,nk))  ; phyto(n)%jexuloss_fe    = 0.0
        allocate(phyto(n)%jexuloss_n(isd:ied,jsd:jed,nk))   ; phyto(n)%jexuloss_n     = 0.0
        allocate(phyto(n)%jexuloss_p(isd:ied,jsd:jed,nk))   ; phyto(n)%jexuloss_p     = 0.0
+       allocate(phyto(n)%jexuloss_sio2(isd:ied,jsd:jed,nk)); phyto(n)%jexuloss_sio2  = 0.0
        allocate(phyto(n)%jhploss_fe(isd:ied,jsd:jed,nk))   ; phyto(n)%jhploss_fe     = 0.0
        allocate(phyto(n)%jhploss_n(isd:ied,jsd:jed,nk))    ; phyto(n)%jhploss_n      = 0.0
        allocate(phyto(n)%jhploss_p(isd:ied,jsd:jed,nk))    ; phyto(n)%jhploss_p      = 0.0
@@ -8029,6 +8030,7 @@ contains
        deallocate(phyto(n)%jexuloss_n)
        deallocate(phyto(n)%jexuloss_p)
        deallocate(phyto(n)%jexuloss_fe)
+       deallocate(phyto(n)%jexuloss_sio2)
        deallocate(phyto(n)%jhploss_fe)
        deallocate(phyto(n)%jhploss_n)
        deallocate(phyto(n)%jhploss_p)

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1040,7 +1040,7 @@ contains
     call get_param(param_file, "generic_COBALT", "mort_Md", phyto(MEDIUM)%mort, &
                    "mortality (cell death) rate constant for medium phytoplankton @ 0 deg. C", &
                    units="day-1", default=0.0, scale=I_sperd)
-	! Diatom silica exudation or loss due to mortality and basal respiration
+    ! Diatom silica exudation or loss due to mortality and basal respiration
     call get_param(param_file, "generic_COBALT", "phi_sidiss_mort_Md", phyto(MEDIUM)%phi_sidiss_mort, &
                    "fraction of medium diatom silica exuded or lost as silicate", &
                    units="none", default=0.0)
@@ -1048,7 +1048,7 @@ contains
                    "fraction of larger diatom silica exuded or lost as silicate", &
                    units="none", default=0.0)
     !
-	! Phytoplankton loss of organic carbon to exudation is assumed to be a constant fraction of NPP following Baines
+    ! Phytoplankton loss of organic carbon to exudation is assumed to be a constant fraction of NPP following Baines
     ! and Pace (1991) (https://aslopubs.onlinelibrary.wiley.com/doi/abs/10.4319/lo.1991.36.6.1078)
     !
     call get_param(param_file, "generic_COBALT", "exu_Sm",phyto(SMALL)%exu, &
@@ -1353,7 +1353,7 @@ contains
                    "fraction of N ingestion by small zooplankton to semi-labile dissolved organic nitrogen", &
                    units="none", default=0.3*(0.30-zoo(1)%phi_det))
     call get_param(param_file, "generic_COBALT", "phi_sldon_mdz", zoo(2)%phi_sldon, &
-                   "fraction of N ingestion by medium zooplankton to semi-labile dissolved organic nitrogen", &
+                /   "fraction of N ingestion by medium zooplankton to semi-labile dissolved organic nitrogen", &
                    units="none", default=0.3*(0.30-zoo(2)%phi_det))
     call get_param(param_file, "generic_COBALT", "phi_sldon_lgz", zoo(3)%phi_sldon, &
                    "fraction of N ingestion by large zooplankton to semi-labile dissolved organic nitrogen", &
@@ -3943,7 +3943,8 @@ contains
        cobalt%nlg_misc(i,j,k)=phyto(LARGE)%f_n(i,j,k) - phyto(LARGE)%f_n(i,j,k)*phyto(LARGE)%silim(i,j,k)
        cobalt%nmd_misc(i,j,k)=phyto(MEDIUM)%f_n(i,j,k) - phyto(MEDIUM)%f_n(i,j,k)*phyto(MEDIUM)%silim(i,j,k)
 
-	   ! silim present in here twice to first determine the biomass of the diatoms, and secondly to determine the uptake
+	   ! silim present in here twice first to find the fraction of nitrogen uptake attributed to diatoms, 
+	   ! and then to scale the Si:N ratio of that uptake
        phyto(LARGE)%juptake_sio4(i,j,k) = &
              max(phyto(LARGE)%juptake_no3(i,j,k)+phyto(LARGE)%juptake_nh4(i,j,k),0.0)*phyto(LARGE)%silim(i,j,k)* &
              phyto(LARGE)%silim(i,j,k)*phyto(LARGE)%si_2_n_max
@@ -3951,10 +3952,10 @@ contains
              max(phyto(MEDIUM)%juptake_no3(i,j,k)+phyto(MEDIUM)%juptake_nh4(i,j,k),0.0)*phyto(MEDIUM)%silim(i,j,k)* &
              phyto(MEDIUM)%silim(i,j,k)*phyto(MEDIUM)%si_2_n_max
 
-       ! If growth is negative, silica gets lost to mortality similar to the other elements
-	   ! multiplied by a conversion efficiency that determines the fraction of the silica shell left over in silg and simd
-	   phyto(MEDIUM)%jexuloss_sio2(i,j,k) = -1.0 * min(0.0,phyto(MEDIUM)%mu(i,j,k)*cobalt%f_simd(i,j,k)*phyto(MEDIUM)%phi_sidiss_mort)
-	   phyto(LARGE)%jexuloss_sio2(i,j,k) = -1.0 * min(0.0,phyto(LARGE)%mu(i,j,k)*cobalt%f_silg(i,j,k)*phyto(LARGE)%phi_sidiss_mort)
+       ! If growth is negative, silica gets lost via dissolution similar to the other elements
+	   ! This term is multiplied by a conversion efficiency that determines the fraction of the silica shell left over in silg and simd
+	   phyto(MEDIUM)%jdissloss_si(i,j,k) = -1.0 * min(0.0,phyto(MEDIUM)%mu(i,j,k)*cobalt%f_simd(i,j,k)*phyto(MEDIUM)%phi_sidiss_mort)
+	   phyto(LARGE)%jdissloss_si(i,j,k) = -1.0 * min(0.0,phyto(LARGE)%mu(i,j,k)*cobalt%f_silg(i,j,k)*phyto(LARGE)%phi_sidiss_mort)
 
        ! Note that this is si_2_n in large phytoplankton pool, not in diatoms themselves (q_si_2_n_lg_diatoms)
        phyto(LARGE)%q_si_2_n(i,j,k) = cobalt%f_silg(i,j,k)/(phyto(LARGE)%f_n(i,j,k)+epsln)
@@ -4523,7 +4524,9 @@ contains
                    phyto(n)%f_n(i,j,k)/(cobalt%refuge_conc + phyto(n)%f_n(i,j,k))
             phyto(n)%jmortloss_p(i,j,k) = phyto(n)%jmortloss_n(i,j,k)*phyto(n)%q_p_2_n(i,j,k)
             phyto(n)%jmortloss_fe(i,j,k) = phyto(n)%jmortloss_n(i,j,k)*phyto(n)%q_fe_2_n(i,j,k)
-            phyto(n)%jmortloss_sio2(i,j,k) = phyto(n)%phi_sidiss_mort*phyto(n)%jmortloss_n(i,j,k)*phyto(n)%q_si_2_n(i,j,k)
+            ! silica dissolution from phytoplankton mortality is also multiplied by a scaling factor that 
+            ! determines the amount of silica test left over as the phytoplankton dies
+            phyto(n)%jdissloss_si(i,j,k) = phyto(n)%phi_sidiss_mort*phyto(n)%jmortloss_n(i,j,k)*phyto(n)%q_si_2_n(i,j,k)
             ! calculate the vertical sinking
             phyto(n)%vmove(i,j,k) = phyto(n)%sink_max*phyto(n)%stress_fac(i,j,k)
        enddo !} n
@@ -4696,7 +4699,7 @@ contains
            cobalt%jprod_fed(i,j,k) = cobalt%jprod_fed(i,j,k)   + phyto(m)%jvirloss_fe(i,j,k) + &
                    phyto(m)%jmortloss_fe(i,j,k) + phyto(m)%jexuloss_fe(i,j,k)
            cobalt%jprod_sio4(i,j,k) = cobalt%jprod_sio4(i,j,k) + phyto(m)%jvirloss_sio2(i,j,k) + &
-		           phyto(m)%jmortloss_sio2(i,j,k) + phyto(m)%jexuloss_sio2(i,j,k)
+		           phyto(m)%jdissloss_si(i,j,k)
        enddo !} m
 
        ! Sources of dissolved organic material from viral lysis due to bacteria
@@ -4797,7 +4800,7 @@ contains
           cobalt%jprod_fed(i,j,k) = cobalt%jprod_fed(i,j,k) + zoo(m)%jprod_fed(i,j,k)
 
           ! Ingested opal not allocated to detritus undergoes rapid dissolution to dissolved silica
-          zoo(m)%jprod_sio4(i,j,k) = (1.0 - zoo(m)%phi_det)*zoo(m)%jingest_sio2(i,j,k)
+          zoo(m)%jprod_sio4(i,j,k) = (1.0 - zoo(m)%phi_det_si)*zoo(m)%jingest_sio2(i,j,k)
           cobalt%jprod_sio4(i,j,k) = cobalt%jprod_sio4(i,j,k) + zoo(m)%jprod_sio4(i,j,k)
        enddo !} m
 
@@ -5663,7 +5666,7 @@ contains
        cobalt%jsilg(i,j,k) = phyto(LARGE)%juptake_sio4(i,j,k) - &
                              phyto(LARGE)%jzloss_sio2(i,j,k) - phyto(LARGE)%jhploss_sio2(i,j,k) - &
                              phyto(LARGE)%jaggloss_sio2(i,j,k) - phyto(LARGE)%jvirloss_sio2(i,j,k) - &
-                             phyto(LARGE)%jmortloss_sio2(i,j,k) - phyto(LARGE)%jexuloss_sio2(i,j,k)
+                             phyto(LARGE)%jdissloss_si(i,j,k)
        cobalt%p_silg(i,j,k,tau) = cobalt%p_silg(i,j,k,tau) + cobalt%jsilg(i,j,k)*dt*grid_tmask(i,j,k)
        !
        ! Medium Phytoplankton Silicon
@@ -5671,7 +5674,7 @@ contains
        cobalt%jsimd(i,j,k) = phyto(MEDIUM)%juptake_sio4(i,j,k) - &
                              phyto(MEDIUM)%jzloss_sio2(i,j,k) - phyto(MEDIUM)%jhploss_sio2(i,j,k) - &
                              phyto(MEDIUM)%jaggloss_sio2(i,j,k) - phyto(MEDIUM)%jvirloss_sio2(i,j,k) - &
-                             phyto(MEDIUM)%jmortloss_sio2(i,j,k) - phyto(MEDIUM)%jexuloss_sio2(i,j,k)
+                             phyto(MEDIUM)%jdissloss_si(i,j,k)
        cobalt%p_simd(i,j,k,tau) = cobalt%p_simd(i,j,k,tau) + cobalt%jsimd(i,j,k)*dt*grid_tmask(i,j,k)
        !
        ! Diazotrophic Phytoplankton Iron
@@ -7428,11 +7431,10 @@ contains
        allocate(phyto(n)%jmortloss_fe(isd:ied,jsd:jed,nk))  ; phyto(n)%jmortloss_fe    = 0.0
        allocate(phyto(n)%jmortloss_n(isd:ied,jsd:jed,nk))   ; phyto(n)%jmortloss_n     = 0.0
        allocate(phyto(n)%jmortloss_p(isd:ied,jsd:jed,nk))   ; phyto(n)%jmortloss_p     = 0.0
-       allocate(phyto(n)%jmortloss_sio2(isd:ied,jsd:jed,nk)); phyto(n)%jmortloss_sio2  = 0.0
+       allocate(phyto(n)%jdissloss_si(isd:ied,jsd:jed,nk)) ; phyto(n)%jdissloss_si  = 0.0
        allocate(phyto(n)%jexuloss_fe(isd:ied,jsd:jed,nk))  ; phyto(n)%jexuloss_fe    = 0.0
        allocate(phyto(n)%jexuloss_n(isd:ied,jsd:jed,nk))   ; phyto(n)%jexuloss_n     = 0.0
        allocate(phyto(n)%jexuloss_p(isd:ied,jsd:jed,nk))   ; phyto(n)%jexuloss_p     = 0.0
-       allocate(phyto(n)%jexuloss_sio2(isd:ied,jsd:jed,nk)); phyto(n)%jexuloss_sio2  = 0.0
        allocate(phyto(n)%jhploss_fe(isd:ied,jsd:jed,nk))   ; phyto(n)%jhploss_fe     = 0.0
        allocate(phyto(n)%jhploss_n(isd:ied,jsd:jed,nk))    ; phyto(n)%jhploss_n      = 0.0
        allocate(phyto(n)%jhploss_p(isd:ied,jsd:jed,nk))    ; phyto(n)%jhploss_p      = 0.0
@@ -8026,11 +8028,10 @@ contains
        deallocate(phyto(n)%jmortloss_n)
        deallocate(phyto(n)%jmortloss_p)
        deallocate(phyto(n)%jmortloss_fe)
-       deallocate(phyto(n)%jmortloss_sio2)
+       deallocate(phyto(n)%jdissloss_si)
        deallocate(phyto(n)%jexuloss_n)
        deallocate(phyto(n)%jexuloss_p)
        deallocate(phyto(n)%jexuloss_fe)
-       deallocate(phyto(n)%jexuloss_sio2)
        deallocate(phyto(n)%jhploss_fe)
        deallocate(phyto(n)%jhploss_n)
        deallocate(phyto(n)%jhploss_p)


### PR DESCRIPTION
Description to come. This is just a placeholder as we work on a fix to improve the silica cycle. Current ESM4.5 runs have a unrealistic build-up of silica at the poles, associated with insufficient sidet generation from phytoplankton mortality.