### PR TITLE
Removing gamma_ndet_fast as a parameter

### DIFF
--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -474,7 +474,6 @@ module cobalt_types
           min_daylength,    &
           gamma_mu_mem,     &
           gamma_ndet,       &
-          gamma_ndet_fast,  &
           gamma_nitrif,     &
           k_nh3_nitrif,     &
           nitrif_b,         &

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1524,10 +1524,10 @@ contains
     call get_param(param_file, "generic_COBALT", "remin_ramp_scale", cobalt%remin_ramp_scale, &
                    "depth scale from the surface over which remineralization ramps up", units="m", default= 50.0)
     ! gamma_ndet is set to produce a Martin-curve like remineralization length scale at temperatures ~10 deg. C
+    ! While this parameter depends on the value of wsink, the resultant value (1/3.5) should be invariant
+    ! Therefore, we will use this same parameter for fast-sinking detritus as well
     call get_param(param_file, "generic_COBALT", "gamma_ndet", cobalt%gamma_ndet, &
                    "Remineralization rate for unprotected organic matter", units="s-1", default=cobalt%wsink/350.0)
-    call get_param(param_file, "generic_COBALT", "gamma_ndet_fast", cobalt%gamma_ndet_fast, &
-                   "Remineralization rate for fast-sinking unprotected organic matter", units="s-1", default=cobalt%wsink_fast/3500.0)
     ! mineral ballasting after Klaas and Archer (2002) and Dunne et al. (2007) (see p. 3) 
     ! conversion is 0.070 g C (g Ca)-1 to moles N (mole Ca)-1; Similar conversions below, but lith remains per gram
     call get_param(param_file, "generic_COBALT", "rpcaco3", cobalt%rpcaco3, "Organic matter protection from CaCO3", &
@@ -4982,7 +4982,8 @@ contains
                cobalt%rpcaco3*(cobalt%f_cadet_arag(i,j,k) + cobalt%f_cadet_calc(i,j,k)) - &
                cobalt%rplith*cobalt%f_lithdet(i,j,k) - cobalt%rpsio2*cobalt%f_sidet(i,j,k) )
 	      ! Adding in the remineralization from fast sinking detritus
-	      cobalt%jremin_ndet_fast(i,j,k) = cobalt%gamma_ndet_fast * cobalt%expkreminT(i,j,k) * &
+          ! Need to use the same remineralization rate (gamma_ndet) as bulk detritus
+	      cobalt%jremin_ndet_fast(i,j,k) = cobalt%gamma_ndet * cobalt%expkreminT(i,j,k) * &
 		        cobalt%f_ndet_fast(i,j,k) * (cobalt%f_o2(i,j,k) / (cobalt%k_o2 + cobalt%f_o2(i,j,k)))
           ! Augment total nh4 production and o2 consumption
           cobalt%jprod_nh4(i,j,k) = cobalt%jprod_nh4(i,j,k) + cobalt%jremin_ndet(i,j,k) + cobalt%jremin_ndet_fast(i,j,k)
@@ -4998,7 +4999,7 @@ contains
                cobalt%rpcaco3*(cobalt%f_cadet_arag(i,j,k) + cobalt%f_cadet_calc(i,j,k)) - &
                cobalt%rplith*cobalt%f_lithdet(i,j,k) - cobalt%rpsio2*cobalt%f_sidet(i,j,k) )
           ! Adding in the remineralization from fast sinking detritus
-          cobalt%jremin_ndet_fast(i,j,k) = cobalt%gamma_ndet_fast * cobalt%f_ndet_fast(i,j,k) * &
+          cobalt%jremin_ndet_fast(i,j,k) = cobalt%gamma_ndet * cobalt%f_ndet_fast(i,j,k) * &
                (cobalt%o2_min / (cobalt%k_o2 + cobalt%o2_min)) * &
                (cobalt%f_no3(i,j,k) / (cobalt%k_no3_denit + cobalt%f_no3(i,j,k))) 
           ! Augment total nh4 production and no3 consumption

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1523,9 +1523,13 @@ contains
                    "Temperature dependence of remineralization", units="deg C-1", default=0.063)
     call get_param(param_file, "generic_COBALT", "remin_ramp_scale", cobalt%remin_ramp_scale, &
                    "depth scale from the surface over which remineralization ramps up", units="m", default= 50.0)
-    ! gamma_ndet is set to produce a Martin-curve like remineralization length scale at temperatures ~10 deg. C
-    ! While this parameter depends on the value of wsink, the resultant value (1/3.5) should be invariant
-    ! Therefore, we will use this same parameter for fast-sinking detritus as well
+    ! gamma_ndet is set to produce a e-folding length scale for fresh (unprotected) organic matter of ~190m at ~10 deg. C, 
+    ! consistent with the Martin curve. The value has been defined as a function of the sinking rate for "standard detritus 
+    ! (i.e., zooplankton fecal pellets/phytoplankton aggregates) so that the remineralization length-scale is preserved even 
+    ! if the sinking rate changed. Once established, gamma_ndet is also used for fast sinking detritus 
+    ! (i.e., unprotected organic matter is assumed to decay at similar rates regardless of whether it sinking slowly or quickly). 
+    ! This means that the ratio of the remineralization length-scale for unprotected fast sinking detritus relative to that for 
+    ! unprotected standard detritus equal the ratio of their sinking speeds (wsink_fast/wsink).
     call get_param(param_file, "generic_COBALT", "gamma_ndet", cobalt%gamma_ndet, &
                    "Remineralization rate for unprotected organic matter", units="s-1", default=cobalt%wsink/350.0)
     ! mineral ballasting after Klaas and Archer (2002) and Dunne et al. (2007) (see p. 3) 
@@ -4982,7 +4986,7 @@ contains
                cobalt%rpcaco3*(cobalt%f_cadet_arag(i,j,k) + cobalt%f_cadet_calc(i,j,k)) - &
                cobalt%rplith*cobalt%f_lithdet(i,j,k) - cobalt%rpsio2*cobalt%f_sidet(i,j,k) )
 	      ! Adding in the remineralization from fast sinking detritus
-          ! Need to use the same remineralization rate (gamma_ndet) as bulk detritus
+          ! Unprotected organic matter assumed to decay at the same rate (gamma_ndet) whether it sinks quickly or not
 	      cobalt%jremin_ndet_fast(i,j,k) = cobalt%gamma_ndet * cobalt%expkreminT(i,j,k) * &
 		        cobalt%f_ndet_fast(i,j,k) * (cobalt%f_o2(i,j,k) / (cobalt%k_o2 + cobalt%f_o2(i,j,k)))
           ! Augment total nh4 production and o2 consumption


### PR DESCRIPTION
With the addition of fast sinking detritus, we also introduced `gamma_ndet_fast`, which is the remineralization rate for (fast-sinking) detritus. We set this value to be equivalent to `gamma_ndet`, which is 1/3.5, designed to produce a remineralization length scale equivalent to that of the Martin curve at 0 degrees C. Like `gamma_ndet`, `gamma_ndet_fast` was dependent on the sinking speed: 
`gamma_ndet`: `default = cobalt%wsink / 350.0`
`gamma_ndet_fast`: `default = cobalt%wsink_fast / 3500.0`

This becomes a problem when the sinking speeds are changed for fast-sinking detritus, which we have been doing during ESM4.5 testing, because while sinking speeds were decreased, the remineralization rates increased, which was not the intended consequence. 

So in this PR, as a quick fix, I have removed `gamma_ndet_fast` entirely, letting the remin rate for fast-sinking detritus be dependent on `gamma_ndet` instead. In the future, `gamma_ndet` itself may need to be changed to to an invariant number (1/3.5) but here we are not imposing that fix just yet. 