### PR TITLE
Enable exchange of runoff DOC from Land to Ice

### DIFF
--- a/generic_tracers/MOM_generic_tracer.F90
+++ b/generic_tracers/MOM_generic_tracer.F90
@@ -731,9 +731,13 @@ subroutine MOM_generic_tracer_column_physics(h_old, h_new, ea, eb, fluxes, Hml, 
       call g_tracer_get_pointer(g_tracer,g_tracer_name,'stf',   stf_array)
       call g_tracer_get_pointer(g_tracer,g_tracer_name,'trunoff',trunoff_array)
       call g_tracer_get_pointer(g_tracer,g_tracer_name,'runoff_tracer_flux',runoff_tracer_flux_array)
-      !nnz: Why is fluxes%river = 0?
-      runoff_tracer_flux_array(:,:) = trunoff_array(:,:) * &
-               US%RZ_T_to_kg_m2s*fluxes%lrunoff(:,:)
+      runoff_tracer_flux_array(:,:) = trunoff_array(:,:) * US%RZ_T_to_kg_m2s*fluxes%lrunoff(:,:)
+      !Add to the geological runoff fluxes the contemporary values calculated by land model for tracers that have them.
+      !Currently 'dic' from GIMICS
+      if(trim(g_tracer_name) == 'dic') then
+        !*1000./12. converts from KgC/m2/s to MoleC/m2/s
+        runoff_tracer_flux_array(:,:) = runoff_tracer_flux_array(:,:) + fluxes%carbon_content_lrunoff(:,:)*1000./12.
+      endif
       stf_array = stf_array + runoff_tracer_flux_array
       g_tracer%runoff_added_to_stf = .true.
     endif


### PR DESCRIPTION
- Land component calculates the DOC (Dissolved Organic Carbon) content flux in runoff (KgC/m2/s)
- COBALT needs access to that runoff flux (currently done via data_override from file)
- Ocean component needs to make the flux available to COBALT
- Ice component needs to make the flux available to ICE
- land_ice_flux_exchange needs to exchange the flux from Land to Ice