### PR TITLE
Diagnostics for tracer content change 

### DIFF
--- a/generic_tracers/cobalt_reg_diag.F90
+++ b/generic_tracers/cobalt_reg_diag.F90
@@ -3286,7 +3286,7 @@ module COBALT_reg_diag
     cobalt%id_jalk = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jalkh","Alkalinity content source",'h','L','s','mole eq kg-1 m s-1','f')
+    vardesc_temp = vardesc("jalkh","Alkalinity content source (jalk * thickness)",'h','L','s','mole eq kg-1 m s-1','f')
     cobalt%id_jalkh = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -3298,7 +3298,7 @@ module COBALT_reg_diag
     cobalt%id_jdic = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jdich","Dissolved Inorganic Carbon content source",'h','L','s','mol kg-1 m s-1','f')
+    vardesc_temp = vardesc("jdich","Dissolved Inorganic Carbon content source (jdic * thickness)",'h','L','s','mol kg-1 m s-1','f')
     cobalt%id_jdich = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -3306,7 +3306,7 @@ module COBALT_reg_diag
     cobalt%id_jno3 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jno3h","no3 content source",'h','L','s','mol kg-1 m s-1','f')
+    vardesc_temp = vardesc("jno3h","no3 content source (jno3 * thickness)",'h','L','s','mol kg-1 m s-1','f')
     cobalt%id_jno3h = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -3314,7 +3314,7 @@ module COBALT_reg_diag
     cobalt%id_jpo4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jpo4h","po4 content source",'h','L','s','mol kg-1 m s-1','f')
+    vardesc_temp = vardesc("jpo4h","po4 content source (jpo4 * thickness)",'h','L','s','mol kg-1 m s-1','f')
     cobalt%id_jpo4h = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -3322,7 +3322,7 @@ module COBALT_reg_diag
     cobalt%id_jsio4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jsio4h","sio4 content source",'h','L','s','mol kg-1 m s-1','f')
+    vardesc_temp = vardesc("jsio4h","sio4 content source (jsio4 * thickness)",'h','L','s','mol kg-1 m s-1','f')
     cobalt%id_jsio4h = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -3334,7 +3334,7 @@ module COBALT_reg_diag
     cobalt%id_jnh4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jnh4h","NH4 content source",'h','L','s','mol kg-1 m s-1','f')
+    vardesc_temp = vardesc("jnh4h","NH4 content source (jnh4 * thickness)",'h','L','s','mol kg-1 m s-1','f')
     cobalt%id_jnh4h = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -3342,7 +3342,7 @@ module COBALT_reg_diag
     cobalt%id_jndet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jndeth","NDET content source",'h','L','s','mol kg-1 m s-1','f')
+    vardesc_temp = vardesc("jndeth","NDET content source (jndet * thickness)",'h','L','s','mol kg-1 m s-1','f')
     cobalt%id_jndeth = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
@@ -3358,7 +3358,7 @@ module COBALT_reg_diag
     cobalt%id_jo2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
-    vardesc_temp = vardesc("jo2h","O2 content source",'h','L','s','mol kg-1 m s-1','f')
+    vardesc_temp = vardesc("jo2h","O2 content source (jo2 * thickness)",'h','L','s','mol kg-1 m s-1','f')
     cobalt%id_jo2h = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 

--- a/generic_tracers/cobalt_reg_diag.F90
+++ b/generic_tracers/cobalt_reg_diag.F90
@@ -1567,7 +1567,7 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("jprod_fedet","Detrital Fedet production",'h','L','s','mol Fe kg-1 s-1','f')
     cobalt%id_jprod_fedet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		 
+
     vardesc_temp = vardesc("jprod_ndet","Detrital PON production",'h','L','s','mol N kg-1 s-1','f')
     cobalt%id_jprod_ndet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -1575,7 +1575,7 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("jprod_ndet_fast","Fast-sinking detrital PON production",'h','L','s','mol N kg-1 s-1','f')
     cobalt%id_jprod_ndet_fast = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		 
+
     vardesc_temp = vardesc("jprod_pdet","Detrital phosphorus production",'h','L','s','mol P kg-1 s-1','f')
     cobalt%id_jprod_pdet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -1583,7 +1583,7 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("jprod_pdet_fast","Fast-sinking detrital phosphorus production",'h','L','s','mol P kg-1 s-1','f')
     cobalt%id_jprod_pdet_fast = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		 
+
     vardesc_temp = vardesc("jprod_ldon","labile dissolved organic nitrogen production",&
                             'h','L','s','mol N kg-1 s-1','f')
     cobalt%id_jprod_ldon = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
@@ -1682,7 +1682,7 @@ module COBALT_reg_diag
                            'h','L','s','mol N kg-1 s-1','f')
     cobalt%id_jremin_ndet_fast = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		 
+
     vardesc_temp = vardesc("jremin_pdet","Phosphorous detritus remineralization",&
                            'h','L','s','mol P kg-1 s-1','f')
     cobalt%id_jremin_pdet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
@@ -1697,7 +1697,7 @@ module COBALT_reg_diag
                            'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jremin_fedet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		 
+
     !
     ! iron cycling diagnostics
     !
@@ -2011,7 +2011,7 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("fndet_fast","Fast-sinking nitrogen detritus flux (@tracer points)",'h','1','s','mol m-2 s-1','f')
     cobalt%id_fndet_fast_tp = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		 
+
     vardesc_temp = vardesc("fpdet","Phosphorus detritus sinking flux (@tracer points)",'h','1','s','mol m-2 s-1','f')
     cobalt%id_fpdet_tp = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -2019,7 +2019,7 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("fpdet_fast","Fast-sinking phosphorus detritus flux (@tracer points)",'h','1','s','mol m-2 s-1','f')
     cobalt%id_fpdet_fast_tp = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		 
+
     vardesc_temp = vardesc("fsidet","sidet sinking flux (@tracer points)",'h','1','s','mol m-2 s-1','f')
     cobalt%id_fsidet_tp = register_diag_field(package_name, vardesc_temp%name, axesTi(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -2067,7 +2067,7 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("fndet_fast_i","Fast-sinking nitrogen detritus flux (@interfaces)",'h','i','s','mol m-2 s-1','f')
     cobalt%id_fndet_fast_i = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		 
+
     vardesc_temp = vardesc("fpdet_i","Phosphorus detritus sinking flux (@interfaces)",'h','i','s','mol m-2 s-1','f')
     cobalt%id_fpdet_i = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -2075,7 +2075,7 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("fpdet_fast_i","Fast-sinking phosphorus detritus flux (@interfaces)",'h','i','s','mol m-2 s-1','f')
     cobalt%id_fpdet_fast_i = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		 
+
     vardesc_temp = vardesc("fsidet_i","sidet sinking flux (@interfaces)",'h','i','s','mol m-2 s-1','f')
     cobalt%id_fsidet_i = register_diag_field(package_name, vardesc_temp%name, axesTi(1:1),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -2132,7 +2132,7 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("ffedet_btm","Iron detritus sinking flux burial",'h','1','s','mol m-2 s-1','f')
     cobalt%id_ffedet_btm = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		
+
     vardesc_temp = vardesc("ffedi_btm","diazo Fe sinking flux to bottom",'h','1','s','mol m-2 s-1','f')
     phyto(DIAZO)%id_ffe_btm = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -2172,7 +2172,7 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("fndet_fast_btm","Fast-sinking nitrogen detritus flux to bottom",'h','1','s','mol m-2 s-1','f')
     cobalt%id_fndet_fast_btm = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		 
+
     vardesc_temp = vardesc("fndi_btm","diazo N sinking flux to bottom",'h','1','s','mol m-2 s-1','f')
     phyto(DIAZO)%id_fn_btm = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -2213,7 +2213,7 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("fpdet_fast_btm","Fast-sinking phosphorus detritus flux to bottom",'h','1','s','mol m-2 s-1','f')
     cobalt%id_fpdet_fast_btm = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		 
+
     vardesc_temp = vardesc("fpdi_btm","diazo P sinking flux to bottom",'h','1','s','mol m-2 s-1','f')
     phyto(DIAZO)%id_fp_btm = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -2945,7 +2945,7 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("jremin_ndet_fast_100","Remineralization of fast-sinking nitrogen detritus integral in upper 100m",'h','1','s','mol m-2 s-1','f')
     cobalt%id_jremin_ndet_fast_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		 
+
     vardesc_temp = vardesc("jprod_mesozoo_200","Mesozooplankton Production, 200m integration",'h','1','s','mol m-2 s-1','f')
     cobalt%id_jprod_mesozoo_200 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -3117,7 +3117,7 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("ndet_fast_100","Fast-sinking nitrogen detritus biomass in upper 100m",'h','1','s','mol m-2','f')
     cobalt%id_f_ndet_fast_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		 
+
     vardesc_temp = vardesc("don_100","Dissolved organic nitrogen (sr+sl+l) in upper 100m",'h','1','s','mol m-2','f')
     cobalt%id_f_don_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -3181,7 +3181,7 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("fndet_fast_100","Fast-sinking nitrogen detritus flux @ 100m",'h','1','s','mol m-2 s-1','f')
     cobalt%id_fndet_fast_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		 
+
     vardesc_temp = vardesc("fpdet_100","Phosphorous detritus sinking flux @ 100m",'h','1','s','mol m-2 s-1','f')
     cobalt%id_fpdet_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -3189,11 +3189,11 @@ module COBALT_reg_diag
     vardesc_temp = vardesc("fpdet_fast_100","Fast-sinking phosphorous detritus flux @ 100m",'h','1','s','mol m-2 s-1','f')
     cobalt%id_fpdet_fast_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		 
+
     vardesc_temp = vardesc("ffedet_100","Iron detritus sinking flux @ 100m",'h','1','s','mol m-2 s-1','f')
     cobalt%id_ffedet_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
-		 
+
     vardesc_temp = vardesc("fsidet_100","Silicon detritus sinking flux @ 100m",'h','1','s','mol m-2 s-1','f')
     cobalt%id_fsidet_100 = register_diag_field(package_name, vardesc_temp%name, axes(1:2),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -3286,6 +3286,10 @@ module COBALT_reg_diag
     cobalt%id_jalk = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
+    vardesc_temp = vardesc("jalkh","Alkalinity content source",'h','L','s','mole eq kg-1 m s-1','f')
+    cobalt%id_jalkh = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
     vardesc_temp = vardesc("jalk_plus_btm","Alkalinity source plus btm",'h','L','s','mole eq kg-1 s-1','f')
     cobalt%id_jalk_plus_btm = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
@@ -3328,6 +3332,10 @@ module COBALT_reg_diag
 
     vardesc_temp = vardesc("jo2","O2 source",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jo2 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jo2h","O2 content source",'h','L','s','mol kg-1 m s-1','f')
+    cobalt%id_jo2h = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
 
@@ -3865,14 +3873,14 @@ module COBALT_reg_diag
          cmor_field_name="expn_i", cmor_units="mol m-2 s-1",                          &
          cmor_standard_name="sinking_mole_flux_of_particulate_organic_nitrogen_in_sea_water", &
          cmor_long_name="Sinking Particulate Organic Nitrogen Flux")
-         
+
     vardesc_temp = vardesc("expp_raw_i","Sinking Particulate Organic Phosphorus Flux (@interfaces)",'h','i','s','mol m-2 s-1','f')
     cobalt%id_expp_i = register_diag_field(package_name, vardesc_temp%name, axes(1:1), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &
          cmor_field_name="expp_i", cmor_units="mol m-2 s-1",                          &
          cmor_standard_name="sinking_mole_flux_of_particulate_organic_phosphorus_in_sea_water", &
          cmor_long_name="Sinking Particulate Organic Phosphorus Flux")
-         
+
     vardesc_temp = vardesc("expfe_raw_i","Sinking Particulate Iron Flux (@interfaces)",'h','i','s','mol m-2 s-1','f')
     cobalt%id_expfe_i = register_diag_field(package_name, vardesc_temp%name, axes(1:1), &
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1, &

--- a/generic_tracers/cobalt_reg_diag.F90
+++ b/generic_tracers/cobalt_reg_diag.F90
@@ -3298,16 +3298,32 @@ module COBALT_reg_diag
     cobalt%id_jdic = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
+    vardesc_temp = vardesc("jdich","Dissolved Inorganic Carbon content source",'h','L','s','mol kg-1 m s-1','f')
+    cobalt%id_jdich = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
     vardesc_temp = vardesc("jno3","no3 source",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jno3 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jno3h","no3 content source",'h','L','s','mol kg-1 m s-1','f')
+    cobalt%id_jno3h = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("jpo4","po4 source",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jpo4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
+    vardesc_temp = vardesc("jpo4h","po4 content source",'h','L','s','mol kg-1 m s-1','f')
+    cobalt%id_jpo4h = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
     vardesc_temp = vardesc("jsio4","sio4 source",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jsio4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jsio4h","sio4 content source",'h','L','s','mol kg-1 m s-1','f')
+    cobalt%id_jsio4h = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("jdic_plus_btm","Dissolved Inorganic Carbon source plus btm",'h','L','s','mol kg-1 s-1','f')
@@ -3318,8 +3334,16 @@ module COBALT_reg_diag
     cobalt%id_jnh4 = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
+    vardesc_temp = vardesc("jnh4h","NH4 content source",'h','L','s','mol kg-1 m s-1','f')
+    cobalt%id_jnh4h = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
     vardesc_temp = vardesc("jndet","NDET source",'h','L','s','mol kg-1 s-1','f')
     cobalt%id_jndet = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
+         init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
+
+    vardesc_temp = vardesc("jndeth","NDET content source",'h','L','s','mol kg-1 m s-1','f')
+    cobalt%id_jndeth = register_diag_field(package_name, vardesc_temp%name, axes(1:3),&
          init_time, vardesc_temp%longname,vardesc_temp%units, missing_value = missing_value1)
 
     vardesc_temp = vardesc("jnh4_plus_btm","NH4 source plus btm",'h','L','s','mol kg-1 s-1','f')

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -29,7 +29,7 @@ module COBALT_send_diag
 
   contains
 
-    !> subroutine that handles send_diag calls for COBALT phyto, zoo, and bact      
+    !> subroutine that handles send_diag calls for COBALT phyto, zoo, and bact
     subroutine cobalt_send_diagnostics(tracer_list,model_time,grid_tmask,Temp,Salt,rho_dzt,dzt,&
                                  ilb,jlb,tau,phyto,zoo,bact,cobalt,&
                                  post_vertdiff)
@@ -44,15 +44,15 @@ module COBALT_send_diag
       logical,                                   intent(in), optional :: post_vertdiff
       !> local variables
       integer :: isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,n,i,j,k
-      logical :: used  
+      logical :: used
       logical :: is_post_vertdiff
       real :: drho_dzt
       real, dimension(:,:,:) ,pointer :: grid_tmask
-      integer, dimension(:,:),pointer :: mask_coast,grid_kmt      
+      integer, dimension(:,:),pointer :: mask_coast,grid_kmt
       integer, dimension(:,:), Allocatable :: k_bot
-      real, dimension(:,:), Allocatable :: rho_dzt_100,rho_dzt_200,rho_dzt_bot    
+      real, dimension(:,:), Allocatable :: rho_dzt_100,rho_dzt_200,rho_dzt_bot
       integer :: k_100,k_200
-      real, dimension(:,:), Allocatable :: field_2d !used to calculate some 2d fields before saving 
+      real, dimension(:,:), Allocatable :: field_2d !used to calculate some 2d fields before saving
       real, dimension(:,:,:), Allocatable :: flux_i !used to save fluxes at the interfaces
 
 
@@ -76,7 +76,7 @@ module COBALT_send_diag
       select case (is_post_vertdiff)
         case (.true.)     ! Saving prognostic tracers after update from vertical diffusion and sinking
 
-          ! Get prognostics tracer fields via their pointers 
+          ! Get prognostics tracer fields via their pointers
           call g_tracer_get_pointer(tracer_list,'alk'    ,'field',cobalt%p_alk    )
           call g_tracer_get_pointer(tracer_list,'cadet_arag','field',cobalt%p_cadet_arag)
           call g_tracer_get_pointer(tracer_list,'cadet_calc','field',cobalt%p_cadet_calc)
@@ -482,7 +482,7 @@ module COBALT_send_diag
           flux_i(:,:,2:nk+1) = cobalt%p_pdet_fast(:,:,1:nk,tau)*cobalt%Rho_0*cobalt%wsink_fast
           used = g_send_data(cobalt%id_fpdet_fast_i, flux_i, model_time, rmask = grid_tmask, &
             is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk+1)
-		  
+
           flux_i(:,:,2:nk+1) = cobalt%p_sidet(:,:,1:nk,tau)*cobalt%Rho_0*cobalt%wsink
           used = g_send_data(cobalt%id_fsidet_i, flux_i, model_time, rmask = grid_tmask, &
             is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk+1)
@@ -921,7 +921,7 @@ module COBALT_send_diag
           ! Includes only calcite detritus, so concentration will be small relative to total particulate calcite
           used = g_send_data(cobalt%id_calc,  cobalt%p_cadet_calc(:,:,:,tau) * cobalt%Rho_0, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-          ! Includes only aragonite detritus, so concentration will be small relative to total particulate aragonite 
+          ! Includes only aragonite detritus, so concentration will be small relative to total particulate aragonite
           used = g_send_data(cobalt%id_arag,  cobalt%p_cadet_arag(:,:,:,tau) * cobalt%Rho_0, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_phydiat, (cobalt%nlg_diatoms+cobalt%nmd_diatoms)*cobalt%c_2_n*cobalt%Rho_0, &
@@ -966,7 +966,7 @@ module COBALT_send_diag
           ! Chlorophyll: CMIP asks for in kg Chl m-3
           used = g_send_data(cobalt%id_chl_cmip, cobalt%f_chl * cobalt%Rho_0 / 1.0e9, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
-          ! Chlorophyll for other phytoplankton groups derived from biomass and Chl:C ratios 
+          ! Chlorophyll for other phytoplankton groups derived from biomass and Chl:C ratios
           used = g_send_data(cobalt%id_chldiat, (phyto(LARGE)%theta * cobalt%nlg_diatoms + &
             phyto(MEDIUM)%theta * cobalt%nmd_diatoms) * cobalt%c_2_n * cobalt%Rho_0 * 12.0e-3, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
@@ -1052,9 +1052,9 @@ module COBALT_send_diag
             is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_expp_tp, (cobalt%p_pdet(:,:,:,tau)*cobalt%wsink + &
             cobalt%p_pdet_fast(:,:,:,tau)*cobalt%wsink_fast + &
-            cobalt%p_psm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + cobalt%p_pmd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + & 
-            cobalt%p_plg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + cobalt%p_pdi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:)) * & 
-            cobalt%Rho_0*grid_tmask(:,:,:), model_time, rmask = grid_tmask, & 
+            cobalt%p_psm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + cobalt%p_pmd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
+            cobalt%p_plg(:,:,:,tau)*phyto(LARGE)%vmove(:,:,:) + cobalt%p_pdi(:,:,:,tau)*phyto(DIAZO)%vmove(:,:,:)) * &
+            cobalt%Rho_0*grid_tmask(:,:,:), model_time, rmask = grid_tmask, &
             is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_expfe_tp, (cobalt%p_fedet(:,:,:,tau)*cobalt%wsink + &
             cobalt%p_fesm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + cobalt%p_femd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
@@ -1087,7 +1087,7 @@ module COBALT_send_diag
           used = g_send_data(cobalt%id_expcob, flux_i(:,:,nk+1), model_time, rmask = grid_tmask(:,:,nk), &
             is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_froc, flux_i(:,:,nk+1), model_time, rmask = grid_tmask(:,:,nk), &
-            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec) 
+            is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           flux_i(:,:,2:nk+1) = (cobalt%p_ndet(:,:,:,tau)*cobalt%wsink + &
             cobalt%p_ndet_fast(:,:,:,tau)*cobalt%wsink_fast + &
             cobalt%p_nsm(:,:,:,tau)*phyto(SMALL)%vmove(:,:,:) + cobalt%p_nmd(:,:,:,tau)*phyto(MEDIUM)%vmove(:,:,:) + &
@@ -1118,7 +1118,7 @@ module COBALT_send_diag
           used = g_send_data(cobalt%id_expfeob, flux_i(:,:,nk+1), model_time, rmask = grid_tmask(:,:,nk), &
             is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
           ! Iron loss to the sediments; minus_tendency_of_ocean_mole_content_of_iron_due_to_sedimentation
-          ! Interpreting this as the outward rather than net flux because fsfe contains sediment dissolution 
+          ! Interpreting this as the outward rather than net flux because fsfe contains sediment dissolution
           used = g_send_data(cobalt%id_frfe, flux_i(:,:,nk+1), &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           flux_i(:,:,2:nk+1) = (cobalt%p_sidet(:,:,:,tau)*cobalt%wsink + &
@@ -1199,7 +1199,7 @@ module COBALT_send_diag
             model_time, rmask = grid_tmask(:,:,1),is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_sios,  cobalt%p_sio4(:,:,1,tau) * cobalt%Rho_0, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          ! Native units of f_chl are micrograms Chl kg-1 (i.e., ug Chl kg-1); CMIP requests kgChl m-3, so:   
+          ! Native units of f_chl are micrograms Chl kg-1 (i.e., ug Chl kg-1); CMIP requests kgChl m-3, so:
           ! ug kg-1 * kg m-3 / 1.0e9 ug kg-1 = kg Chl m-3
           used = g_send_data(cobalt%id_chlos,  cobalt%f_chl(:,:,1) * cobalt%Rho_0 / 1.0e9, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
@@ -1965,6 +1965,8 @@ module COBALT_send_diag
           !
           used = g_send_data(cobalt%id_jalk, cobalt%jalk, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jalkh, cobalt%jalkh, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jalk_plus_btm, cobalt%jalk_plus_btm, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jdiss_cadet_arag_plus_btm, cobalt%jdiss_cadet_arag_plus_btm, &
@@ -1992,6 +1994,8 @@ module COBALT_send_diag
           used = g_send_data(cobalt%id_jo2_plus_btm, cobalt%jo2_plus_btm, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jo2, cobalt%jo2, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jo2h, cobalt%jo2h, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
 
           !
@@ -2057,7 +2061,7 @@ module COBALT_send_diag
           !
           allocate( field_2d(isd:ied,jsd:jed) )
           ! biomass-weighted diatom nitrogen limitation (contributions from medium and large)
-          field_2d(:,:) = & 
+          field_2d(:,:) = &
             ( phyto(MEDIUM)%nlim_bw_100(:,:)*phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
               phyto(LARGE)%nlim_bw_100(:,:)*phyto(LARGE)%silim_bw_100(:,:)*phyto(LARGE)%f_n_100(:,:) ) / &
             max(epsln, phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
@@ -2119,7 +2123,7 @@ module COBALT_send_diag
               (1.0 - phyto(LARGE)%silim_bw_100(:,:))*phyto(LARGE)%f_n_100(:,:) )
           used = g_send_data(cobalt%id_limfemisc, field_2d,  &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          
+
           ! biomass-weighted diatom phosphorus limitation (contributions from medium and large)
           field_2d(:,:) = &
             ( phyto(MEDIUM)%plim_bw_100(:,:)*phyto(MEDIUM)%silim_bw_100(:,:)*phyto(MEDIUM)%f_n_100(:,:) + &
@@ -2143,7 +2147,7 @@ module COBALT_send_diag
           deallocate(field_2d)
 
           ! Switched to full water column to be consistent with latest CMIP diagnostics and ensure all NPP is captured
-          ! For primary production, included the standard CMIP breakdown by functional type (diatom, diazotroph, 
+          ! For primary production, included the standard CMIP breakdown by functional type (diatom, diazotroph,
           ! picophyto and misc) and a breakdown strictly by size classes (pico, nano, micro) for FISH-MIP
           ! Total = diat + diaz + pico + misc (standard CMIP)
           ! Total = pico + nano + micro (by size class)
@@ -2183,7 +2187,7 @@ module COBALT_send_diag
           used = g_send_data(cobalt%id_icfriver,  cobalt%runoff_flux_dic + cobalt%fcased_redis + &
             cobalt%fcadet_arag_btm + (cobalt%fntot_btm - cobalt%fn_burial)*cobalt%c_2_n, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-          ! tendency_of_ocean_mole_content_of_organic_carbon_due_to_runoff_and_sediment_dissolution 
+          ! tendency_of_ocean_mole_content_of_organic_carbon_due_to_runoff_and_sediment_dissolution
           used = g_send_data(cobalt%id_ocfriver, cobalt%c_2_n* &
             (cobalt%runoff_flux_ldon+cobalt%runoff_flux_sldon+cobalt%runoff_flux_srdon), &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
@@ -2196,9 +2200,9 @@ module COBALT_send_diag
             cobalt%runoff_flux_srdon + cobalt%wc_vert_int_nfix + cobalt%fntot_btm - cobalt%fn_burial, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
           ! Tendency_of_ocean_mole_content_of_iron_due_to_deposition_and_runoff_and_sediment_dissolution
-          ! included iceberg and geothermal sources to get the full budget 
+          ! included iceberg and geothermal sources to get the full budget
           used = g_send_data(cobalt%id_fsfe,  cobalt%runoff_flux_fed + cobalt%dry_fed + cobalt%wet_fed + &
-            cobalt%ffe_sed+cobalt%ffe_geotherm+cobalt%wc_vert_int_jfe_iceberg, model_time, rmask = grid_tmask(:,:,1), & 
+            cobalt%ffe_sed+cobalt%ffe_geotherm+cobalt%wc_vert_int_jfe_iceberg, model_time, rmask = grid_tmask(:,:,1), &
             is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
 
 ! 2016/08/15 - we will not be providing these fields
@@ -2315,7 +2319,7 @@ module COBALT_send_diag
         used = g_send_data(cobalt%id_irr_sfc_dms,  cobalt%irr_sfc_dms,   &
         model_time, rmask = grid_tmask(:,:,1),&
         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)
-        
+
         used = g_send_data(cobalt%id_chl_dmsp,  cobalt%chl_dmsp,   &
         model_time, rmask = grid_tmask(:,:,1),&
         is_in=isc, js_in=jsc, ie_in=iec, je_in=jec)

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -1975,17 +1975,29 @@ module COBALT_send_diag
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jdic, cobalt%jdic, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jdich, cobalt%jdich, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jno3, cobalt%jno3, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jno3h, cobalt%jno3h, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jpo4, cobalt%jpo4, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jpo4h, cobalt%jpo4h, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jsio4, cobalt%jsio4, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jsio4h, cobalt%jsio4h, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jdic_plus_btm, cobalt%jdic_plus_btm, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jnh4, cobalt%jnh4, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jnh4h, cobalt%jnh4h, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jndet, cobalt%jndet, &
+            model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
+          used = g_send_data(cobalt%id_jndeth, cobalt%jndeth, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)
           used = g_send_data(cobalt%id_jndet_fast, cobalt%jndet_fast, &
             model_time, rmask = grid_tmask, is_in=isc, js_in=jsc, ks_in=1,ie_in=iec, je_in=jec, ke_in=nk)

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -660,6 +660,7 @@ module cobalt_types
           jcadet_arag,&
           jcadet_calc,&
           jdic,&
+          jdich,&
           jdic_plus_btm,&
           jdin_plus_btm,&
           jfed,&
@@ -678,10 +679,13 @@ module cobalt_types
           jlith,&
           jlithdet,&
           jndet,&
+          jndeth,&
           jndet_fast,&
           jnh4,&
+          jnh4h,&
           jnh4_plus_btm,&
           jno3,&
+          jno3h,&
           jno3_plus_btm,&
           jo2,&
           jo2h,&
@@ -689,6 +693,7 @@ module cobalt_types
           jpdet,&
           jpdet_fast,&
           jpo4,&
+          jpo4h,&
           jpo4_plus_btm,&
           jsrdon,&
           jsrdop,&
@@ -698,6 +703,7 @@ module cobalt_types
           jsimd,&
           jsilg,&
           jsio4,&
+          jsio4h,&
           jsio4_plus_btm,&
           jprod_ndet,&
           jprod_ndet_fast,&
@@ -1091,12 +1097,18 @@ module cobalt_types
           id_jalkh         = -1,       &
           id_jalk_plus_btm = -1,       &
           id_jdic          = -1,       &
+          id_jdich         = -1,       &
           id_jdic_plus_btm = -1,       &
           id_jnh4          = -1,       &
+          id_jnh4h         = -1,       &
           id_jno3          = -1,       &
+          id_jno3h         = -1,       &
           id_jpo4          = -1,       &
+          id_jpo4h         = -1,       &
           id_jsio4         = -1,       &
+          id_jsio4h        = -1,       &
           id_jndet         = -1,       &
+          id_jndeth        = -1,       &
           id_jndet_fast    = -1,       &
           id_jnh4_plus_btm = -1,       &
           id_jno3denit_wc  = -1,       &

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -655,6 +655,7 @@ module cobalt_types
           jnmdz,&
           jnlgz,&
           jalk,&
+          jalkh,&
           jalk_plus_btm,&
           jcadet_arag,&
           jcadet_calc,&
@@ -683,6 +684,7 @@ module cobalt_types
           jno3,&
           jno3_plus_btm,&
           jo2,&
+          jo2h,&
           jo2_plus_btm,&
           jpdet,&
           jpdet_fast,&
@@ -923,7 +925,7 @@ module cobalt_types
           wc_vert_int_jo2resp,&
           wc_vert_int_jprod_cadet,&
           wc_vert_int_jprod_cadet_arag,&
-          wc_vert_int_jprod_cadet_calc,& 
+          wc_vert_int_jprod_cadet_calc,&
           wc_vert_int_jno3denit,&
           wc_vert_int_jprod_no3nitrif,&
           wc_vert_int_juptake_nh4,&
@@ -1086,6 +1088,7 @@ module cobalt_types
           id_irr_mix       = -1,       &
           id_irr_aclm_inst = -1,       &
           id_jalk          = -1,       &
+          id_jalkh         = -1,       &
           id_jalk_plus_btm = -1,       &
           id_jdic          = -1,       &
           id_jdic_plus_btm = -1,       &
@@ -1328,6 +1331,7 @@ module cobalt_types
           id_f_sio4_int_100 = -1, &
           id_jo2_plus_btm   = -1, &
           id_jo2            = -1, &
+          id_jo2h           = -1, &
           id_jalk_100       = -1, &
           id_jdic_100       = -1, &
           id_jdin_100       = -1, &

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -5762,6 +5762,7 @@ contains
                              phyto(LARGE)%juptake_no3(i,j,k) - phyto(MEDIUM)%juptake_no3(i,j,k) - &
                              phyto(SMALL)%juptake_no3(i,j,k) - &
                              cobalt%jno3denit_wc(i,j,k) - cobalt%juptake_no3amx(i,j,k)
+       cobalt%jno3h(i,j,k) = cobalt%jno3(i,j,k) * dzt(i,j,k)
        cobalt%p_no3(i,j,k,tau) = cobalt%p_no3(i,j,k,tau) + &
                (cobalt%jno3(i,j,k)+cobalt%jno3_iceberg(i,j,k))*dt*grid_tmask(i,j,k)
     enddo; enddo ; enddo  !} i,j,k
@@ -5776,6 +5777,7 @@ contains
                             phyto(LARGE)%juptake_nh4(i,j,k) - phyto(MEDIUM)%juptake_nh4(i,j,k) - &
                             phyto(SMALL)%juptake_nh4(i,j,k) - &
                             cobalt%juptake_nh4nitrif(i,j,k) - cobalt%juptake_nh4amx(i,j,k)
+       cobalt%jnh4h(i,j,k) = cobalt%jnh4(i,j,k) * dzt(i,j,k)
        cobalt%p_nh4(i,j,k,tau) = cobalt%p_nh4(i,j,k,tau) + cobalt%jnh4(i,j,k) * dt * grid_tmask(i,j,k)
        !
        ! PO4
@@ -5783,6 +5785,7 @@ contains
        cobalt%jpo4(i,j,k) = cobalt%jprod_po4(i,j,k) - phyto(DIAZO)%juptake_po4(i,j,k) - &
                             phyto(LARGE)%juptake_po4(i,j,k) - phyto(MEDIUM)%juptake_po4(i,j,k) - &
                             phyto(SMALL)%juptake_po4(i,j,k)
+       cobalt%jpo4h(i,j,k) = cobalt%jpo4(i,j,k) * dzt(i,j,k)
        cobalt%p_po4(i,j,k,tau) = cobalt%p_po4(i,j,k,tau) + &
               (cobalt%jpo4(i,j,k)+cobalt%jpo4_iceberg(i,j,k)) * dt * grid_tmask(i,j,k)
        !
@@ -5790,6 +5793,7 @@ contains
        !
        cobalt%jsio4(i,j,k) = cobalt%jprod_sio4(i,j,k) - phyto(LARGE)%juptake_sio4(i,j,k) - &
                              phyto(MEDIUM)%juptake_sio4(i,j,k)
+       cobalt%jsio4h(i,j,k) = cobalt%jsio4(i,j,k) * dzt(i,j,k)
        cobalt%p_sio4(i,j,k,tau) = cobalt%p_sio4(i,j,k,tau) + cobalt%jsio4(i,j,k) * dt * grid_tmask(i,j,k)
     enddo; enddo ; enddo  !} i,j,k
 
@@ -5834,6 +5838,7 @@ contains
        cobalt%jndet(i,j,k) = cobalt%jprod_ndet(i,j,k) - cobalt%jremin_ndet(i,j,k) - &
                              cobalt%det_jzloss_n(i,j,k) - cobalt%det_jhploss_n(i,j,k)
        cobalt%jndet_fast(i,j,k) = cobalt%jprod_ndet_fast(i,j,k) - cobalt%jremin_ndet_fast(i,j,k)
+       cobalt%jndeth(i,j,k) = cobalt%jndet(i,j,k) * dzt(i,j,k)
        cobalt%p_ndet(i,j,k,tau) = cobalt%p_ndet(i,j,k,tau) + cobalt%jndet(i,j,k)*dt*grid_tmask(i,j,k)
        cobalt%p_ndet_fast(i,j,k,tau) = cobalt%p_ndet_fast(i,j,k,tau) + cobalt%jndet_fast(i,j,k)*dt*grid_tmask(i,j,k)
        !
@@ -5963,7 +5968,7 @@ contains
           cobalt%jdiss_cadet_arag(i,j,k) + cobalt%jdiss_cadet_calc(i,j,k) - &
           cobalt%jprod_cadet_arag(i,j,k) - cobalt%jprod_cadet_calc(i,j,k) - &
           cobalt%jdic_caco3_nerbur(i,j,k))
-
+       cobalt%jdich(i,j,k) = cobalt%jdic(i,j,k) * dzt(i,j,k)
        cobalt%p_dic(i,j,k,tau) = cobalt%p_dic(i,j,k,tau) + cobalt%jdic(i,j,k) * dt * grid_tmask(i,j,k)
     enddo; enddo ; enddo !} i,j,k
 !
@@ -7614,6 +7619,7 @@ contains
     allocate(cobalt%jcadet_arag(isd:ied, jsd:jed, 1:nk))  ; cobalt%jcadet_arag=0.0
     allocate(cobalt%jcadet_calc(isd:ied, jsd:jed, 1:nk))  ; cobalt%jcadet_calc=0.0
     allocate(cobalt%jdic(isd:ied, jsd:jed, 1:nk))         ; cobalt%jdic=0.0
+    allocate(cobalt%jdich(isd:ied, jsd:jed, 1:nk))        ; cobalt%jdich=0.0
     allocate(cobalt%jdic_plus_btm(isd:ied, jsd:jed, 1:nk)); cobalt%jdic_plus_btm=0.0
     allocate(cobalt%jdin_plus_btm(isd:ied, jsd:jed, 1:nk)); cobalt%jdin_plus_btm=0.0
     allocate(cobalt%jfed(isd:ied, jsd:jed, 1:nk))         ; cobalt%jfed=0.0
@@ -7628,17 +7634,21 @@ contains
     allocate(cobalt%jlith(isd:ied, jsd:jed, 1:nk))        ; cobalt%jlith=0.0
     allocate(cobalt%jlithdet(isd:ied, jsd:jed, 1:nk))     ; cobalt%jlithdet=0.0
     allocate(cobalt%jndet(isd:ied, jsd:jed, 1:nk))        ; cobalt%jndet=0.0
+    allocate(cobalt%jndeth(isd:ied, jsd:jed, 1:nk))       ; cobalt%jndeth=0.0
     allocate(cobalt%jndet_fast(isd:ied, jsd:jed, 1:nk))   ; cobalt%jndet_fast=0.0
     allocate(cobalt%jnh4(isd:ied, jsd:jed, 1:nk))         ; cobalt%jnh4=0.0
+    allocate(cobalt%jnh4h(isd:ied, jsd:jed, 1:nk))        ; cobalt%jnh4h=0.0
     allocate(cobalt%jnh4_plus_btm(isd:ied, jsd:jed, 1:nk)); cobalt%jnh4_plus_btm=0.0
     allocate(cobalt%jno3(isd:ied, jsd:jed, 1:nk))         ; cobalt%jno3=0.0
+    allocate(cobalt%jno3h(isd:ied, jsd:jed, 1:nk))        ; cobalt%jno3h=0.0
     allocate(cobalt%jno3_plus_btm(isd:ied, jsd:jed, 1:nk)); cobalt%jno3_plus_btm=0.0
     allocate(cobalt%jo2(isd:ied, jsd:jed, 1:nk))          ; cobalt%jo2=0.0
-    allocate(cobalt%jo2h(isd:ied, jsd:jed, 1:nk))          ; cobalt%jo2h=0.0
+    allocate(cobalt%jo2h(isd:ied, jsd:jed, 1:nk))         ; cobalt%jo2h=0.0
     allocate(cobalt%jo2_plus_btm(isd:ied, jsd:jed, 1:nk)) ; cobalt%jo2_plus_btm=0.0
     allocate(cobalt%jpdet(isd:ied, jsd:jed, 1:nk))        ; cobalt%jpdet=0.0
     allocate(cobalt%jpdet_fast(isd:ied, jsd:jed, 1:nk))   ; cobalt%jpdet_fast=0.0
     allocate(cobalt%jpo4(isd:ied, jsd:jed, 1:nk))         ; cobalt%jpo4=0.0
+    allocate(cobalt%jpo4h(isd:ied, jsd:jed, 1:nk))        ; cobalt%jpo4h=0.0
     allocate(cobalt%jpo4_plus_btm(isd:ied, jsd:jed, 1:nk)); cobalt%jpo4_plus_btm=0.0
     allocate(cobalt%jsrdon(isd:ied, jsd:jed, 1:nk))       ; cobalt%jsrdon=0.0
     allocate(cobalt%jsrdop(isd:ied, jsd:jed, 1:nk))       ; cobalt%jsrdop=0.0
@@ -7648,6 +7658,7 @@ contains
     allocate(cobalt%jsilg(isd:ied, jsd:jed, 1:nk))        ; cobalt%jsilg=0.0
     allocate(cobalt%jsimd(isd:ied, jsd:jed, 1:nk))        ; cobalt%jsimd=0.0
     allocate(cobalt%jsio4(isd:ied, jsd:jed, 1:nk))        ; cobalt%jsio4=0.0
+    allocate(cobalt%jsio4h(isd:ied, jsd:jed, 1:nk))        ; cobalt%jsio4h=0.0
     allocate(cobalt%jsio4_plus_btm(isd:ied, jsd:jed, 1:nk)); cobalt%jsio4_plus_btm=0.0
     allocate(cobalt%jprod_fed(isd:ied, jsd:jed, 1:nk))    ; cobalt%jprod_fed=0.0
     allocate(cobalt%jprod_fedet(isd:ied, jsd:jed, 1:nk))  ; cobalt%jprod_fedet=0.0
@@ -8209,6 +8220,7 @@ contains
     deallocate(cobalt%jcadet_arag)
     deallocate(cobalt%jcadet_calc)
     deallocate(cobalt%jdic)
+    deallocate(cobalt%jdich)
     deallocate(cobalt%jdic_plus_btm)
     deallocate(cobalt%jdin_plus_btm)
     deallocate(cobalt%jfed)
@@ -8223,10 +8235,13 @@ contains
     deallocate(cobalt%jlith)
     deallocate(cobalt%jlithdet)
     deallocate(cobalt%jndet)
+    deallocate(cobalt%jndeth)
     deallocate(cobalt%jndet_fast)
     deallocate(cobalt%jnh4)
+    deallocate(cobalt%jnh4h)
     deallocate(cobalt%jnh4_plus_btm)
     deallocate(cobalt%jno3)
+    deallocate(cobalt%jno3h)
     deallocate(cobalt%jno3_plus_btm)
     deallocate(cobalt%jo2)
     deallocate(cobalt%jo2h)
@@ -8234,6 +8249,7 @@ contains
     deallocate(cobalt%jpdet)
     deallocate(cobalt%jpdet_fast)
     deallocate(cobalt%jpo4)
+    deallocate(cobalt%jpo4h)
     deallocate(cobalt%jpo4_plus_btm)
     deallocate(cobalt%jsrdon)
     deallocate(cobalt%jsrdop)
@@ -8243,6 +8259,7 @@ contains
     deallocate(cobalt%jsilg)
     deallocate(cobalt%jsimd)
     deallocate(cobalt%jsio4)
+    deallocate(cobalt%jsio4h)
     deallocate(cobalt%jsio4_plus_btm)
     deallocate(cobalt%jprod_ndet)
     deallocate(cobalt%jprod_ndet_fast)

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -47,7 +47,7 @@
 !  improve seasonal dynamics.
 !
 !  COBALTv3 now includes 42 prognostic state variables:
-!  
+!
 !       alk: alkalinity
 !       cadet_arag: calcium carbonate detritus (aragonite)
 !       cadet_calc: calcium carbonate detritus (calcite)
@@ -74,10 +74,10 @@
 !       o2: oxygen
 !       pdet: phosphorous detritus
 !       pdet_fast: fast-sinking phosphorous detritus
-!       pdi: diazotroph phosphorus 
-!       plg: large phytoplankton phosphorus 
-!       pmd: medium phytoplankton phosphorus 
-!       psm: small phytoplankton phosphorus 
+!       pdi: diazotroph phosphorus
+!       plg: large phytoplankton phosphorus
+!       pmd: medium phytoplankton phosphorus
+!       psm: small phytoplankton phosphorus
 !       po4: phosphate
 !       srdon: semi-refractory dissolved organic nitrogen
 !       srdop: semi-refractory dissolved organic phosphorous
@@ -1483,22 +1483,22 @@ contains
     ! Burial rates are based on O'Mara & Dunne (2019) and affect alkalinity and DIC at a 2:1 ratio.
     ! The burial flux is vertically distributed evenly over the top 150m of the water column.
     ! This is not exactly 150 m, but extends down to the model layer that includes the 150m depth.
-    ! The impact of neritic burial is distributed over 150m to account for the limited ability of global models 
-    ! to resolve coastal bathymetry. In high-resolution regional models, a better approach is to apply the burial 
+    ! The impact of neritic burial is distributed over 150m to account for the limited ability of global models
+    ! to resolve coastal bathymetry. In high-resolution regional models, a better approach is to apply the burial
     ! effect directly to the bottom boundary condition via b_alk and b_dic.
     ! The spatial pattern is prescribed, while the magnitude is temporally constant.
-    ! If the logical flag "do_resp_ca_diss" is set to true, respiration-driven CaCO3 dissolution 
+    ! If the logical flag "do_resp_ca_diss" is set to true, respiration-driven CaCO3 dissolution
     ! due to localized undersaturation around sinking particles is activated.
-    ! This is parameterized as a fixed ratio of organic matter remineralization, targeting enhanced 
+    ! This is parameterized as a fixed ratio of organic matter remineralization, targeting enhanced
     ! CaCO3 dissolution in the upper ocean (e.g., ≤300 m; Kwon et al., 2024).
-    ! The ratio is chosen to yield a global CaCO3 flux of ~0.75 Pg-C yr-1 at 300 m, consistent with 
-    ! Sulpis et al. (2021), who estimated 0.9 ± 0.15 Pg-C yr-1.   
+    ! The ratio is chosen to yield a global CaCO3 flux of ~0.75 Pg-C yr-1 at 300 m, consistent with
+    ! Sulpis et al. (2021), who estimated 0.9 ± 0.15 Pg-C yr-1.
     !
     ! O'Mara and Dunne, 2019; https://www.nature.com/articles/s41598-019-41064-w
     ! Kwon et al., 2024; https://www.science.org/doi/10.1126/sciadv.adl0779
-    ! Sulpis et al., 2021; https://www.nature.com/articles/s41561-021-00743-y  
+    ! Sulpis et al., 2021; https://www.nature.com/articles/s41561-021-00743-y
     call get_param(param_file, "generic_COBALT", "do_ner_ca_bur", cobalt%do_ner_ca_bur, &
-            "logical flag to include neritic CaCO3 burial", default=.false.) 
+            "logical flag to include neritic CaCO3 burial", default=.false.)
     call get_param(param_file, "generic_COBALT", "do_resp_ca_diss", cobalt%do_resp_ca_diss, &
             "logical flag to include CaCO3 dissolution due to undersaturation around sinking particles", default=.false.)
     ! >>
@@ -1510,7 +1510,7 @@ contains
     call get_param(param_file, "generic_COBALT", "resp_ca_2_n_calc", cobalt%resp_ca_2_n_calc, &
                    "ratio of calcite dissolution to organic matter remineralization (respiration-driven)", &
                    units="kg (mol N)-1", default = 0.0, scale = c2n)
-    ! >>          
+    ! >>
 
     ! Organic matter remineralization: Oxygen and temperature dependence follows Laufkotter et al. (2017).
     call get_param(param_file, "generic_COBALT", "k_o2", cobalt%k_o2, "O2 half-saturation for remineralization", &
@@ -1523,16 +1523,16 @@ contains
                    "Temperature dependence of remineralization", units="deg C-1", default=0.063)
     call get_param(param_file, "generic_COBALT", "remin_ramp_scale", cobalt%remin_ramp_scale, &
                    "depth scale from the surface over which remineralization ramps up", units="m", default= 50.0)
-    ! gamma_ndet is set to produce a e-folding length scale for fresh (unprotected) organic matter of ~190m at ~10 deg. C, 
-    ! consistent with the Martin curve. The value has been defined as a function of the sinking rate for "standard detritus 
-    ! (i.e., zooplankton fecal pellets/phytoplankton aggregates) so that the remineralization length-scale is preserved even 
-    ! if the sinking rate changed. Once established, gamma_ndet is also used for fast sinking detritus 
-    ! (i.e., unprotected organic matter is assumed to decay at similar rates regardless of whether it sinking slowly or quickly). 
-    ! This means that the ratio of the remineralization length-scale for unprotected fast sinking detritus relative to that for 
+    ! gamma_ndet is set to produce a e-folding length scale for fresh (unprotected) organic matter of ~190m at ~10 deg. C,
+    ! consistent with the Martin curve. The value has been defined as a function of the sinking rate for "standard detritus
+    ! (i.e., zooplankton fecal pellets/phytoplankton aggregates) so that the remineralization length-scale is preserved even
+    ! if the sinking rate changed. Once established, gamma_ndet is also used for fast sinking detritus
+    ! (i.e., unprotected organic matter is assumed to decay at similar rates regardless of whether it sinking slowly or quickly).
+    ! This means that the ratio of the remineralization length-scale for unprotected fast sinking detritus relative to that for
     ! unprotected standard detritus equal the ratio of their sinking speeds (wsink_fast/wsink).
     call get_param(param_file, "generic_COBALT", "gamma_ndet", cobalt%gamma_ndet, &
                    "Remineralization rate for unprotected organic matter", units="s-1", default=cobalt%wsink/350.0)
-    ! mineral ballasting after Klaas and Archer (2002) and Dunne et al. (2007) (see p. 3) 
+    ! mineral ballasting after Klaas and Archer (2002) and Dunne et al. (2007) (see p. 3)
     ! conversion is 0.070 g C (g Ca)-1 to moles N (mole Ca)-1; Similar conversions below, but lith remains per gram
     call get_param(param_file, "generic_COBALT", "rpcaco3", cobalt%rpcaco3, "Organic matter protection from CaCO3", &
                    units="mol N mol Ca-1", default= 0.070/12.0*16.0/106.0*100.0)
@@ -3133,7 +3133,7 @@ contains
     integer :: k_150
     real, dimension(:,:), Allocatable :: rho_dzt_150
     real, dimension(:,:,:), Allocatable :: thickness_ratio_150
-    ! >> 
+    ! >>
     real,dimension(1:NUM_ZOO,1:NUM_PREY) :: ipa_matrix,pa_matrix,ingest_matrix
     real,dimension(1:NUM_PREY) :: hp_ipa_vec,hp_pa_vec,hp_ingest_vec
     real,dimension(1:NUM_PREY) :: prey_vec,prey_p2n_vec,prey_fe2n_vec,prey_si2n_vec
@@ -3645,7 +3645,7 @@ contains
        tmp_irrad_aclm = 0.0  ! integrates the irradiance in the surface photoacclimation layer
        tmp_zaclm = 0.0       ! tracks depth of top of the curent layer photoacclimation layer calcs
        do n = 1,NUM_PHYTO
-         ! Tracks the temp*nutrient limitation of light-saturated photosynthesis in the mixed layer 
+         ! Tracks the temp*nutrient limitation of light-saturated photosynthesis in the mixed layer
          phyto(n)%tmp_pcmlim_aclm_ML = 0.0
        enddo
        ! Define the irradiance threshold for a "deep" mixed layer for photoacclimation
@@ -3947,7 +3947,7 @@ contains
        cobalt%nlg_misc(i,j,k)=phyto(LARGE)%f_n(i,j,k) - phyto(LARGE)%f_n(i,j,k)*phyto(LARGE)%silim(i,j,k)
        cobalt%nmd_misc(i,j,k)=phyto(MEDIUM)%f_n(i,j,k) - phyto(MEDIUM)%f_n(i,j,k)*phyto(MEDIUM)%silim(i,j,k)
 
-	   ! silim present in here twice first to find the fraction of nitrogen uptake attributed to diatoms, 
+	   ! silim present in here twice first to find the fraction of nitrogen uptake attributed to diatoms,
 	   ! and then to scale the Si:N ratio of that uptake
        phyto(LARGE)%juptake_sio4(i,j,k) = &
              max(phyto(LARGE)%juptake_no3(i,j,k)+phyto(LARGE)%juptake_nh4(i,j,k),0.0)*phyto(LARGE)%silim(i,j,k)* &
@@ -4048,7 +4048,7 @@ contains
        ! anaerobic remineralization.
        bact(1)%o2lim(i,j,k) = max(cobalt%f_o2(i,j,k),cobalt%o2_min)/  &
                               (cobalt%k_o2 + max(cobalt%f_o2(i,j,k),cobalt%o2_min))
-       ! Note that nitrate availability affects the anaerobic remineralization of dissolved organic material 
+       ! Note that nitrate availability affects the anaerobic remineralization of dissolved organic material
        ! as that of particulate organic material
        if (cobalt%f_o2(i,j,k) .gt. cobalt%o2_min) then !{
           bact(1)%no3lim(i,j,k) = 1.0
@@ -4528,7 +4528,7 @@ contains
                    phyto(n)%f_n(i,j,k)/(cobalt%refuge_conc + phyto(n)%f_n(i,j,k))
             phyto(n)%jmortloss_p(i,j,k) = phyto(n)%jmortloss_n(i,j,k)*phyto(n)%q_p_2_n(i,j,k)
             phyto(n)%jmortloss_fe(i,j,k) = phyto(n)%jmortloss_n(i,j,k)*phyto(n)%q_fe_2_n(i,j,k)
-            ! silica dissolution from phytoplankton mortality is also multiplied by a scaling factor that 
+            ! silica dissolution from phytoplankton mortality is also multiplied by a scaling factor that
             ! determines the amount of silica test left over as the phytoplankton dies
             phyto(n)%jdissloss_si(i,j,k) = phyto(n)%jdissloss_si(i,j,k) + &
                     phyto(n)%phi_sidiss_mort*phyto(n)%jmortloss_n(i,j,k)*phyto(n)%q_si_2_n(i,j,k)
@@ -4641,7 +4641,7 @@ contains
            zoo(m)%jprod_srdop(i,j,k) = zoo(m)%phi_srdop*zoo(m)%jingest_p(i,j,k)
            zoo(m)%jprod_fedet(i,j,k) = zoo(m)%phi_det*zoo(m)%jingest_fe(i,j,k)
            zoo(m)%jprod_sidet(i,j,k) = zoo(m)%phi_det_si*zoo(m)%jingest_sio2(i,j,k)
-		   
+
            ! augment cumulative production variables for detritus and dissolved organics
            cobalt%jprod_ndet(i,j,k) = cobalt%jprod_ndet(i,j,k) + zoo(m)%jprod_ndet(i,j,k)
            cobalt%jprod_pdet(i,j,k) = cobalt%jprod_pdet(i,j,k) + zoo(m)%jprod_pdet(i,j,k)
@@ -4873,7 +4873,7 @@ contains
         ! data_override is intended to replace internal model fields with externally specified data
         call data_override('OCN', 'neritic_cased_burial', neritic_cased_burial(isc:iec,jsc:jec), model_time,override=neritic_override)
         ! Set up vertical redistribution based on local depth structure
-        ! Calculate number of layers covering the top 150m and depth ratios across these layers        
+        ! Calculate number of layers covering the top 150m and depth ratios across these layers
         allocate(rho_dzt_150(isc:iec,jsc:jec))
         allocate(thickness_ratio_150(isc:iec,jsc:jec,1:nk)); thickness_ratio_150 = 0.0
 
@@ -4894,7 +4894,7 @@ contains
            else
               cobalt%jdic_caco3_nerbur(i,j,1:nk) = 0.0
            endif
-        enddo ; enddo  !} i,j 
+        enddo ; enddo  !} i,j
     else
         ! No neritic burial: set jdic_caco3_nerbur to zero to maintain consistency in carbon and alkalinity budgets
         cobalt%jdic_caco3_nerbur = 0.0
@@ -5005,7 +5005,7 @@ contains
           ! Adding in the remineralization from fast sinking detritus
           cobalt%jremin_ndet_fast(i,j,k) = cobalt%gamma_ndet * cobalt%f_ndet_fast(i,j,k) * &
                (cobalt%o2_min / (cobalt%k_o2 + cobalt%o2_min)) * &
-               (cobalt%f_no3(i,j,k) / (cobalt%k_no3_denit + cobalt%f_no3(i,j,k))) 
+               (cobalt%f_no3(i,j,k) / (cobalt%k_no3_denit + cobalt%f_no3(i,j,k)))
           ! Augment total nh4 production and no3 consumption
           cobalt%jno3denit_wc(i,j,k) = cobalt%jno3denit_wc(i,j,k) + &
 		       (cobalt%jremin_ndet(i,j,k) + cobalt%jremin_ndet_fast(i,j,k)) * cobalt%n_2_n_denit
@@ -5028,13 +5028,13 @@ contains
        cobalt%jremin_fedet(i,j,k) = (cobalt%jremin_ndet(i,j,k) + cobalt%jremin_ndet_fast(i,j,k)) * &
          (cobalt%k_o2 + max(cobalt%f_o2(i,j,k),cobalt%o2_min))/max(cobalt%f_o2(i,j,k),cobalt%o2_min) / &
          (cobalt%f_ndet(i,j,k) + cobalt%f_ndet_fast(i,j,k) + epsln) * cobalt%remin_eff_fedet*cobalt%f_fedet(i,j,k)
-		 
+
        cobalt%jprod_fed(i,j,k) = cobalt%jprod_fed(i,j,k) + cobalt%jremin_fedet(i,j,k)
     enddo; enddo; enddo  !} i,j,k
 
     ! << Enhanced CaCO3 dissolution driven by localized undersaturation around sinking particles >>
     ! Add CaCO3 dissolution enhancement associated with organic matter (OM) decomposition
-    ! 
+    !
     ! This routine applies a fixed ratio between POC remineralization and additional CaCO3 dissolution
     if (cobalt%do_resp_ca_diss) then
         do k=1,nk ; do j=jsc,jec ; do i=isc,iec  !{
@@ -5045,10 +5045,10 @@ contains
                                             cobalt%resp_ca_2_n_calc * cobalt%f_cadet_calc(i,j,k) * &
                                             cobalt%jremin_ndet(i,j,k)
         enddo; enddo; enddo  !} i,j,k
-    endif     
-    ! >> 
+    endif
+    ! >>
 
-    ! 
+    !
     ! 4.5: Iron scavenging onto detritus
     !
     ! COBALT uses a single ligand complexation model for iron scavenging onto detritus (e.g., Archer and Johnson, 2000).
@@ -5157,7 +5157,7 @@ contains
 
     do j = jsc, jec; do i = isc, iec  !{
        if (grid_kmt(i,j) .gt. 0) then !{
-		   
+
           ! Add the phytoplankton fluxes to the detritus fluxes to get total flux to benthos
           cobalt%fntot_btm(i,j) = cobalt%f_ndet_btf(i,j,1) + cobalt%f_ndet_fast_btf(i,j,1) + cobalt%f_ndi_btf(i,j,1) + &
             cobalt%f_nsm_btf(i,j,1) + cobalt%f_nmd_btf(i,j,1) + cobalt%f_nlg_btf(i,j,1)
@@ -5549,7 +5549,7 @@ contains
          ! << Apply neritic CaCO3 burial contribution to net carbon source/sink term
          ! This term is zero when neritic burial is turned off (default: jdic_caco3_nerbur = 0.0)
          net_srcc(i,j,k) = -cobalt%jdic_caco3_nerbur(i,j,k) *dt*grid_tmask(i,j,k)
-         ! >>         
+         ! >>
          pre_totc(i,j,k) = (cobalt%p_dic(i,j,k,tau) + &
                     cobalt%p_cadet_arag(i,j,k,tau) + cobalt%p_cadet_calc(i,j,k,tau) + &
                     cobalt%c_2_n*(cobalt%p_ndi(i,j,k,tau) + cobalt%p_nlg(i,j,k,tau) + &
@@ -5842,7 +5842,7 @@ contains
        cobalt%jpdet(i,j,k) = cobalt%jprod_pdet(i,j,k) - cobalt%jremin_pdet(i,j,k) - &
                              cobalt%det_jzloss_p(i,j,k) - cobalt%det_jhploss_p(i,j,k)
        cobalt%jpdet_fast(i,j,k) = cobalt%jprod_pdet_fast(i,j,k) - cobalt%jremin_pdet_fast(i,j,k)
-       cobalt%p_pdet(i,j,k,tau) = cobalt%p_pdet(i,j,k,tau) + cobalt%jpdet(i,j,k)*dt*grid_tmask(i,j,k)	   
+       cobalt%p_pdet(i,j,k,tau) = cobalt%p_pdet(i,j,k,tau) + cobalt%jpdet(i,j,k)*dt*grid_tmask(i,j,k)
        cobalt%p_pdet_fast(i,j,k,tau) = cobalt%p_pdet_fast(i,j,k,tau) + cobalt%jpdet_fast(i,j,k)*dt*grid_tmask(i,j,k)
        !
        ! Sidet
@@ -5921,6 +5921,7 @@ contains
             phyto(MEDIUM)%juptake_nh4(i,j,k) + phyto(SMALL)%juptake_nh4(i,j,k)) + &
             cobalt%o2_2_nfix*phyto(DIAZO)%juptake_n2(i,j,k)) * grid_tmask(i,j,k)
        cobalt%jo2(i,j,k) = cobalt%jo2(i,j,k) - cobalt%jo2resp_wc(i,j,k)
+       cobalt%jo2h(i,j,k) = cobalt%jo2(i,j,k) * dzt(i,j,k)
        cobalt%p_o2(i,j,k,tau) = cobalt%p_o2(i,j,k,tau) + cobalt%jo2(i,j,k) * dt * grid_tmask(i,j,k)
     enddo; enddo ; enddo  !} i,j,k
     !
@@ -5934,7 +5935,7 @@ contains
        !      matter remineralization
        !
        ! << Apply neritic CaCO3 burial contribution
-       ! This term is zero when neritic burial is turned off (default: jdic_caco3_nerbur = 0.0) >>       
+       ! This term is zero when neritic burial is turned off (default: jdic_caco3_nerbur = 0.0) >>
        cobalt%jalk(i,j,k) = 2.0 * (cobalt%jdiss_cadet_arag(i,j,k) +        &
           cobalt%jdiss_cadet_calc(i,j,k) - cobalt%jprod_cadet_arag(i,j,k) - &
           cobalt%jprod_cadet_calc(i,j,k) - cobalt%jdic_caco3_nerbur(i,j,k)) + &
@@ -5947,6 +5948,7 @@ contains
           phyto(MEDIUM)%juptake_nh4(i,j,k) - &
           phyto(SMALL)%juptake_nh4(i,j,k) - 2.0 * cobalt%juptake_nh4nitrif(i,j,k)
 
+       cobalt%jalkh(i,j,k) = cobalt%jalk(i,j,k) * dzt(i,j,k)
        cobalt%p_alk(i,j,k,tau) = cobalt%p_alk(i,j,k,tau) + cobalt%jalk(i,j,k) * dt * grid_tmask(i,j,k)
        !
        ! Dissolved Inorganic Carbon
@@ -6363,14 +6365,14 @@ contains
        cobalt%wc_vert_int_alk(i,j) = 0.0
        ! Fluxes
        cobalt%wc_vert_int_npp(i,j) = 0.0              ! wc integrated net primary production
-       ! Include breakdowns by functional group and by size to support CMIP7/FISH-MIP 
+       ! Include breakdowns by functional group and by size to support CMIP7/FISH-MIP
        cobalt%wc_vert_int_npp_diat(i,j) = 0.0         ! wc integrated net primary production, diatoms
        cobalt%wc_vert_int_npp_diaz(i,j) = 0.0         ! wc integrated net primary production, diazotrophs
        cobalt%wc_vert_int_npp_misc(i,j) = 0.0         ! wc integrated net primary production, misc
        cobalt%wc_vert_int_npp_pico(i,j) = 0.0         ! wc integrated net primary production, picophytoplankton
-       cobalt%wc_vert_int_npp_nano(i,j) = 0.0         ! wc integrated net primary production, nanophytoplankton 
-       cobalt%wc_vert_int_npp_micro(i,j) = 0.0        ! wc integrated net primary production, microphytoplankton 
-       cobalt%wc_vert_int_jdiss_sidet(i,j) = 0.0      ! wc integrated dissolution of silica detritus     
+       cobalt%wc_vert_int_npp_nano(i,j) = 0.0         ! wc integrated net primary production, nanophytoplankton
+       cobalt%wc_vert_int_npp_micro(i,j) = 0.0        ! wc integrated net primary production, microphytoplankton
+       cobalt%wc_vert_int_jdiss_sidet(i,j) = 0.0      ! wc integrated dissolution of silica detritus
        cobalt%wc_vert_int_jdiss_cadet(i,j) = 0.0      ! wc integrated dissolution of calcite detritus
        cobalt%wc_vert_int_jo2resp(i,j) = 0.0          ! wc integrated oxygen consumption
        cobalt%wc_vert_int_jprod_cadet(i,j) = 0.0      ! wc integrated production of calcite detritus
@@ -6877,7 +6879,7 @@ contains
         endif
     enddo; enddo  !} i, j
     deallocate(rho_dzt_100)
-    
+
     do j = jsc, jec ; do i = isc, iec ; !{
       if (grid_kmt(i,j) .gt. 0) then !{
          cobalt%cased_2d(i,j) = cobalt%f_cased(i,j,1)
@@ -6938,7 +6940,7 @@ contains
              cobalt%jdic_caco3_nerbur_150(i,j) = cobalt%jdic_caco3_nerbur_150(i,j) + &
                                                  cobalt%jdic_caco3_nerbur(i,j,k) * rho_dzt(i,j,k)
           enddo  !} k
-       enddo ; enddo  !} i,j 
+       enddo ; enddo  !} i,j
     else
        ! No neritic burial: set integral to zero
        cobalt%jdic_caco3_nerbur_150 = 0.0
@@ -7563,7 +7565,7 @@ contains
     allocate(cobalt%co3_sol_arag(isd:ied, jsd:jed, 1:nk)) ; cobalt%co3_sol_arag=0.0
     allocate(cobalt%co3_sol_calc(isd:ied, jsd:jed, 1:nk)) ; cobalt%co3_sol_calc=0.0
     allocate(cobalt%f_chl(isd:ied, jsd:jed, 1:nk))        ; cobalt%f_chl=0.0
-    allocate(cobalt%f_nh3(isd:ied, jsd:jed, 1:nk))        ; cobalt%f_nh3=0.0    
+    allocate(cobalt%f_nh3(isd:ied, jsd:jed, 1:nk))        ; cobalt%f_nh3=0.0
     allocate(cobalt%f_co3_ion(isd:ied, jsd:jed, 1:nk))    ; cobalt%f_co3_ion=0.0
     allocate(cobalt%f_htotal(isd:ied, jsd:jed, 1:nk))     ; cobalt%f_htotal=0.0
     allocate(cobalt%f_irr_aclm(isd:ied, jsd:jed, 1:nk))    ; cobalt%f_irr_aclm=0.0
@@ -7607,6 +7609,7 @@ contains
     allocate(cobalt%jnmdz(isd:ied, jsd:jed, 1:nk))        ; cobalt%jnmdz=0.0
     allocate(cobalt%jnlgz(isd:ied, jsd:jed, 1:nk))        ; cobalt%jnlgz=0.0
     allocate(cobalt%jalk(isd:ied, jsd:jed, 1:nk))         ; cobalt%jalk=0.0
+    allocate(cobalt%jalkh(isd:ied, jsd:jed, 1:nk))        ; cobalt%jalkh=0.0
     allocate(cobalt%jalk_plus_btm(isd:ied, jsd:jed, 1:nk)); cobalt%jalk_plus_btm=0.0
     allocate(cobalt%jcadet_arag(isd:ied, jsd:jed, 1:nk))  ; cobalt%jcadet_arag=0.0
     allocate(cobalt%jcadet_calc(isd:ied, jsd:jed, 1:nk))  ; cobalt%jcadet_calc=0.0
@@ -7631,6 +7634,7 @@ contains
     allocate(cobalt%jno3(isd:ied, jsd:jed, 1:nk))         ; cobalt%jno3=0.0
     allocate(cobalt%jno3_plus_btm(isd:ied, jsd:jed, 1:nk)); cobalt%jno3_plus_btm=0.0
     allocate(cobalt%jo2(isd:ied, jsd:jed, 1:nk))          ; cobalt%jo2=0.0
+    allocate(cobalt%jo2h(isd:ied, jsd:jed, 1:nk))          ; cobalt%jo2h=0.0
     allocate(cobalt%jo2_plus_btm(isd:ied, jsd:jed, 1:nk)) ; cobalt%jo2_plus_btm=0.0
     allocate(cobalt%jpdet(isd:ied, jsd:jed, 1:nk))        ; cobalt%jpdet=0.0
     allocate(cobalt%jpdet_fast(isd:ied, jsd:jed, 1:nk))   ; cobalt%jpdet_fast=0.0
@@ -7665,7 +7669,7 @@ contains
     ! << Always allocate 3-D neritic CaCO3 burial production field
     ! Needed for DIC and alkalinity budgets even if burial is disabled (set to zero if do_ner_ca_bur = .false.)
     allocate(cobalt%jdic_caco3_nerbur(isd:ied, jsd:jed, 1:nk)); cobalt%jdic_caco3_nerbur=0.0
-    ! >>  
+    ! >>
     allocate(cobalt%jprod_nh4(isd:ied, jsd:jed, 1:nk))    ; cobalt%jprod_nh4=0.0
     allocate(cobalt%jprod_nh4_plus_btm(isd:ied, jsd:jed, 1:nk))    ; cobalt%jprod_nh4_plus_btm=0.0
     allocate(cobalt%jprod_po4(isd:ied, jsd:jed, 1:nk))    ; cobalt%jprod_po4=0.0
@@ -8200,6 +8204,7 @@ contains
     deallocate(cobalt%jnmdz)
     deallocate(cobalt%jnlgz)
     deallocate(cobalt%jalk)
+    deallocate(cobalt%jalkh)
     deallocate(cobalt%jalk_plus_btm)
     deallocate(cobalt%jcadet_arag)
     deallocate(cobalt%jcadet_calc)
@@ -8224,6 +8229,7 @@ contains
     deallocate(cobalt%jno3)
     deallocate(cobalt%jno3_plus_btm)
     deallocate(cobalt%jo2)
+    deallocate(cobalt%jo2h)
     deallocate(cobalt%jo2_plus_btm)
     deallocate(cobalt%jpdet)
     deallocate(cobalt%jpdet_fast)
@@ -8255,9 +8261,9 @@ contains
     deallocate(cobalt%jprod_lithdet)
     deallocate(cobalt%jprod_cadet_arag)
     deallocate(cobalt%jprod_cadet_calc)
-    ! << Deallocate variables for neritic CaCO3 burial 
+    ! << Deallocate variables for neritic CaCO3 burial
     deallocate(cobalt%jdic_caco3_nerbur)
-    ! >>     
+    ! >>
     deallocate(cobalt%jprod_nh4)
     deallocate(cobalt%jprod_nh4_plus_btm)
     deallocate(cobalt%jprod_po4)


### PR DESCRIPTION
This PR adds back diagnostic terms for content (concentration * thickness) change due to processes in COBALT as suggested in #158 

There are 8 new diagnostics: jno3h, jnh4h, jpo4h, jsio4h, jndeth, jdich, jalkh, and jo2h. All of these are just the pre-existing concentration terms times the thickness. 

Having the exact thickness being used during the model step is helpful for accurately calculating the budget. Here, I multiply by the thickness that COBALT is seeing (dzt) to ensure it is correct. 

With these diagnostics, the tendency (for oxygen, as an example) is
`o2h_tendency = o2_advection_xy + o2h_tendency_vert_remap + o2_diffusion_xy + o2_vdiffuse_impl + jo2h`

My text editor cleared out a bunch of trailing whitespaces, so the changes in this PR should be viewed with whitespace changes ignored. 