### PR TITLE
Remove do_vertfill_pre

### DIFF
--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -26,7 +26,6 @@ module cobalt_types
   logical, public :: do_14c             = .false.            !< If true, then simulate radiocarbon
   logical, public :: do_nh3_atm_ocean_exchange = .false.     ! If true, then do NH3 air-sea exchange
   !
-  logical, public :: do_vertfill_pre = .false.
   logical, public :: debug           = .false.             !< not use
   real, public    :: imbalance_tolerance=1.0e-10           !< the tolerance for non-conservation in C,N,P,Sc,Fe
 

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -182,7 +182,7 @@ module generic_COBALT
                                              !! in generic_COBALT_nml.
 
   namelist /generic_COBALT_nml/ co2_calc, do_14c, do_nh3_atm_ocean_exchange, scheme_nitrif, debug, &
-     do_vertfill_pre,imbalance_tolerance,as_param_cobalt
+     imbalance_tolerance,as_param_cobalt
 
   !
   ! Array allocations and flux calculations assume that phyto(1) is the
@@ -3180,19 +3180,6 @@ contains
     integer :: stdoutunit, imbal_flag, outunit
     type(g_tracer_type), pointer :: g_tracer,g_tracer_next
     real :: KD_SMOOTH = 1.0E-05
-
-    if(do_vertfill_pre) then
-      g_tracer => tracer_list
-      do
-       if(g_tracer_is_prog(g_tracer)) then
-         call g_tracer_vertfill(g_tracer, dzt, KD_SMOOTH*dt, tau=1)
-       endif
-       !traverse the linked list till hit NULL
-       call g_tracer_get_next(g_tracer, g_tracer_next)
-       if(.NOT. associated(g_tracer_next)) exit
-       g_tracer=>g_tracer_next
-      enddo
-    endif
 
     r_dt = 1.0 / dt
 


### PR DESCRIPTION
Follows up on #168 by removing the namelist option do_vertfill_pre and the logic to apply vertfill when it is true. I'm not aware of any configurations that use this option, and enabling it would break the budget diagnostics. 