### PR TITLE
Remove unused EOS subroutines

### DIFF
--- a/generic_tracers/MOM_generic_tracer.F90
+++ b/generic_tracers/MOM_generic_tracer.F90
@@ -33,9 +33,8 @@ use MOM_ALE_sponge, only : set_up_ALE_sponge_field, ALE_sponge_CS
 use MOM_ALE_sponge, only : ALE_sponge_CS, initialize_ALE_sponge
 use MOM_coms, only : EFP_type, max_across_PEs, min_across_PEs, PE_here
 use MOM_diagnose_mld,  only : diagnoseMLDbyDensityDifference, diagnoseMLDbyEnergy
-use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr
 use MOM_diag_mediator, only : diag_ctrl, get_diag_time_end
-use MOM_error_handler, only : MOM_error, FATAL, WARNING, NOTE, is_root_pe
+use MOM_error_handler, only : MOM_error, FATAL, WARNING, NOTE
 use MOM_file_parser, only : get_param, log_param, log_version, param_file_type
 use MOM_forcing_type, only : forcing, optics_type
 use MOM_grid, only : ocean_grid_type
@@ -47,9 +46,9 @@ use MOM_open_boundary, only : register_obgc_segments, fill_obgc_segments
 use MOM_open_boundary, only : set_obgc_segments_props
 use MOM_restart, only : register_restart_field, query_initialized, set_initialized, MOM_restart_CS
 use MOM_spatial_means, only : global_area_mean, global_mass_int_EFP, array_global_min_max
-use MOM_sponge, only : set_up_sponge_field, sponge_CS
+use MOM_sponge, only : sponge_CS
 use MOM_time_manager, only : time_type, set_time
-use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut
+use MOM_tracer_diabatic, only : applyTracerBoundaryFluxesInOut
 use MOM_tracer_registry, only : register_tracer, tracer_registry_type
 use MOM_tracer_Z_init, only : tracer_Z_init
 use MOM_tracer_initialization_from_Z, only : MOM_initialize_tracer_from_Z

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -138,7 +138,6 @@ module generic_COBALT
   use data_override_mod, only: data_override
   use fms_mod,           only: write_version_number, FATAL, WARNING, stdout, stdlog,mpp_pe,mpp_root_pe
   use fms_mod,           only: check_nml_error
-  use MOM_EOS,           only: calculate_density, EOS_type
 
   use g_tracer_utils, only : g_tracer_type,g_tracer_start_param_list,g_tracer_end_param_list
   use g_tracer_utils, only : g_tracer_add,g_tracer_add_param, g_tracer_set_files

--- a/generic_tracers/generic_tracer.F90
+++ b/generic_tracers/generic_tracer.F90
@@ -105,7 +105,6 @@ module generic_tracer
   use generic_COBALT,  only : generic_COBALT_set_boundary_values, generic_COBALT_end, do_generic_COBALT
   use generic_COBALT,  only : as_param_cobalt
 
-  use MOM_EOS,         only: EOS_type
 
   implicit none ; private
 


### PR DESCRIPTION
Short cleanup PR that simply removes unused EOS imports from `generic_Cobalt.F90` and `generic_tracer.F90` so that COBALT has fewer dependencies on MOM. This will hopefully prevent either of these files from recompiling when there are changes in MOM affecting MOM_EOS.F90. 

As a side note, there are other imports in `MOM_generic_tracers.F90` that don't appear to be used either. I did not include them in this PR since they are all parts of modules that are used, so removing them probably won't help prevent recompiles, but I thought I'd mention it anyways; 
```
use MOM_coms, only : EFP_type, max_across_PEs, min_across_PEs, PE_here ! last three unused
use MOM_diagnose_mld,  only : diagnoseMLDbyDensityDifference, diagnoseMLDbyEnergy ! last one unused
use MOM_diag_mediator, only : post_data, register_diag_field, safe_alloc_ptr ! none used
use MOM_diag_mediator, only : diag_ctrl, get_diag_time_end
use MOM_error_handler, only : MOM_error, FATAL, WARNING, NOTE, is_root_pe ! last unused
...
use MOM_sponge, only : set_up_sponge_field, sponge_CS ! first unused
use MOM_time_manager, only : time_type, set_time
use MOM_tracer_diabatic, only : tracer_vertdiff, applyTracerBoundaryFluxesInOut ! first unused
```