### PR TITLE
Switch testing to Ubuntu 2024_04 container 

### DIFF
--- a/.github/workflows/cobalt_ci.yml
+++ b/.github/workflows/cobalt_ci.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     # define container
     container:
-       image: ghcr.io/noaa-gfdl/cefi-regional-mom6/1d_mom6_cobalt:base
+       image: ghcr.io/noaa-gfdl/cefi-regional-mom6/1d_mom6_cobalt:2024_04
        options: --user=builder
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/.github/workflows/cobalt_ci.yml
+++ b/.github/workflows/cobalt_ci.yml
@@ -88,15 +88,15 @@ jobs:
           ncwa -a xh,yh o2_col_budget.nc -O o2_col_budget.nc
           # Check residual for surface layer
           ncks -d zl,0 o2_col_budget.nc o2_sfc_budget.nc
-          resid=$( ncap2 -s 'result = o2h_tendency -
+          resid=$( ncap2 -O -s 'result = o2h_tendency -
               (o2_advection_xy + o2h_tendency_vert_remap + o2_vdiffuse_impl + o2_diffusion_xy + jo2h);
-              print(result)' o2_sfc_budget.nc |  awk -F'=' '{print $2}')
+              print(result)' o2_sfc_budget.nc ncap2_tmp.nc |  awk -F'=' '{print $2}')
           python3 check_residual.py $resid
           # Check residual for column total
           ncwa -y ttl -a zl o2_col_budget.nc o2_tot_budget.nc
-          resid=$( ncap2 -s 'result = o2h_tendency -
+          resid=$( ncap2 -O -s 'result = o2h_tendency -
               (o2_advection_xy + o2h_tendency_vert_remap + o2_vdiffuse_impl + o2_diffusion_xy + jo2h);
-              print(result)' o2_tot_budget.nc |  awk -F'=' '{print $2}')
+              print(result)' o2_tot_budget.nc ncap2_tmp.nc |  awk -F'=' '{print $2}')
           python3 check_residual.py $resid
 
       - name: Check alkalinity budget closure
@@ -109,15 +109,15 @@ jobs:
           ncwa -a xh,yh alk_col_budget.nc -O alk_col_budget.nc
           # Check residual for surface layer
           ncks -d zl,0 alk_col_budget.nc alk_sfc_budget.nc
-          resid=$( ncap2 -s 'result = alkh_tendency -
+          resid=$( ncap2 -O -s 'result = alkh_tendency -
               (alk_advection_xy + alkh_tendency_vert_remap + alk_vdiffuse_impl + alk_diffusion_xy + jalkh);
-              print(result)' alk_sfc_budget.nc |  awk -F'=' '{print $2}')
+              print(result)' alk_sfc_budget.nc ncap2_temp.nc |  awk -F'=' '{print $2}')
           python3 check_residual.py $resid
           # Check residual for column total
           ncwa -y ttl -a zl alk_col_budget.nc alk_tot_budget.nc
-          resid=$( ncap2 -s 'result = alkh_tendency -
+          resid=$( ncap2 -O -s 'result = alkh_tendency -
               (alk_advection_xy + alkh_tendency_vert_remap + alk_vdiffuse_impl + alk_diffusion_xy + jalkh);
-              print(result)' alk_tot_budget.nc |  awk -F'=' '{print $2}')
+              print(result)' alk_tot_budget.nc ncap2_temp.nc |  awk -F'=' '{print $2}')
           python3 check_residual.py $resid
 
       - name: Check nitrate budget closure
@@ -130,13 +130,13 @@ jobs:
           ncwa -a xh,yh no3_col_budget.nc -O no3_col_budget.nc
           # Check residual for surface layer
           ncks -d zl,0 no3_col_budget.nc no3_sfc_budget.nc
-          resid=$( ncap2 -s 'result = no3h_tendency -
+          resid=$( ncap2 -O -s 'result = no3h_tendency -
               (no3_advection_xy + no3h_tendency_vert_remap + no3_vdiffuse_impl + no3_diffusion_xy + jno3h);
-              print(result)' no3_sfc_budget.nc |  awk -F'=' '{print $2}')
+              print(result)' no3_sfc_budget.nc ncap2_temp.nc |  awk -F'=' '{print $2}')
           python3 check_residual.py $resid
           # Check residual for column total
           ncwa -y ttl -a zl no3_col_budget.nc no3_tot_budget.nc
-          resid=$( ncap2 -s 'result = no3h_tendency -
+          resid=$( ncap2 -O -s 'result = no3h_tendency -
               (no3_advection_xy + no3h_tendency_vert_remap + no3_vdiffuse_impl + no3_diffusion_xy + jno3h);
-              print(result)' no3_tot_budget.nc |  awk -F'=' '{print $2}')
+              print(result)' no3_tot_budget.nc ncap2_temp.nc |  awk -F'=' '{print $2}')
           python3 check_residual.py $resid


### PR DESCRIPTION
This PR changes the tag in the ci workflow to use the Ubuntu 2024_04 container to get around a gfortran 11 issue ( which is the default used by the base Ubuntu 22.02 containe) revealed by NOAA-GFDL/CEFI-regional-MOM6#280