### PR TITLE
Simplify bottom layer diagnostics routines into one new, small module

### DIFF
--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -296,8 +296,6 @@ module COBALT_send_diag
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
 
           ! Calculate bottom averaged diagnostics.
-          ! Note that averages for btm_o2, btm_no3, btm_co3_ion, and btm_co3_sol_calc
-          ! were already calculated in generic_COBALT_update_from_source.
           call generic_bld_average(cobalt%bld, cobalt%p_alk(:,:,:,tau), cobalt%btm_alk)
           call generic_bld_average(cobalt%bld, cobalt%p_dic(:,:,:,tau), cobalt%btm_dic)
           call generic_bld_average(cobalt%bld, Temp(:,:,:), cobalt%btm_temp)
@@ -311,6 +309,12 @@ module COBALT_send_diag
             call generic_bld_average(cobalt%bld, cobalt%f_co3_ion, cobalt%btm_co3_ion)
             call generic_bld_average(cobalt%bld, cobalt%co3_sol_calc, cobalt%btm_co3_sol_calc)
           endif
+
+          ! btm_o2 and btm_no3 were calculated during the update from source, 
+          ! but we always need to recalculate them here because their fields are changed
+          ! later in that routine.
+          call generic_bld_average(cobalt%bld, cobalt%p_o2(:,:,:,tau), cobalt%btm_o2)
+          call generic_bld_average(cobalt%bld, cobalt%p_no3(:,:,:,tau), cobalt%btm_no3)
 
           do j = jsc, jec ; do i = isc, iec
             cobalt%btm_omega_calc(i,j) = 0.0

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -50,7 +50,6 @@ module COBALT_send_diag
       real :: drho_dzt
       real, dimension(:,:,:) ,pointer :: grid_tmask
       integer, dimension(:,:),pointer :: mask_coast,grid_kmt
-      integer, dimension(:,:), Allocatable :: k_bot
       real, dimension(:,:), Allocatable :: rho_dzt_100,rho_dzt_200
       integer :: k_100,k_200
       real, dimension(:,:), Allocatable :: field_2d !used to calculate some 2d fields before saving

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -20,6 +20,7 @@ module COBALT_send_diag
 
   use g_tracer_utils, only : g_send_data,g_tracer_get_pointer,g_tracer_set_values
   use g_tracer_utils, only : g_tracer_type, g_tracer_get_common
+  use generic_bottom_layer_diags, only : generic_bld, generic_bld_average
   use FMS_co2calc_mod, only : FMS_co2calc, CO2_dope_vector
 
   implicit none; private
@@ -50,7 +51,7 @@ module COBALT_send_diag
       real, dimension(:,:,:) ,pointer :: grid_tmask
       integer, dimension(:,:),pointer :: mask_coast,grid_kmt
       integer, dimension(:,:), Allocatable :: k_bot
-      real, dimension(:,:), Allocatable :: rho_dzt_100,rho_dzt_200,rho_dzt_bot
+      real, dimension(:,:), Allocatable :: rho_dzt_100,rho_dzt_200
       integer :: k_100,k_200
       real, dimension(:,:), Allocatable :: field_2d !used to calculate some 2d fields before saving
       real, dimension(:,:,:), Allocatable :: flux_i !used to save fluxes at the interfaces
@@ -187,6 +188,9 @@ module COBALT_send_diag
               cobalt%nmd_misc(i,j,k)=phyto(MEDIUM)%f_n(i,j,k) - phyto(MEDIUM)%f_n(i,j,k)*phyto(MEDIUM)%silim(i,j,k)
             enddo; enddo ; enddo !} i,j,k
 
+            call generic_bld_average(cobalt%bld, cobalt%f_co3_ion, cobalt%btm_co3_ion)
+            call generic_bld_average(cobalt%bld, cobalt%co3_sol_calc, cobalt%btm_co3_sol_calc)
+
           endif !} recalculate carbon system properties
 
           used = g_send_data(cobalt%id_co3_sol_arag, cobalt%co3_sol_arag, &
@@ -295,73 +299,29 @@ module COBALT_send_diag
           used = g_send_data(cobalt%id_sfc_co3_sol_calc, cobalt%co3_sol_calc(:,:,1),  &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
 
-          ! Calculate bottom layer values over a thickness defined by cobalt%bottom_thickness
-          ! rather than the bottom-most layer as in MOM4/5.  This avoids numerical issues
-          ! generated in "vanishing" layers that overlie the benthos in most regions.
-          allocate(rho_dzt_bot(isc:iec,jsc:jec))
-          allocate(k_bot(isc:iec,jsc:jec))
-          do j = jsc, jec ; do i = isc, iec  !{
-            rho_dzt_bot(i,j) = 0.0
-            cobalt%btm_temp(i,j) = 0.0
-            cobalt%btm_o2(i,j) = 0.0
-            cobalt%btm_dic(i,j) = 0.0
-            cobalt%btm_alk(i,j) = 0.0
-            cobalt%btm_htotal(i,j) = 0.0
-            cobalt%btm_co3_sol_arag(i,j) = 0.0
-            cobalt%btm_co3_sol_calc(i,j) = 0.0
-            cobalt%btm_co3_ion(i,j) = 0.0
+          call generic_bld_average(cobalt%bld, cobalt%p_o2(:,:,:,tau), cobalt%btm_o2)
+          call generic_bld_average(cobalt%bld, cobalt%p_alk(:,:,:,tau), cobalt%btm_alk)
+          call generic_bld_average(cobalt%bld, cobalt%p_dic(:,:,:,tau), cobalt%btm_dic)
+          call generic_bld_average(cobalt%bld, Temp(:,:,:), cobalt%btm_temp)
+          call generic_bld_average(cobalt%bld, cobalt%f_htotal(:,:,:), cobalt%btm_htotal)
+          call generic_bld_average(cobalt%bld, cobalt%co3_sol_arag(:,:,:), cobalt%btm_co3_sol_arag)
+
+          do j = jsc, jec ; do i = isc, iec
             cobalt%btm_omega_calc(i,j) = 0.0
             cobalt%btm_omega_arag(i,j) = 0.0
-            k_bot(i,j) = 0
             k = grid_kmt(i,j)
-            if (k .gt. 0) then !{
+            if (k .gt. 0) then
               cobalt%grid_kmt_diag(i,j) = float(k)
               cobalt%rho_dzt_kmt_diag(i,j) = rho_dzt(i,j,k)
-              do k = grid_kmt(i,j),1,-1   !{
-                if (rho_dzt_bot(i,j).lt.cobalt%Rho_0*cobalt%bottom_thickness) then
-                  k_bot(i,j) = k
-                  rho_dzt_bot(i,j) = rho_dzt_bot(i,j) + rho_dzt(i,j,k)
-                  cobalt%k_bot_diag(i,j) = grid_kmt(i,j)-float(k)+1.0
-                  cobalt%btm_o2(i,j) = cobalt%btm_o2(i,j) + cobalt%p_o2(i,j,k,tau)*rho_dzt(i,j,k)
-                  cobalt%btm_alk(i,j) = cobalt%btm_alk(i,j) + cobalt%p_alk(i,j,k,tau)*rho_dzt(i,j,k)
-                  cobalt%btm_dic(i,j) = cobalt%btm_dic(i,j) + cobalt%p_dic(i,j,k,tau)*rho_dzt(i,j,k)
-                  cobalt%btm_temp(i,j) = cobalt%btm_temp(i,j) + Temp(i,j,k)*rho_dzt(i,j,k)
-                  cobalt%btm_htotal(i,j) = cobalt%btm_htotal(i,j) + cobalt%f_htotal(i,j,k)*rho_dzt(i,j,k)
-                  cobalt%btm_co3_sol_arag(i,j) = cobalt%btm_co3_sol_arag(i,j) + &
-                    cobalt%co3_sol_arag(i,j,k)*rho_dzt(i,j,k)
-                  cobalt%btm_co3_sol_calc(i,j) = cobalt%btm_co3_sol_calc(i,j) + &
-                    cobalt%co3_sol_calc(i,j,k)*rho_dzt(i,j,k)
-                  cobalt%btm_co3_ion(i,j) = cobalt%btm_co3_ion(i,j) + cobalt%f_co3_ion(i,j,k)*rho_dzt(i,j,k)
-                endif
-              enddo
               ! diagnostic to assess how far up into the water column info is being drawn from
-              cobalt%rho_dzt_bot_diag(i,j) = rho_dzt_bot(i,j)
-              ! calculate overshoot and subtract off
-              drho_dzt = rho_dzt_bot(i,j) - cobalt%Rho_0*cobalt%bottom_thickness
-              cobalt%btm_temp(i,j)=cobalt%btm_temp(i,j)-Temp(i,j,k_bot(i,j))*drho_dzt
-              cobalt%btm_o2(i,j)=cobalt%btm_o2(i,j)-cobalt%p_o2(i,j,k_bot(i,j),tau)*drho_dzt
-              cobalt%btm_alk(i,j)=cobalt%btm_alk(i,j)-cobalt%p_alk(i,j,k_bot(i,j),tau)*drho_dzt
-              cobalt%btm_dic(i,j)=cobalt%btm_dic(i,j)-cobalt%p_dic(i,j,k_bot(i,j),tau)*drho_dzt
-              cobalt%btm_htotal(i,j)=cobalt%btm_htotal(i,j)-cobalt%f_htotal(i,j,k_bot(i,j))*drho_dzt
-              cobalt%btm_co3_sol_arag(i,j)=cobalt%btm_co3_sol_arag(i,j)-cobalt%co3_sol_arag(i,j,k_bot(i,j))*drho_dzt
-              cobalt%btm_co3_sol_calc(i,j)=cobalt%btm_co3_sol_calc(i,j)-cobalt%co3_sol_calc(i,j,k_bot(i,j))*drho_dzt
-              cobalt%btm_co3_ion(i,j)=cobalt%btm_co3_ion(i,j)-cobalt%f_co3_ion(i,j,k_bot(i,j))*drho_dzt
-              ! convert back to moles kg-1
-              cobalt%btm_temp(i,j)=cobalt%btm_temp(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-              cobalt%btm_o2(i,j)=cobalt%btm_o2(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-              cobalt%btm_alk(i,j)=cobalt%btm_alk(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-              cobalt%btm_dic(i,j)=cobalt%btm_dic(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-              cobalt%btm_htotal(i,j)=cobalt%btm_htotal(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-              cobalt%btm_co3_sol_arag(i,j)=cobalt%btm_co3_sol_arag(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-              cobalt%btm_co3_sol_calc(i,j)=cobalt%btm_co3_sol_calc(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-              cobalt%btm_co3_ion(i,j)=cobalt%btm_co3_ion(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-              ! calculate bottom saturation states
+              cobalt%rho_dzt_bot_diag(i,j) = cobalt%bld%rho_dzt_bot(i,j)
+              cobalt%k_bot_diag(i,j) = k - float(cobalt%bld%k_bot(i,j)) + 1.0
+              ! Always recompute omega_calc in case it was changed above
+              ! (when cobalt%recalculate_carbon is .true.)
               cobalt%btm_omega_calc(i,j) = cobalt%btm_co3_ion(i,j)/cobalt%btm_co3_sol_calc(i,j)
               cobalt%btm_omega_arag(i,j) = cobalt%btm_co3_ion(i,j)/cobalt%btm_co3_sol_arag(i,j)
              endif
           enddo; enddo
-          deallocate(rho_dzt_bot)
-          deallocate(k_bot)
 
           ! CALCULATE BOTTOM PROGNOSTIC TRACERS
           used = g_send_data(cobalt%id_btm_temp, cobalt%btm_temp, &

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -295,18 +295,18 @@ module COBALT_send_diag
           used = g_send_data(cobalt%id_sfc_co3_sol_calc, cobalt%co3_sol_calc(:,:,1),  &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
 
-          ! Bottom averaged diagnostics
-
-          call generic_bld_average(cobalt%bld, cobalt%p_o2(:,:,:,tau), cobalt%btm_o2)
+          ! Calculate bottom averaged diagnostics.
+          ! Note that averages for btm_o2, btm_no3, btm_co3_ion, and btm_co3_sol_calc
+          ! were already calculated in generic_COBALT_update_from_source.
           call generic_bld_average(cobalt%bld, cobalt%p_alk(:,:,:,tau), cobalt%btm_alk)
           call generic_bld_average(cobalt%bld, cobalt%p_dic(:,:,:,tau), cobalt%btm_dic)
           call generic_bld_average(cobalt%bld, Temp(:,:,:), cobalt%btm_temp)
           call generic_bld_average(cobalt%bld, cobalt%f_htotal(:,:,:), cobalt%btm_htotal)
           call generic_bld_average(cobalt%bld, cobalt%co3_sol_arag(:,:,:), cobalt%btm_co3_sol_arag)
 
-          ! Averages for btm_co3_ion and btm_co3_sol_calc were already calculated during
-          ! generic_COBALT_update_from_source. If the carbon system has been recalculated above,
-          ! we also need to re-average them.
+          ! Because the averages for btm_co3_ion and btm_co3_sol_calc were already calculated during
+          ! generic_COBALT_update_from_source, we only need to re-average them if the
+          ! carbon system was recalculated above.
           if (cobalt%recalculate_carbon) then
             call generic_bld_average(cobalt%bld, cobalt%f_co3_ion, cobalt%btm_co3_ion)
             call generic_bld_average(cobalt%bld, cobalt%co3_sol_calc, cobalt%btm_co3_sol_calc)

--- a/generic_tracers/cobalt_send_diag.F90
+++ b/generic_tracers/cobalt_send_diag.F90
@@ -187,9 +187,6 @@ module COBALT_send_diag
               cobalt%nmd_misc(i,j,k)=phyto(MEDIUM)%f_n(i,j,k) - phyto(MEDIUM)%f_n(i,j,k)*phyto(MEDIUM)%silim(i,j,k)
             enddo; enddo ; enddo !} i,j,k
 
-            call generic_bld_average(cobalt%bld, cobalt%f_co3_ion, cobalt%btm_co3_ion)
-            call generic_bld_average(cobalt%bld, cobalt%co3_sol_calc, cobalt%btm_co3_sol_calc)
-
           endif !} recalculate carbon system properties
 
           used = g_send_data(cobalt%id_co3_sol_arag, cobalt%co3_sol_arag, &
@@ -298,12 +295,22 @@ module COBALT_send_diag
           used = g_send_data(cobalt%id_sfc_co3_sol_calc, cobalt%co3_sol_calc(:,:,1),  &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
 
+          ! Bottom averaged diagnostics
+
           call generic_bld_average(cobalt%bld, cobalt%p_o2(:,:,:,tau), cobalt%btm_o2)
           call generic_bld_average(cobalt%bld, cobalt%p_alk(:,:,:,tau), cobalt%btm_alk)
           call generic_bld_average(cobalt%bld, cobalt%p_dic(:,:,:,tau), cobalt%btm_dic)
           call generic_bld_average(cobalt%bld, Temp(:,:,:), cobalt%btm_temp)
           call generic_bld_average(cobalt%bld, cobalt%f_htotal(:,:,:), cobalt%btm_htotal)
           call generic_bld_average(cobalt%bld, cobalt%co3_sol_arag(:,:,:), cobalt%btm_co3_sol_arag)
+
+          ! Averages for btm_co3_ion and btm_co3_sol_calc were already calculated during
+          ! generic_COBALT_update_from_source. If the carbon system has been recalculated above,
+          ! we also need to re-average them.
+          if (cobalt%recalculate_carbon) then
+            call generic_bld_average(cobalt%bld, cobalt%f_co3_ion, cobalt%btm_co3_ion)
+            call generic_bld_average(cobalt%bld, cobalt%co3_sol_calc, cobalt%btm_co3_sol_calc)
+          endif
 
           do j = jsc, jec ; do i = isc, iec
             cobalt%btm_omega_calc(i,j) = 0.0
@@ -322,7 +329,7 @@ module COBALT_send_diag
              endif
           enddo; enddo
 
-          ! CALCULATE BOTTOM PROGNOSTIC TRACERS
+          ! Send bottom diagnostics
           used = g_send_data(cobalt%id_btm_temp, cobalt%btm_temp, &
             model_time, rmask = grid_tmask(:,:,1), is_in=isc, js_in=jsc,ie_in=iec, je_in=jec)
           used = g_send_data(cobalt%id_btm_o2, cobalt%btm_o2, &

--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -3,6 +3,7 @@
 !<----------------------------------------------------------------
 module cobalt_types
   use field_manager_mod, only: fm_string_len
+  use generic_bottom_layer_diags, only: generic_bld
   implicit none; private
 
   !
@@ -1023,6 +1024,9 @@ module cobalt_types
      character(len=fm_string_len)          :: file
      character(len=fm_string_len) :: ice_restart_file
      character(len=fm_string_len) :: ocean_restart_file,IC_file
+
+     ! Generic bottom layer diagnostics
+     type(generic_bld) :: bld
 
      integer               ::          &
           id_co3_sol_arag  = -1,       &

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -150,6 +150,9 @@ module generic_COBALT
   use g_tracer_utils, only : g_send_data, is_root_pe
   use g_tracer_utils, only : g_tracer_is_prog, g_tracer_vertfill, g_tracer_get_next
 
+  use generic_bottom_layer_diags, only: generic_bld, generic_bld_alloc, generic_bld_update
+  use generic_bottom_layer_diags, only: generic_bld_average, generic_bld_dealloc
+
   use cobalt_types
   use cobalt_send_diag, only : cobalt_send_diagnostics
   use cobalt_reg_diag, only : cobalt_reg_diagnostics
@@ -3087,7 +3090,8 @@ contains
   !     ilb,jlb,tau,dt,grid_dat,model_time,nbands,max_wavelength_band,sw_pen_band,opacity_band,internal_heat,frunoff)
 
     type(g_tracer_type),            pointer    :: tracer_list
-    real, dimension(ilb:,jlb:,:),   intent(in) :: Temp,Salt,rho_dzt,dzt
+    real, dimension(ilb:,jlb:,:),   intent(in) :: Temp,Salt,dzt
+    real, dimension(ilb:,jlb:,:), target, intent(in) :: rho_dzt
     real, dimension(ilb:,jlb:),     intent(in) :: hblt_depth
     integer,                        intent(in) :: ilb,jlb,tau
     real,                           intent(in) :: dt
@@ -3184,6 +3188,8 @@ contains
 
     call g_tracer_get_common(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau,&
          grid_tmask=grid_tmask,grid_mask_coast=mask_coast,grid_kmt=grid_kmt)
+
+    call generic_bld_update(cobalt%bld, rho_dzt, grid_kmt)
 
     call mpp_clock_begin(id_clock_carbon_calculations)
     !Get necessary fields
@@ -5132,14 +5138,12 @@ contains
        endif !}
     enddo; enddo  !} i,j
 
-    ! Calculate the bottom conditions and the fluxes to the bottom for diagnostics and benthic flux calculations.
-    ! MOM4/5 used the bottom grid cell, but MOM6 often has a number of vanishingly thin layers overlying the bottom.
-    ! Grid scale noise in these layers can occur, particularly for quantities with large bottom fluxes.  COBALT thus
-    ! uses conditions over a specified bottom layer thickness (cobalt%bottom_thickness, default = 1m) for bottom calcs.
-
-    ! Local variables used to determine the layers falling within the bottom thickness
-    allocate(rho_dzt_bot(isc:iec,jsc:jec))
-    allocate(k_bot(isc:iec,jsc:jec))
+    ! The following bottom averages need to be calculated now because they're used in other calculations.
+    ! All other bottom averages should be calculated in cobalt_send_diagnostics.
+    call generic_bld_average(cobalt%bld, cobalt%f_o2, cobalt%btm_o2)
+    call generic_bld_average(cobalt%bld, cobalt%f_no3, cobalt%btm_no3)
+    call generic_bld_average(cobalt%bld, cobalt%f_co3_ion, cobalt%btm_co3_ion)
+    call generic_bld_average(cobalt%bld, cobalt%co3_sol_calc, cobalt%btm_co3_sol_calc)
 
     do j = jsc, jec; do i = isc, iec  !{
        if (grid_kmt(i,j) .gt. 0) then !{
@@ -5154,39 +5158,6 @@ contains
           cobalt%fsitot_btm(i,j) = cobalt%f_sidet_btf(i,j,1) + cobalt%f_silg_btf(i,j,1) + &
             cobalt%f_simd_btf(i,j,1)
 
-          ! Calculate the values of tracers influencing the sedimentary transformations
-          ! and fluxes over a layer defined by "bottom_thickess".
-          rho_dzt_bot(i,j) = 0.0
-          cobalt%btm_o2(i,j) = 0.0
-          cobalt%btm_no3(i,j) = 0.0
-          cobalt%btm_co3_sol_calc(i,j) = 0.0
-          cobalt%btm_co3_ion(i,j) = 0.0
-          cobalt%btm_omega_calc(i,j) = 0.0
-          k_bot(i,j) = 0
-          ! Note that grid_kmt is always the total number of layers in MOM6
-          do k = grid_kmt(i,j),1,-1   !{
-            ! Check if the top of layer k is within the bottom thickness.  If so, include its properties in the bottom
-            ! layer averages.  Overshoots will be subtracted off later.
-            if (rho_dzt_bot(i,j).lt.(cobalt%Rho_0*cobalt%bottom_thickness)) then
-              k_bot(i,j) = k
-              rho_dzt_bot(i,j) = rho_dzt_bot(i,j) + rho_dzt(i,j,k)
-              cobalt%btm_o2(i,j) = cobalt%btm_o2(i,j) + cobalt%f_o2(i,j,k)*rho_dzt(i,j,k)
-              cobalt%btm_no3(i,j) = cobalt%btm_no3(i,j) + cobalt%f_no3(i,j,k)*rho_dzt(i,j,k)
-              cobalt%btm_co3_sol_calc(i,j) = cobalt%btm_co3_sol_calc(i,j) + cobalt%co3_sol_calc(i,j,k)*rho_dzt(i,j,k)
-              cobalt%btm_co3_ion(i,j) = cobalt%btm_co3_ion(i,j) + cobalt%f_co3_ion(i,j,k)*rho_dzt(i,j,k)
-            endif
-          enddo
-          ! Subtract off overshoot
-          drho_dzt = rho_dzt_bot(i,j) - cobalt%Rho_0*cobalt%bottom_thickness
-          cobalt%btm_o2(i,j)=cobalt%btm_o2(i,j)-cobalt%f_o2(i,j,k_bot(i,j))*drho_dzt
-          cobalt%btm_no3(i,j)=cobalt%btm_no3(i,j)-cobalt%f_no3(i,j,k_bot(i,j))*drho_dzt
-          cobalt%btm_co3_sol_calc(i,j)=cobalt%btm_co3_sol_calc(i,j)-cobalt%co3_sol_calc(i,j,k_bot(i,j))*drho_dzt
-          cobalt%btm_co3_ion(i,j)=cobalt%btm_co3_ion(i,j)-cobalt%f_co3_ion(i,j,k_bot(i,j))*drho_dzt
-          ! convert back to moles kg-1
-          cobalt%btm_o2(i,j)=cobalt%btm_o2(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-          cobalt%btm_no3(i,j)=cobalt%btm_no3(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-          cobalt%btm_co3_sol_calc(i,j)=cobalt%btm_co3_sol_calc(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
-          cobalt%btm_co3_ion(i,j)=cobalt%btm_co3_ion(i,j)/(cobalt%bottom_thickness*cobalt%Rho_0)
           ! calculate the saturation state with respect to calcite for subsequent calculations
           cobalt%btm_omega_calc(i,j)=cobalt%btm_co3_ion(i,j)/cobalt%btm_co3_sol_calc(i,j)
 
@@ -5431,8 +5402,6 @@ contains
 
        endif !}
     enddo; enddo  !} i, j
-    deallocate(rho_dzt_bot)
-    deallocate(k_bot)
 
     do k = 2, nk ; do j = jsc, jec ; do i = isc, iec   !{
        cobalt%f_cased(i,j,k) = 0.0
@@ -7391,6 +7360,8 @@ contains
 
     call g_tracer_get_common(isc,iec,jsc,jec,isd,ied,jsd,jed,nk,ntau)
 
+    call generic_bld_alloc(cobalt%bld, isc, iec, jsc, jec, cobalt%Rho_0, cobalt%bottom_thickness)
+
     !Allocate all the private arrays.
 
     !Used in FMS_co2calc
@@ -8009,6 +7980,7 @@ contains
   subroutine user_deallocate_arrays
     integer n
 
+    call generic_bld_dealloc(cobalt%bld)
     deallocate(cobalt%htotalhi,cobalt%htotallo)
 
     do n = 1, NUM_PHYTO

--- a/generic_tracers/generic_bottom_layer_diags.F90
+++ b/generic_tracers/generic_bottom_layer_diags.F90
@@ -63,6 +63,8 @@ module generic_bottom_layer_diags
             if (bld%rho_dzt_bot(i,j).lt.(bld%Rho_0*bld%bottom_thickness)) then
               bld%k_bot(i,j) = k
               bld%rho_dzt_bot(i,j) = bld%rho_dzt_bot(i,j) + bld%rho_dzt(i,j,k)
+            else
+              exit
             endif
           enddo
         endif

--- a/generic_tracers/generic_bottom_layer_diags.F90
+++ b/generic_tracers/generic_bottom_layer_diags.F90
@@ -7,10 +7,10 @@ module generic_bottom_layer_diags
   private
 
   type, public :: generic_bld
-    real, pointer :: rho_dzt(:, :, :) => null()  !< density * dz * dt
-    integer, allocatable :: kmt(:, :)            !< index of the bottom layer, copy of grid_kmt
-    integer, allocatable :: k_bot(:, :)          !< shallowest layer within bottom_thickness
+    real, pointer :: rho_dzt(:, :, :) => null()  !< density * thickness
     real, allocatable :: rho_dzt_bot(:, :)       !< Accumulated mass in bottom layer
+    integer, pointer :: kmt(:, :) => null()      !< Index of the bottom layer
+    integer, allocatable :: k_bot(:, :)          !< Shallowest layer within bottom_thickness
     real :: Rho_0, bottom_thickness
     integer :: isc, iec, jsc, jec
   end type generic_bld
@@ -23,7 +23,6 @@ module generic_bottom_layer_diags
       type(generic_bld), intent(inout) :: bld
       integer, intent(in) :: isc, iec, jsc, jec
       real, intent(in) :: Rho_0, bottom_thickness
-      allocate(bld%kmt(isc:iec, jsc:jec))
       allocate(bld%k_bot(isc:iec, jsc:jec))
       allocate(bld%rho_dzt_bot(isc:iec, jsc:jec))
       bld%isc = isc
@@ -37,7 +36,7 @@ module generic_bottom_layer_diags
     subroutine generic_bld_dealloc(bld)
       type(generic_bld), intent(inout) :: bld
       nullify(bld%rho_dzt)
-      deallocate(bld%kmt)
+      nullify(bld%kmt)
       deallocate(bld%k_bot)
       deallocate(bld%rho_dzt_bot)
     end subroutine generic_bld_dealloc
@@ -47,19 +46,20 @@ module generic_bottom_layer_diags
     subroutine generic_bld_update(bld, rho_dzt, grid_kmt)
       type(generic_bld), intent(inout) :: bld
       real, target :: rho_dzt(:, :, :)
-      integer, intent(in) :: grid_kmt(:, :)
+      integer, target :: grid_kmt(:, :)
       integer :: i, j, k
 
       bld%rho_dzt => rho_dzt
+      bld%kmt => grid_kmt
 
       do j = bld%jsc, bld%jec; do i = bld%isc, bld%iec
-        bld%kmt(i,j) = grid_kmt(i,j)
         bld%k_bot(i,j) = 0
         bld%rho_dzt_bot(i,j) = 0.0
-        if (grid_kmt(i,j) .gt. 0) then
-          do k = grid_kmt(i,j),1,-1
-            ! Check if the top of layer k is within the bottom thickness.  If so, include its properties in the bottom
-            ! layer averages.  Overshoots will be subtracted off later.
+        if (bld%kmt(i,j) .gt. 0) then
+          do k = bld%kmt(i,j),1,-1
+            ! Check if the top of layer k is within the bottom thickness.
+            ! If so, include its properties in the bottom
+            ! layer averages. Overshoots will be subtracted off later.
             if (bld%rho_dzt_bot(i,j).lt.(bld%Rho_0*bld%bottom_thickness)) then
               bld%k_bot(i,j) = k
               bld%rho_dzt_bot(i,j) = bld%rho_dzt_bot(i,j) + bld%rho_dzt(i,j,k)

--- a/generic_tracers/generic_bottom_layer_diags.F90
+++ b/generic_tracers/generic_bottom_layer_diags.F90
@@ -1,0 +1,91 @@
+! The generic_bottom_layer_diags module simplifies the averaging of 3D data
+! over a layer near the bottom topography. The main subroutine is generic_bld_average,
+! which does the actual averaging of the 3D data into a 2D bottom field.
+! The other subroutines allocate and update information about the vertical coordinates.
+module generic_bottom_layer_diags
+  implicit none
+  private
+
+  type, public :: generic_bld
+    real, pointer :: rho_dzt(:, :, :) => null()  !< density * dz * dt
+    integer, allocatable :: kmt(:, :)            !< index of the bottom layer, copy of grid_kmt
+    integer, allocatable :: k_bot(:, :)          !< shallowest layer within bottom_thickness
+    real, allocatable :: rho_dzt_bot(:, :)       !< Accumulated mass in bottom layer
+    real :: Rho_0, bottom_thickness
+    integer :: isc, iec, jsc, jec
+  end type generic_bld
+
+  public generic_bld_alloc, generic_bld_dealloc, generic_bld_update, generic_bld_average
+
+  contains
+
+    subroutine generic_bld_alloc(bld, isc, iec, jsc, jec, Rho_0, bottom_thickness)
+      type(generic_bld), intent(inout) :: bld
+      integer, intent(in) :: isc, iec, jsc, jec
+      real, intent(in) :: Rho_0, bottom_thickness
+      allocate(bld%kmt(isc:iec, jsc:jec))
+      allocate(bld%k_bot(isc:iec, jsc:jec))
+      allocate(bld%rho_dzt_bot(isc:iec, jsc:jec))
+      bld%isc = isc
+      bld%iec = iec
+      bld%jsc = jsc
+      bld%jec = jec
+      bld%Rho_0 = Rho_0
+      bld%bottom_thickness = bottom_thickness
+    end subroutine generic_bld_alloc
+
+    subroutine generic_bld_dealloc(bld)
+      type(generic_bld), intent(inout) :: bld
+      nullify(bld%rho_dzt)
+      deallocate(bld%kmt)
+      deallocate(bld%k_bot)
+      deallocate(bld%rho_dzt_bot)
+    end subroutine generic_bld_dealloc
+
+    !> Update layer information needed for bottom averaging.
+    !! Should be called at beginning of time step.
+    subroutine generic_bld_update(bld, rho_dzt, grid_kmt)
+      type(generic_bld), intent(inout) :: bld
+      real, target :: rho_dzt(:, :, :)
+      integer, intent(in) :: grid_kmt(:, :)
+      integer :: i, j, k
+
+      bld%rho_dzt => rho_dzt
+
+      do j = bld%jsc, bld%jec; do i = bld%isc, bld%iec
+        bld%kmt(i,j) = grid_kmt(i,j)
+        bld%k_bot(i,j) = 0
+        bld%rho_dzt_bot(i,j) = 0.0
+        if (grid_kmt(i,j) .gt. 0) then
+          do k = grid_kmt(i,j),1,-1
+            ! Check if the top of layer k is within the bottom thickness.  If so, include its properties in the bottom
+            ! layer averages.  Overshoots will be subtracted off later.
+            if (bld%rho_dzt_bot(i,j).lt.(bld%Rho_0*bld%bottom_thickness)) then
+              bld%k_bot(i,j) = k
+              bld%rho_dzt_bot(i,j) = bld%rho_dzt_bot(i,j) + bld%rho_dzt(i,j,k)
+            endif
+          enddo
+        endif
+      end do; end do
+    end subroutine generic_bld_update
+
+    !> Average a 3D field over the bottom layer defined by the bottom thickness.
+    subroutine generic_bld_average(bld, field, field_btm)
+      type(generic_bld), intent(in) :: bld
+      real, intent(in) :: field(:, :, :)   !< 3D field to be averaged
+      real, intent(out) :: field_btm(:, :) !< 2D field of bottom layer average
+      integer :: i, j, k
+
+      do j = bld%jsc, bld%jec; do i = bld%isc, bld%iec
+        field_btm(i,j) = 0.0
+        if (bld%kmt(i,j) .gt. 0) then
+          do k = bld%kmt(i,j), bld%k_bot(i,j), -1
+            field_btm(i,j) = field_btm(i,j) + field(i,j,k) * bld%rho_dzt(i,j,k)
+          enddo
+          ! Remove overshoot from the last layer added to the average.
+          field_btm(i,j) = field_btm(i,j) - field(i,j,bld%k_bot(i,j))*(bld%rho_dzt_bot(i,j) - bld%Rho_0*bld%bottom_thickness)
+          field_btm(i,j) = field_btm(i,j) / (bld%bottom_thickness*bld%Rho_0)
+        endif
+      end do; end do
+    end subroutine generic_bld_average
+end module generic_bottom_layer_diags

--- a/generic_tracers/generic_bottom_layer_diags.F90
+++ b/generic_tracers/generic_bottom_layer_diags.F90
@@ -3,6 +3,7 @@
 ! which does the actual averaging of the 3D data into a 2D bottom field.
 ! The other subroutines allocate and update information about the vertical coordinates.
 module generic_bottom_layer_diags
+  use MOM_error_handler, only : MOM_error, FATAL
   implicit none
   private
 
@@ -77,6 +78,12 @@ module generic_bottom_layer_diags
       real, intent(in) :: field(:, :, :)   !< 3D field to be averaged
       real, intent(out) :: field_btm(:, :) !< 2D field of bottom layer average
       integer :: i, j, k
+
+      ! COBALT always calls generic_bld_update beforehand,
+      ! but check anyways in case another module is using this routine.
+      if (.not. associated(bld%rho_dzt) .or. .not. associated(bld%kmt)) then
+        call MOM_error(FATAL, "generic_bld_update must be called before generic_bld_average.")
+      endif
 
       do j = bld%jsc, bld%jec; do i = bld%isc, bld%iec
         field_btm(i,j) = 0.0


### PR DESCRIPTION
This PR refactors the calculation of bottom diagnostics for generic tracers in COBALT into a new module, `generic_bottom_layer_diags`. 

The benefits of doing this are
1. Less repeated code
2. Easier to add new bottom diagnostics (just register, call generic_bld_average, and send)
3. Potentially simpler to change how the bottom averages are calculated in the future

The algorithm used for bottom averaging here is an exact duplicate of the old code (averaging over `bottom_thickness`) so the diagnostic output should not change.

AI use: these changes were planned and reviewed with help from Opus 4.8, but the implementation and code were fully done by hand. 