### PR TITLE
Explicitly deallocate and reduce size of arrays used in source/sink imbalance calc and for storing thicknesses

### DIFF
--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -3166,12 +3166,13 @@ contains
     real, dimension(:,:),   Allocatable :: neritic_cased_burial
     ! >>
 
-    real, dimension(:,:,:), Allocatable :: ztop, zmid, zbot
     real, dimension(:,:,:), Allocatable :: pre_totn, net_srcn, post_totn
     real, dimension(:,:,:), Allocatable :: pre_totp, net_srcp, post_totp
     real, dimension(:,:,:), Allocatable :: pre_totsi, post_totsi
     real, dimension(:,:,:), Allocatable :: pre_totfe, net_srcfe, post_totfe
     real, dimension(:,:,:), Allocatable :: pre_totc, net_srcc, post_totc
+    real, dimension(:,:),   Allocatable :: ztop
+    real, dimension(:,:,:), Allocatable :: zmid, zbot
     real, dimension(:,:),   Allocatable :: pka_nh3,phos_nh3_exchange
 
     real :: tr,ltr
@@ -3202,28 +3203,29 @@ contains
     !
     ! Calculate some thickness/vertical reference points for later calculations
     !
-    allocate(ztop(isc:iec,jsc:jec,1:nk))
+    allocate(ztop(isc:iec,jsc:jec))
     allocate(zmid(isc:iec,jsc:jec,1:nk))
     allocate(zbot(isc:iec,jsc:jec,1:nk))
     do j = jsc, jec ; do i = isc, iec   !{
        cobalt%zt(i,j,1) = dzt(i,j,1)
-       ztop(i,j,1) = 0.0
+       ztop(i,j) = 0.0
        zmid(i,j,1) = 0.5*dzt(i,j,1)
        zbot(i,j,1) = dzt(i,j,1)
     enddo; enddo !} i,j
 
     do k = 2, nk ; do j = jsc, jec ; do i = isc, iec   !{
        cobalt%zt(i,j,k) = cobalt%zt(i,j,k-1) + dzt(i,j,k)
-       ztop(i,j,k) = zbot(i,j,k-1)
-       zmid(i,j,k) = ztop(i,j,k) + 0.5*dzt(i,j,k)
-       zbot(i,j,k) = ztop(i,j,k) + dzt(i,j,k)
+       ztop(i,j) = zbot(i,j,k-1)
+       zmid(i,j,k) = ztop(i,j) + 0.5*dzt(i,j,k)
+       zbot(i,j,k) = ztop(i,j) + dzt(i,j,k)
     enddo; enddo ; enddo !} i,j,k
+
+    deallocate(ztop)
 
     !---------------------------------------------------------------------
     !Calculate co3_ion
     !Also calculate co2 fluxes csurf and alpha for the next round of exchange
     !---------------------------------------------------------------------
-
 
     k=1
     do j = jsc, jec ; do i = isc, iec  !{
@@ -3707,6 +3709,7 @@ contains
     enddo;  enddo !} i,j
 
     deallocate(tmp_irr_band)
+    deallocate(zmid)
     !
     ! Calculate the final photoacclimation irradiance using the standard relaxation
     ! scheme (I_aclm(t+1) = I_aclm(t) + (I*(24/daylength)-I_aclm(t))*gamma*dt).
@@ -5017,6 +5020,8 @@ contains
 
        cobalt%jprod_fed(i,j,k) = cobalt%jprod_fed(i,j,k) + cobalt%jremin_fedet(i,j,k)
     enddo; enddo; enddo  !} i,j,k
+
+    deallocate(zbot)
 
     ! << Enhanced CaCO3 dissolution driven by localized undersaturation around sinking particles >>
     ! Add CaCO3 dissolution enhancement associated with organic matter (OM) decomposition

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -3166,8 +3166,7 @@ contains
     real, dimension(:,:),   Allocatable :: neritic_cased_burial
     ! >>
 
-    real, dimension(:,:),   Allocatable :: ztop
-    real, dimension(:,:,:), Allocatable :: zmid, zbot
+    real, dimension(:,:), Allocatable :: zmid_nk ! z-coordinate at the middle of the last vertical layer
     real, dimension(:,:,:), Allocatable :: pre_totn, net_srcn
     real, dimension(:,:,:), Allocatable :: pre_totp, net_srcp
     real, dimension(:,:,:), Allocatable :: pre_totsi
@@ -3204,24 +3203,16 @@ contains
     !
     ! Calculate some thickness/vertical reference points for later calculations
     !
-    allocate(ztop(isc:iec,jsc:jec))
-    allocate(zmid(isc:iec,jsc:jec,1:nk))
-    allocate(zbot(isc:iec,jsc:jec,1:nk))
+    allocate(zmid_nk(isc:iec,jsc:jec))
     do j = jsc, jec ; do i = isc, iec   !{
        cobalt%zt(i,j,1) = dzt(i,j,1)
-       ztop(i,j) = 0.0
-       zmid(i,j,1) = 0.5*dzt(i,j,1)
-       zbot(i,j,1) = dzt(i,j,1)
     enddo; enddo !} i,j
 
     do k = 2, nk ; do j = jsc, jec ; do i = isc, iec   !{
        cobalt%zt(i,j,k) = cobalt%zt(i,j,k-1) + dzt(i,j,k)
-       ztop(i,j) = zbot(i,j,k-1)
-       zmid(i,j,k) = ztop(i,j) + 0.5*dzt(i,j,k)
-       zbot(i,j,k) = ztop(i,j) + dzt(i,j,k)
     enddo; enddo ; enddo !} i,j,k
 
-    deallocate(ztop)
+    zmid_nk = cobalt%zt(:,:,max(1,nk-1)) + 0.5*dzt(:,:,nk)
 
     !---------------------------------------------------------------------
     !Calculate co3_ion
@@ -3647,7 +3638,7 @@ contains
              ! Issue: This code currently includes an option to increase opacity in shallow/fresh
              ! water.  This should be moved to a namelist (and eventually replaced with a more
              ! robust coastal optics model with full feedbacks to the physics)
-             if ((zmid(i,j,nk).le.cobalt%case2_depth).or.(Salt(i,j,k).le.cobalt%case2_salt)) then
+             if ((zmid_nk(i,j).le.cobalt%case2_depth).or.(Salt(i,j,k).le.cobalt%case2_salt)) then
                tmp_opacity = opacity_band(nb,i,j,k) + cobalt%case2_opac_add
              else
                tmp_opacity = opacity_band(nb,i,j,k)
@@ -3710,7 +3701,7 @@ contains
     enddo;  enddo !} i,j
 
     deallocate(tmp_irr_band)
-    deallocate(zmid)
+    deallocate(zmid_nk)
     !
     ! Calculate the final photoacclimation irradiance using the standard relaxation
     ! scheme (I_aclm(t+1) = I_aclm(t) + (I*(24/daylength)-I_aclm(t))*gamma*dt).
@@ -4971,7 +4962,7 @@ contains
        ! Calculate remineralization under aerobic remineralization
        if (cobalt%f_o2(i,j,k) .gt. cobalt%o2_min) then  !{
           cobalt%jremin_ndet(i,j,k) = cobalt%gamma_ndet * cobalt%expkreminT(i,j,k) * &
-               zbot(i,j,k)/(zbot(i,j,k) + cobalt%remin_ramp_scale) * cobalt%f_o2(i,j,k) / &
+               cobalt%zt(i,j,k)/(cobalt%zt(i,j,k) + cobalt%remin_ramp_scale) * cobalt%f_o2(i,j,k) / &
                ( cobalt%k_o2 + cobalt%f_o2(i,j,k) )*max( 0.0, cobalt%f_ndet(i,j,k) - &
                cobalt%rpcaco3*(cobalt%f_cadet_arag(i,j,k) + cobalt%f_cadet_calc(i,j,k)) - &
                cobalt%rplith*cobalt%f_lithdet(i,j,k) - cobalt%rpsio2*cobalt%f_sidet(i,j,k) )
@@ -5021,8 +5012,6 @@ contains
 
        cobalt%jprod_fed(i,j,k) = cobalt%jprod_fed(i,j,k) + cobalt%jremin_fedet(i,j,k)
     enddo; enddo; enddo  !} i,j,k
-
-    deallocate(zbot)
 
     ! << Enhanced CaCO3 dissolution driven by localized undersaturation around sinking particles >>
     ! Add CaCO3 dissolution enhancement associated with organic matter (OM) decomposition

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -3166,14 +3166,15 @@ contains
     real, dimension(:,:),   Allocatable :: neritic_cased_burial
     ! >>
 
-    real, dimension(:,:,:), Allocatable :: pre_totn, net_srcn, post_totn
-    real, dimension(:,:,:), Allocatable :: pre_totp, net_srcp, post_totp
-    real, dimension(:,:,:), Allocatable :: pre_totsi, post_totsi
-    real, dimension(:,:,:), Allocatable :: pre_totfe, net_srcfe, post_totfe
-    real, dimension(:,:,:), Allocatable :: pre_totc, net_srcc, post_totc
     real, dimension(:,:),   Allocatable :: ztop
     real, dimension(:,:,:), Allocatable :: zmid, zbot
+    real, dimension(:,:,:), Allocatable :: pre_totn, net_srcn
+    real, dimension(:,:,:), Allocatable :: pre_totp, net_srcp
+    real, dimension(:,:,:), Allocatable :: pre_totsi
+    real, dimension(:,:,:), Allocatable :: pre_totfe, net_srcfe
+    real, dimension(:,:,:), Allocatable :: pre_totc, net_srcc
     real, dimension(:,:),   Allocatable :: pka_nh3,phos_nh3_exchange
+    real :: post_totn, post_totp, post_totsi, post_totfe, post_totc
 
     real :: tr,ltr
     real :: imbal
@@ -6079,15 +6080,14 @@ contains
     ! day-1, so an imbalance of order 1 would be very large whereas 1e-9 is very small.
     ! A reccomended tolerance is between 1e-7 and 1e-9.
     imbal_flag = 0;
-    stdoutunit = stdout();
-    allocate(post_totn(isc:iec,jsc:jec,1:nk))
-    allocate(post_totc(isc:iec,jsc:jec,1:nk))
-    allocate(post_totp(isc:iec,jsc:jec,1:nk))
-    allocate(post_totsi(isc:iec,jsc:jec,1:nk))
-    allocate(post_totfe(isc:iec,jsc:jec,1:nk))
+    post_totn = 0;
+    post_totc = 0;
+    post_totp = 0;
+    post_totsi = 0;
+    post_totfe = 0;
     do k = 1, nk ; do j = jsc, jec ; do i = isc, iec  !{
       if (dzt(i,j,k).gt.cobalt%min_thickness) then
-         post_totn(i,j,k) = (cobalt%p_no3(i,j,k,tau) + cobalt%p_nh4(i,j,k,tau) + &
+         post_totn = (cobalt%p_no3(i,j,k,tau) + cobalt%p_nh4(i,j,k,tau) + &
                     cobalt%p_ndi(i,j,k,tau) + cobalt%p_nlg(i,j,k,tau) + cobalt%p_nmd(i,j,k,tau) + &
                     cobalt%p_nsm(i,j,k,tau) + cobalt%p_nbact(i,j,k,tau) + &
                     cobalt%p_ldon(i,j,k,tau) + cobalt%p_sldon(i,j,k,tau) + &
@@ -6095,13 +6095,13 @@ contains
 					cobalt%p_ndet_fast(i,j,k,tau) + &
                     cobalt%p_nsmz(i,j,k,tau) + cobalt%p_nmdz(i,j,k,tau) + &
                     cobalt%p_nlgz(i,j,k,tau))*grid_tmask(i,j,k)
-         imbal = (post_totn(i,j,k) - pre_totn(i,j,k) - net_srcn(i,j,k))*86400.0/dt*1.03e6
+         imbal = (post_totn - pre_totn(i,j,k) - net_srcn(i,j,k))*86400.0/dt*1.03e6
          if (abs(imbal).gt.imbalance_tolerance) then
            call mpp_error(FATAL,&
            '==>biological source/sink imbalance (generic_COBALT_update_from_source): Nitrogen')
          endif
 
-         post_totc(i,j,k) = (cobalt%p_dic(i,j,k,tau) + &
+         post_totc = (cobalt%p_dic(i,j,k,tau) + &
                     cobalt%p_cadet_arag(i,j,k,tau) + cobalt%p_cadet_calc(i,j,k,tau) + &
                     cobalt%c_2_n*(cobalt%p_ndi(i,j,k,tau) + cobalt%p_nlg(i,j,k,tau) + &
                     cobalt%p_nmd(i,j,k,tau) + cobalt%p_nsm(i,j,k,tau) + cobalt%p_nbact(i,j,k,tau) + &
@@ -6110,13 +6110,13 @@ contains
 					cobalt%p_ndet_fast(i,j,k,tau) + &
                     cobalt%p_nsmz(i,j,k,tau) + cobalt%p_nmdz(i,j,k,tau) + &
                     cobalt%p_nlgz(i,j,k,tau)))*grid_tmask(i,j,k)
-        imbal = (post_totc(i,j,k) - pre_totc(i,j,k) - net_srcc(i,j,k))*86400.0/dt*1.03e6
+        imbal = (post_totc - pre_totc(i,j,k) - net_srcc(i,j,k))*86400.0/dt*1.03e6
          if (abs(imbal).gt.imbalance_tolerance) then
            call mpp_error(FATAL,&
            '==>biological source/sink imbalance (generic_COBALT_update_from_source): Carbon')
          endif
 
-         post_totp(i,j,k) = (cobalt%p_po4(i,j,k,tau) + cobalt%p_pdi(i,j,k,tau) + &
+         post_totp = (cobalt%p_po4(i,j,k,tau) + cobalt%p_pdi(i,j,k,tau) + &
                     cobalt%p_plg(i,j,k,tau) + cobalt%p_pmd(i,j,k,tau) + cobalt%p_psm(i,j,k,tau) + &
                     cobalt%p_ldop(i,j,k,tau) + cobalt%p_sldop(i,j,k,tau) + &
                     cobalt%p_srdop(i,j,k,tau) + cobalt%p_pdet(i,j,k,tau) + &
@@ -6125,30 +6125,41 @@ contains
                     cobalt%p_nmdz(i,j,k,tau)*zoo(2)%q_p_2_n + &
                     cobalt%p_nlgz(i,j,k,tau)*zoo(3)%q_p_2_n + &
                     bact(1)%q_p_2_n*cobalt%p_nbact(i,j,k,tau))*grid_tmask(i,j,k)
-         imbal = (post_totp(i,j,k) - pre_totp(i,j,k) - net_srcp(i,j,k))*86400.0/dt*1.03e6
+         imbal = (post_totp - pre_totp(i,j,k) - net_srcp(i,j,k))*86400.0/dt*1.03e6
          if (abs(imbal).gt.imbalance_tolerance) then
            call mpp_error(FATAL,&
            '==>biological source/sink imbalance (generic_COBALT_update_from_source): Phosphorus')
          endif
 
-         post_totfe(i,j,k) = (cobalt%p_fed(i,j,k,tau) + cobalt%p_fedi(i,j,k,tau) + &
+         post_totfe = (cobalt%p_fed(i,j,k,tau) + cobalt%p_fedi(i,j,k,tau) + &
                     cobalt%p_felg(i,j,k,tau) + cobalt%p_femd(i,j,k,tau) + cobalt%p_fesm(i,j,k,tau) + &
                     cobalt%p_fedet(i,j,k,tau))*grid_tmask(i,j,k)
-         imbal = (post_totfe(i,j,k) - pre_totfe(i,j,k) - net_srcfe(i,j,k))*86400.0/dt*1.03e6
+         imbal = (post_totfe - pre_totfe(i,j,k) - net_srcfe(i,j,k))*86400.0/dt*1.03e6
          if (abs(imbal).gt.imbalance_tolerance) then
            call mpp_error(FATAL,&
            '==>biological source/sink imbalance (generic_COBALT_update_from_source): Iron')
          endif
 
-         post_totsi(i,j,k) = (cobalt%p_sio4(i,j,k,tau) + cobalt%p_silg(i,j,k,tau) + &
+         post_totsi = (cobalt%p_sio4(i,j,k,tau) + cobalt%p_silg(i,j,k,tau) + &
                     cobalt%p_simd(i,j,k,tau) + cobalt%p_sidet(i,j,k,tau))*grid_tmask(i,j,k)
-         imbal = (post_totsi(i,j,k) - pre_totsi(i,j,k))*86400.0/dt*1.03e6
+         imbal = (post_totsi - pre_totsi(i,j,k))*86400.0/dt*1.03e6
          if (abs(imbal).gt.imbalance_tolerance) then
            call mpp_error(FATAL,&
            '==>biological source/sink imbalance (generic_COBALT_update_from_source): Silica')
          endif
       endif
     enddo; enddo ; enddo  !} i,j,k
+
+    ! Deallocate total nutrient arrays:
+    deallocate(pre_totn)
+    deallocate(pre_totc)
+    deallocate(net_srcn)
+    deallocate(net_srcp)
+    deallocate(net_srcc)
+    deallocate(pre_totp)
+    deallocate(pre_totfe)
+    deallocate(net_srcfe)
+    deallocate(pre_totsi)
 
     !
     !----------------


### PR DESCRIPTION
This PR does several things: 

1.) It adds explicit `deallocate` statements for arrays used to store thicknesses and calculate imbalances after the source/sink calculations

2.) It reduces `ztop` from `3d` to `2d` since we don't need to keep track of previous k values of `ztop` in a given layer

3.) It converts the 3d `post_tot<nutrient>` arrays to scalars, since the values those arrays hold are only used once for element-wise checks. 

The original intent of this PR was just to be explicit about de-allocating allocated memory - I think the [compiler technically handles](https://www.fortran90.org/src/best-practices.html#allocatable-arrays) this for us, but I thought it would be cleaner to include those statement. I realized in the process that most of these arrays could be made smaller, which has the added benefit of getting rid of the expensive 3D allocations that come with each`post_tot` array in each call to `generic_COBALT_update_from_source`. 

This seemed to improve the runtime of the NEP10.COBALT test case slightly, though to be honest I can't find my reference times on c5 and the difference isn't huge as COBALT is not the most expensive part of that test case. Still, this approach seems a little more memory friendly, so I figured I would open the PR. 