### PR TITLE
Cleanup of FMS_co2calc

### DIFF
--- a/generic_tracers/FMS_co2calc.F90
+++ b/generic_tracers/FMS_co2calc.F90
@@ -18,15 +18,19 @@ module FMS_co2calc_mod  !{
 !</REVIEWER>
 !
 !<OVERVIEW>
-! Surface fCO2 calculation
+! Carbonate chemistry calculation (pCO2, CO2*, CO3--, and saturation states)
 !</OVERVIEW>
 !
 !<DESCRIPTION>
-! Calculate the fugacity of CO2 at the surface in thermodynamic
+! Calculate the partial pressure of CO2 (pCO2) in thermodynamic
 ! equilibrium with the current alkalinity (Alk) and total dissolved
-! inorganic carbon (DIC) at a particular temperature and salinity
-! using an initial guess for the total hydrogen
-! ion concentration (htotal)
+! inorganic carbon (DIC) at a particular temperature and salinity,
+! via mocsy's vars() routine. mocsy also returns an initial-guess-free
+! solve for the total hydrogen ion concentration (htotal); the
+! htotallo/htotalhi bracket arguments below are optional and retained
+! only for interface compatibility with existing callers, which
+! currently always pass them but whose values are not used to seed an
+! iterative solver.
 !</DESCRIPTION>
 !
 
@@ -38,7 +42,6 @@ module FMS_co2calc_mod  !{
 !------------------------------------------------------------------
 !
 
-use fm_util_mod, only: fm_util_start_namelist, fm_util_end_namelist
 use fms_mod,     only: check_nml_error
 use mpp_mod,     only: input_nml_file, mpp_error, stdout, stdlog, WARNING, FATAL
 use mocsy_vars,  only: vars
@@ -111,45 +114,50 @@ end subroutine read_mocsy_namelist
 !
 ! <DESCRIPTION>
 !       Calculate co2* from total alkalinity and total CO2 at
-! temperature (t) and salinity (s).
-! It is assumed that init_ocmip2_co2calc has already been called with
-! the T and S to calculate the various coefficients.
+! temperature (t) and salinity (s), via mocsy's vars() routine.
 !
 ! INPUT
 !
-!       dope_vec   = an array of indices corresponding to the compute 
+!       dope_vec   = an array of indices corresponding to the compute
 !                    and data domain boundaries.
 !
 !       mask       = land mask array (0.0 = land)
 !
-!       dic_in     = total inorganic carbon (mol/kg) 
+!       dic_in     = total inorganic carbon (mol/kg)
 !                    where 1 T = 1 metric ton = 1000 kg
 !
-!       ta_in      = total alkalinity (eq/kg) 
+!       ta_in      = total alkalinity (eq/kg)
 !
-!       pt_in      = inorganic phosphate (mol/kg) 
+!       pt_in      = inorganic phosphate (mol/kg)
 !
-!       sit_in     = inorganic silicate (mol/kg) 
-!
-!       htotallo   = lower limit of htotal range
-!
-!       htotalhi   = upper limit of htotal range
+!       sit_in     = inorganic silicate (mol/kg)
 !
 !       htotal     = H+ concentration (mol/kg)
 !
 !  INPUT (optional)
 !
-!       zt         = dzt
+!       zt         = dzt; depth of the layer being solved (m). Mocsy is
+!                    called with optgas='Pinsitu', so co2star/pCO2surf/
+!                    co3_ion/omega_* below are the IN-SITU values at this
+!                    depth, not fixed-surface-pressure values. They read
+!                    as "surface" only because every current caller in
+!                    this repo passes the top model layer's zt.
+!
+!       htotallo   = lower limit of htotal range (not used since mocsy's
+!                    own pH solver doesn't need a bisection bracket;
+!                    retained only for interface compatibility)
+!
+!       htotalhi   = upper limit of htotal range (see htotallo)
 !
 ! OUTPUT
 !       co2star    = CO2*water, or H2CO3 concentration (mol/kg)
 !       alpha      = Solubility of CO2 for air (mol/kg/atm)
-!       pco2surf   = oceanic pCO2 (ppmv)
+!       pco2surf   = oceanic pCO2, in-situ at depth zt (uatm)
 !       co3_ion    = Carbonate ion, or CO3-- concentration (mol/kg)
-!       omega_arag = aragonite saturation state (mol/kg ; avail. only w/ mocsy)
-!       omega_calc = aragonite saturation state (mol/kg ; avail. only w/ mocsy)
+!       omega_arag = aragonite saturation state (dimensionless; avail. only w/ mocsy)
+!       omega_calc = calcite saturation state (dimensionless; avail. only w/ mocsy)
 !
-! FILES and PROGRAMS NEEDED: drtsafe, ta_iter_1
+! FILES and PROGRAMS NEEDED: mocsy_vars::vars()
 !
 ! IMPORTANT: co2star and alpha need to be multiplied by rho before being
 ! passed to the atmosphere.
@@ -162,13 +170,6 @@ subroutine FMS_co2calc(dope_vec, mask,                      &
                           co3_ion, omega_arag, omega_calc)  !{
 
 implicit none
-
-!
-!       local parameters
-!
-
-real, parameter :: permeg = 1.e-6
-real, parameter :: xacc = 1.0e-10
 
 ! Mocsy parameters
 real, dimension(1) :: ph, pco2, fco2, co2, hco3, co3,  &
@@ -187,13 +188,13 @@ real, dimension(dope_vec%isd:dope_vec%ied,dope_vec%jsd:dope_vec%jed), &
                                dic_in, &
                                pt_in, &
                                sit_in, &
-                               ta_in, &
-                               htotallo, &
-                               htotalhi
+                               ta_in
 real, dimension(dope_vec%isd:dope_vec%ied,dope_vec%jsd:dope_vec%jed), &
       intent(inout)         :: htotal
 real, dimension(dope_vec%isd:dope_vec%ied,dope_vec%jsd:dope_vec%jed), &
-      intent(in), optional  :: zt
+      intent(in), optional  :: zt, &
+                               htotallo, &
+                               htotalhi
 real, dimension(dope_vec%isd:dope_vec%ied,dope_vec%jsd:dope_vec%jed), &
       intent(out), optional :: alpha, &
                                pCO2surf, &
@@ -206,51 +207,11 @@ real, dimension(dope_vec%isd:dope_vec%ied,dope_vec%jsd:dope_vec%jed), &
 !
 integer :: isc, iec, jsc, jec
 integer :: i,j
-real :: alpha_internal
-real :: bt
-real :: co2star_internal
-real :: dlogtk
-real :: ft
-real :: htotal2
-real :: invtk
-real :: is
-real :: is2
-real :: k1
-real :: k2
-real :: k1p
-real :: k2p
-real :: k3p
-real :: kb
-real :: kf
-real :: ks
-real :: ksi
-real :: kw
-real :: log100
-real :: s2
-real :: scl
-real :: sqrtis
-real :: sqrts
-real :: st
-real :: tk
-real :: tk100
-real :: tk1002
-real :: logf_of_s
 real :: salinity
 
-!character(len=10) :: co2_calc_method
-
-!  co2_calc_method = trim(co2_calc)
-!  if (co2_calc == 'mocsy') then
-    if (.not. present(zt)) then 
-        call mpp_error(FATAL,"Depth must be specified when invoking Mocsy.") 
+    if (.not. present(zt)) then
+        call mpp_error(FATAL,"Depth must be specified when invoking Mocsy.")
     end if
-!  end if   
-!else
-!  call mpp_error(FATAL,"co2_calc must be mocsy.")
-!end if
-
-
-
 
 ! Set the loop indices.
   isc = dope_vec%isc ; iec = dope_vec%iec
@@ -259,8 +220,6 @@ real :: salinity
 !
 !       Initialize the module
 !
-  log100 = log(100.0)
-
   do j = jsc, jec  !{
     do i = isc, iec  !{
       if (mask(i,j) .gt. 0.0) then  !{
@@ -361,216 +320,5 @@ return
 end subroutine  FMS_co2calc  !}
 ! </SUBROUTINE> NAME="FMS_co2calc"
 
-!#######################################################################
-! <FUNCTION NAME="drtsafe">
-!
-! <DESCRIPTION>
-!       File taken from Numerical Recipes. Modified  R. M. Key 4/94
-! </DESCRIPTION>
-
-function drtsafe(k1, k2, kb, k1p, k2p, k3p, ksi, kw, ks, kf, &
-               bt, dic, ft, pt, sit, st, ta, x1_in, x2_in, x, xacc)  !{
-
-implicit none
-
-!
-!       arguments
-!
-
-real    :: k1, k2, kb, k1p, k2p, k3p, ksi, kw, ks, kf
-real    :: bt, dic, ft, pt, sit, st, ta
-real    :: drtsafe
-real    :: x1_in, x2_in, x, xacc
-
-!
-!       local parameters
-!
-
-integer, parameter      :: maxit = 100
-
-!
-!       local variables
-!
-
-integer :: j
-real    :: fl, df, fh, swap, xl, xh, dxold, dx, f, temp
-real    :: x1
-real    :: x2
-logical :: bracketed
-
-drtsafe=x
-call ta_iter_1(k1, k2, kb, k1p, k2p, k3p, ksi, kw, ks, kf, &
-               bt, dic, ft, pt, sit, st, ta, drtsafe, f, df)
-dx=f/df
-if (abs(dx) .lt. xacc) then
-!     write (6,*) 'Exiting drtsafe at C on iteration  ', j, ', ph = ', -log10(drtsafe)
-  return
-endif
-
-bracketed = .false.
-x1 = x
-x2 = x
-
-do j = 1, 10
-
-  x1 = x1 * 0.1
-  x2 = x2 * 10.0
-  call ta_iter_1(k1, k2, kb, k1p, k2p, k3p, ksi, kw, ks, kf, &
-                 bt, dic, ft, pt, sit, st, ta, x1, fl, temp)
-  call ta_iter_1(k1, k2, kb, k1p, k2p, k3p, ksi, kw, ks, kf, &
-                 bt, dic, ft, pt, sit, st, ta, x2, fh, temp)
-  if (fl*fh .lt. 0.0) then
-    bracketed = .true.
-    exit
-  endif
-
-enddo
-
-if (.not. bracketed) then
-  call mpp_error(WARNING, 'drtsafe: root not bracketed')
-endif
-
-if(fl .lt. 0.0) then
-  xl=x1
-  xh=x2
-else
-  xh=x1
-  xl=x2
-  swap=fl
-  fl=fh
-  fh=swap
-end if
-drtsafe=0.5*(x1+x2)
-dxold=abs(x2-x1)
-dx=dxold
-call ta_iter_1(k1, k2, kb, k1p, k2p, k3p, ksi, kw, ks, kf, &
-               bt, dic, ft, pt, sit, st, ta, drtsafe, f, df)
-do j=1,maxit  !{
-  if (((drtsafe-xh)*df-f)*((drtsafe-xl)*df-f) .ge. 0.0 .or.     &
-      abs(2.0*f) .gt. abs(dxold*df)) then
-    dxold=dx
-    dx=0.5*(xh-xl)
-    drtsafe=xl+dx
-    if (xl .eq. drtsafe) then
-!     write (6,*) 'Exiting drtsafe at A on iteration  ', j, ', ph = ', -log10(drtsafe)
-      return
-    endif
-  else
-    dxold=dx
-    dx=f/df
-    temp=drtsafe
-    drtsafe=drtsafe-dx
-    if (temp .eq. drtsafe) then
-!     write (6,*) 'Exiting drtsafe at B on iteration  ', j, ', ph = ', -log10(drtsafe)
-      return
-    endif
-  end if
-  if (abs(dx) .lt. xacc) then
-!     write (6,*) 'Exiting drtsafe at C on iteration  ', j, ', ph = ', -log10(drtsafe)
-    return
-  endif
-  call ta_iter_1(k1, k2, kb, k1p, k2p, k3p, ksi, kw, ks, kf, &
-                 bt, dic, ft, pt, sit, st, ta, drtsafe, f, df)
-  if(f .lt. 0.0) then
-    xl=drtsafe
-    fl=f
-  else
-    xh=drtsafe
-    fh=f
-  end if
-enddo  !} j
-
-! should have an error condition here for not converging?
-
-return
-
-end  function  drtsafe  !}
-! </FUNCTION> NAME="drtsafe"
-
-!#######################################################################
-! <SUBROUTINE NAME="ta_iter_1">
-!
-! <DESCRIPTION>
-! This routine expresses TA as a function of DIC, htotal and constants.
-! It also calculates the derivative of this function with respect to 
-! htotal. It is used in the iterative solution for htotal. In the call
-! "x" is the input value for htotal, "fn" is the calculated value for TA
-! and "df" is the value for dTA/dhtotal
-! </DESCRIPTION>
-
-subroutine ta_iter_1(k1, k2, kb, k1p, k2p, k3p, ksi, kw, ks, kf, &
-                     bt, dic, ft, pt, sit, st, ta, x, fn, df)  !{
-
-implicit none
-
-!
-!       arguments
-!
-
-real    :: k1, k2, kb, k1p, k2p, k3p, ksi, kw, ks, kf
-real    :: bt, dic, ft, pt, sit, st, ta, x, fn, df
-
-!
-!       local variables
-!
-
-real    :: x2, x3, k12, k12p, k123p, c, a, am1, am2, da, b, bm1, bm2, db
-real    :: xpkbm1,xpkfm1,xpksim1,xpkscm1
-
-x2 = x*x
-x3 = x2*x
-k12 = k1*k2
-k12p = k1p*k2p
-k123p = k12p*k3p
-c = 1.0/(1.0 + st/ks)
-
-a = x3 + k1p*x2 + k12p*x + k123p
-am1 = 1.0/a
-am2 = am1*am1
-da = 3.0*x2 + 2.0*k1p*x + k12p
-
-b = x2 + k1*x + k12
-bm1 = 1.0/b
-bm2 = bm1*bm1
-db = 2.0*x + k1
-
-xpkbm1  = 1.0/(x+kb)
-xpkfm1  = 1.0/(x+kf)
-xpksim1 = 1.0/(x+ksi)
-xpkscm1 = 1.0/(x+ks*c)
-
-!
-!     fn = hco3+co3+borate+oh+hpo4+2*po4+silicate+hfree+hso4+hf+h3po4-ta
-!OR
-!fn = -ta  + kw/x - c x 
-!   + dic (k1 x + 2 k12)/(k12 + k1 x + x^2)
-!   + pt  (2 k123p + k12p x - x^3)/(k123p + k12p x + k1p x^2 + x^3)
-!   + bt/(1. + x/kb) + sit/(1. + x/ksi) 
-!   - st/(1. + (c ks)/x) - ft/(1. + kf/x)
-
-fn = - ta + kw/x - c*x               &
-     + dic*(k1*x+2.0*k12)*bm1        &
-     + pt*(-x3+k12p*x+2.0*k123p)*am1 &
-     + bt *kb *xpkbm1                &
-     + sit*ksi*xpksim1               &
-     - st *x  *xpkscm1               &
-     - ft *x  *xpkfm1              
-
-!
-!     df = dfn/dx
-!
-df = - kw/x2 - c                                               &
-     + dic*(bm1*k1 - bm2*db*(k1*x+2.0*k12))                    &
-     + pt*(am1*(-3.*x2+k12p) - am2*da*(-x3+k12p*x+2.0*k123p))  &
-     - bt*  kb  *xpkbm1 *xpkbm1                                &
-     - sit* ksi *xpksim1*xpksim1                               &
-     - st*  ks*c*xpkscm1*xpkscm1                               &
-     - ft*  kf  *xpkfm1 *xpkfm1                                
-     
-
-return
-
-end subroutine  ta_iter_1  !}
-! </SUBROUTINE> NAME="ta_iter_1"
 
 end module  FMS_co2calc_mod  !}


### PR DESCRIPTION
This PR addresses issue #184, and is a follow up to #71 / #72. This PR removes OCMIP2 era code that is no longer used and are unnecessary to keep around. 

- `drtsafe` and `ta_iter_1` (the old Newton-Raphson pH solver) and a bunch of unused local variables it fed is now removed. This code is not used since FMS_co2calc only calls mocsy and never touches any of them. Confirmed via grep that nothing else in the repository calls them.
- `htotallo` and `htotalhi` are now optional arguments. They're never used in `mocsy` and seems to be OCMIP2 era code for helping to start the OCMIP2 pH root finder. Cleaning up `htotal` and associated `htotal*` terms should be a separate issue ticket and PR. In the meantime, we have made these two variables optional so that backwards compatibility is maintained, and newer models (like CBED) do not need to pass in unnecessary variables.

This PR also includes cleanup of many comments that appear to be legacy / original but caused confusion when trying to understand the functionality of this code. The comments also clarify that the `pCO2` output from mocsy saved as`pCO2surf` is actually in situ pCO2 (because `optGAS='Pinsitu'`) but does not change the variable name to preserve backwards compatibility with COBALT, BLING and `generic_abiotic`.
 