### PR TITLE
Adding DON pathway for higher level predators

### DIFF
--- a/generic_tracers/cobalt_types.F90
+++ b/generic_tracers/cobalt_types.F90
@@ -558,6 +558,9 @@ module cobalt_types
           hp_ipa_lgz,       & ! "  "  "  "  "  "  "  "  "   large zooplankton to hp
           hp_ipa_det,       & ! "  "  "  "  "  "  "  "  "   detritus to hp
           hp_phi_det,       & ! fraction of ingested N to detritus
+          hp_phi_ldon,      & ! fraction of ingested N to labile dissolved organic nitrogen
+          hp_phi_sldon,     & ! fraction of ingested N to semi-labile dissolved organic nitrogen
+          hp_phi_srdon,     & ! fraction of ingested N to semi-refractory dissolved organic nitrogen
           frac_fastsinking    ! fraction of higher predator detritus that is fast-sinking
 
      real, dimension(3)                    :: total_atm_co2

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -4670,11 +4670,15 @@ contains
           cobalt%jprod_ndet(i,j,k) = cobalt%jprod_ndet(i,j,k) + cobalt%hp_phi_det*cobalt%hp_jingest_n(i,j,k)
           cobalt%jprod_pdet(i,j,k) = cobalt%jprod_pdet(i,j,k) + cobalt%hp_phi_det*cobalt%hp_jingest_p(i,j,k)
        endif
-       ! A portion of egestion will be released into dissolved organic nitrogen pools
+       
+       ! A portion of egestion will be released into dissolved organic nitrogen and phosphorus pools
        ! hp_phi_det + hp_phi_ldon + hp_phi_sldon + hp_phi_srdon = 0.35 (total egestion)
        cobalt%jprod_ldon(i,j,k) = cobalt%jprod_ldon(i,j,k) + cobalt%hp_phi_ldon*cobalt%hp_jingest_n(i,j,k)
        cobalt%jprod_sldon(i,j,k) = cobalt%jprod_sldon(i,j,k) + cobalt%hp_phi_sldon*cobalt%hp_jingest_n(i,j,k)
        cobalt%jprod_srdon(i,j,k) = cobalt%jprod_srdon(i,j,k) + cobalt%hp_phi_srdon*cobalt%hp_jingest_n(i,j,k)
+       cobalt%jprod_ldop(i,j,k) = cobalt%jprod_ldop(i,j,k) + cobalt%hp_phi_ldon*cobalt%hp_jingest_p(i,j,k)
+       cobalt%jprod_sldop(i,j,k) = cobalt%jprod_sldop(i,j,k) + cobalt%hp_phi_sldon*cobalt%hp_jingest_p(i,j,k)
+       cobalt%jprod_srdop(i,j,k) = cobalt%jprod_srdop(i,j,k) + cobalt%hp_phi_srdon*cobalt%hp_jingest_p(i,j,k)
 
        ! Silica and iron detritus from HP does not sink quickly - just gets added to the bulk total
        cobalt%jprod_fedet(i,j,k) = cobalt%jprod_fedet(i,j,k) + cobalt%hp_phi_det*cobalt%hp_jingest_fe(i,j,k)
@@ -4819,12 +4823,13 @@ contains
        if (cobalt%f_o2(i,j,k) .gt. cobalt%o2_min) then
          cobalt%jprod_nh4(i,j,k) = cobalt%jprod_nh4(i,j,k) + &
                                   (1.0-cobalt%hp_phi_det-cobalt%hp_phi_ldon-cobalt%hp_phi_sldon-cobalt%hp_phi_srdon)*cobalt%hp_jingest_n(i,j,k)
-         cobalt%jprod_po4(i,j,k) = cobalt%jprod_po4(i,j,k) + (1.0-cobalt%hp_phi_det)*cobalt%hp_jingest_p(i,j,k)
+         cobalt%jprod_po4(i,j,k) = cobalt%jprod_po4(i,j,k) + &
+                                  (1.0-cobalt%hp_phi_det-cobalt%hp_phi_ldon-cobalt%hp_phi_sldon-cobalt%hp_phi_srdon)*cobalt%hp_jingest_p(i,j,k)
          cobalt%jo2resp_wc(i,j,k) = cobalt%jo2resp_wc(i,j,k) + &
                                     (1.0-cobalt%hp_phi_det-cobalt%hp_phi_ldon-cobalt%hp_phi_sldon-cobalt%hp_phi_srdon)*cobalt%hp_jingest_n(i,j,k)*cobalt%o2_2_nh4
        else
-         cobalt%jprod_ndet(i,j,k) = cobalt%jprod_ndet(i,j,k) + (1.0-cobalt%hp_phi_det)*cobalt%hp_jingest_n(i,j,k)
-         cobalt%jprod_pdet(i,j,k) = cobalt%jprod_pdet(i,j,k) + (1.0-cobalt%hp_phi_det)*cobalt%hp_jingest_p(i,j,k)
+         cobalt%jprod_ndet(i,j,k) = cobalt%jprod_ndet(i,j,k) + (1.0-cobalt%hp_phi_det-cobalt%hp_phi_ldon-cobalt%hp_phi_sldon-cobalt%hp_phi_srdon)*cobalt%hp_jingest_n(i,j,k)
+         cobalt%jprod_pdet(i,j,k) = cobalt%jprod_pdet(i,j,k) + (1.0-cobalt%hp_phi_det-cobalt%hp_phi_ldon-cobalt%hp_phi_sldon-cobalt%hp_phi_srdon)*cobalt%hp_jingest_p(i,j,k)
        endif
 
     enddo; enddo ; enddo !} i,j,k

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1447,10 +1447,19 @@ contains
                    "innate availability of bacteria to higher predator feeding (0-1)", units="none", default=0.0)
     call get_param(param_file, "generic_COBALT", "hp_ipa_det", cobalt%hp_ipa_det, &
                    "innate availability of detritus to higher predator feeding (0-1)", units="none", default=0.0)
-    ! The material ingested by higher predators is partitioned between detritus and remineralization.
-    ! Remineralization = 1.0 - hp_phi_det
+    ! The material ingested by higher predators is partitioned between detritus, remineralization, and dissolved organic nitrogen
+    ! Remineralization = 1.0 - hp_phi_det - hp_phi_ldon - hp_phi_sldon - hp_phi_srdon
     call get_param(param_file, "generic_COBALT", "hp_phi_det", cobalt%hp_phi_det, &
                    "fraction of ingestion by higher predators to detritus", units="none", default=0.35)
+    call get_param(param_file, "generic_COBALT", "hp_phi_ldon", cobalt%hp_phi_ldon, &
+                  "fraction of N ingestion by higher predators to labile dissolved organic nitrogen", &
+                  units="none", default=0.0)
+    call get_param(param_file, "generic_COBALT", "hp_phi_sldon", cobalt%hp_phi_sldon, &
+                  "fraction of N ingestion by higher predators to semi-labile dissolved organic nitrogen", &
+                  units="none", default=0.0)
+    call get_param(param_file, "generic_COBALT", "hp_phi_srdon", cobalt%hp_phi_srdon, &
+                   "fraction of N ingestion by higher predators to semi-refractory dissolved organic nitrogen", &
+                  units="none", default=0.0)
 
     call get_param(param_file, "generic_COBALT", "frac_fastsinking", cobalt%frac_fastsinking, &
                    "Fraction of N and P detritus higher predators that is fast-sinking", units="none", default=1.0)
@@ -4658,6 +4667,10 @@ contains
           cobalt%jprod_ndet(i,j,k) = cobalt%jprod_ndet(i,j,k) + cobalt%hp_phi_det*cobalt%hp_jingest_n(i,j,k)
           cobalt%jprod_pdet(i,j,k) = cobalt%jprod_pdet(i,j,k) + cobalt%hp_phi_det*cobalt%hp_jingest_p(i,j,k)
        endif
+       ! A portion of egestion will be released into dissolved organic nitrogen pools
+       cobalt%jprod_ldon(i,j,k) = cobalt%jprod_ldon(i,j,k) + cobalt%hp_phi_ldon*cobalt%hp_jingest_n(i,j,k)
+       cobalt%jprod_sldon(i,j,k) = cobalt%jprod_sldon(i,j,k) + cobalt%hp_phi_sldon*cobalt%hp_jingest_n(i,j,k)
+       cobalt%jprod_srdon(i,j,k) = cobalt%jprod_srdon(i,j,k) + cobalt%hp_phi_srdon*cobalt%hp_jingest_n(i,j,k)
 
        ! Silica and iron detritus from HP does not sink quickly - just gets added to the bulk total
        cobalt%jprod_fedet(i,j,k) = cobalt%jprod_fedet(i,j,k) + cobalt%hp_phi_det*cobalt%hp_jingest_fe(i,j,k)
@@ -4800,10 +4813,11 @@ contains
        cobalt%jprod_sio4(i,j,k) = cobalt%jprod_sio4(i,j,k) + (1.0-cobalt%hp_phi_det)*cobalt%hp_jingest_sio2(i,j,k)
        ! If o2 is sufficient, respire what is not egested.  If not, everything is routed to detritus
        if (cobalt%f_o2(i,j,k) .gt. cobalt%o2_min) then
-         cobalt%jprod_nh4(i,j,k) = cobalt%jprod_nh4(i,j,k) + (1.0-cobalt%hp_phi_det)*cobalt%hp_jingest_n(i,j,k)
+         cobalt%jprod_nh4(i,j,k) = cobalt%jprod_nh4(i,j,k) + &
+                                  (1.0-cobalt%hp_phi_det-cobalt%hp_phi_ldon-cobalt%hp_phi_sldon-cobalt%hp_phi_srdon)*cobalt%hp_jingest_n(i,j,k)
          cobalt%jprod_po4(i,j,k) = cobalt%jprod_po4(i,j,k) + (1.0-cobalt%hp_phi_det)*cobalt%hp_jingest_p(i,j,k)
-         cobalt%jo2resp_wc(i,j,k) = cobalt%jo2resp_wc(i,j,k) + (1.0-cobalt%hp_phi_det)*cobalt%hp_jingest_n(i,j,k)* &
-                                    cobalt%o2_2_nh4
+         cobalt%jo2resp_wc(i,j,k) = cobalt%jo2resp_wc(i,j,k) + &
+                                    (1.0-cobalt%hp_phi_det-cobalt%hp_phi_ldon-cobalt%hp_phi_sldon-cobalt%hp_phi_srdon)*cobalt%hp_jingest_n(i,j,k)*cobalt%o2_2_nh4
        else
          cobalt%jprod_ndet(i,j,k) = cobalt%jprod_ndet(i,j,k) + (1.0-cobalt%hp_phi_det)*cobalt%hp_jingest_n(i,j,k)
          cobalt%jprod_pdet(i,j,k) = cobalt%jprod_pdet(i,j,k) + (1.0-cobalt%hp_phi_det)*cobalt%hp_jingest_p(i,j,k)

--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -1449,6 +1449,9 @@ contains
                    "innate availability of detritus to higher predator feeding (0-1)", units="none", default=0.0)
     ! The material ingested by higher predators is partitioned between detritus, remineralization, and dissolved organic nitrogen
     ! Remineralization = 1.0 - hp_phi_det - hp_phi_ldon - hp_phi_sldon - hp_phi_srdon
+    ! hp_phi_det + hp_phi_ldon + hp_phi_sldon + hp_phi_srdon must equal 0.35 to maintain the assimilation efficiency
+    ! The DON pathways were added to generalize the higher predator ingestion carbon partitioning for future experiments
+    ! and are set to zero by default to avoid changing answers
     call get_param(param_file, "generic_COBALT", "hp_phi_det", cobalt%hp_phi_det, &
                    "fraction of ingestion by higher predators to detritus", units="none", default=0.35)
     call get_param(param_file, "generic_COBALT", "hp_phi_ldon", cobalt%hp_phi_ldon, &
@@ -4668,6 +4671,7 @@ contains
           cobalt%jprod_pdet(i,j,k) = cobalt%jprod_pdet(i,j,k) + cobalt%hp_phi_det*cobalt%hp_jingest_p(i,j,k)
        endif
        ! A portion of egestion will be released into dissolved organic nitrogen pools
+       ! hp_phi_det + hp_phi_ldon + hp_phi_sldon + hp_phi_srdon = 0.35 (total egestion)
        cobalt%jprod_ldon(i,j,k) = cobalt%jprod_ldon(i,j,k) + cobalt%hp_phi_ldon*cobalt%hp_jingest_n(i,j,k)
        cobalt%jprod_sldon(i,j,k) = cobalt%jprod_sldon(i,j,k) + cobalt%hp_phi_sldon*cobalt%hp_jingest_n(i,j,k)
        cobalt%jprod_srdon(i,j,k) = cobalt%jprod_srdon(i,j,k) + cobalt%hp_phi_srdon*cobalt%hp_jingest_n(i,j,k)


### PR DESCRIPTION
The DON pathways were added to generalize the higher predator ingestion carbon partitioning for future experiments and are set to zero by default to avoid changing answers. Comments in the code specify that `hp_phi_det` + `hp_phi_ldon` + `hp_phi_sldon` + `hp_phi_srdon` must equal 0.35 to maintain the assimilation efficiency.

Closes #183 